### PR TITLE
feat: streaming SSE via Bedrock converse_stream + AWS Lambda Web Adapter

### DIFF
--- a/docs/adr/0002-streaming-lambda-web-adapter.md
+++ b/docs/adr/0002-streaming-lambda-web-adapter.md
@@ -1,0 +1,82 @@
+# ADR-0002: Streaming via AWS Lambda Web Adapter
+Date: 2026-04-25  
+Status: Accepted
+
+## Context
+
+SSE (server-sent events) streaming from a Lambda function requires the
+response bytes to be forwarded to the caller incrementally, not buffered.
+
+The existing setup uses **Mangum** as an ASGI adapter.  Mangum collects the
+full FastAPI response in memory and returns it as a single Lambda invocation
+result, so `StreamingResponse` endpoints are silently buffered — the client
+receives all data at once after the model finishes.
+
+Lambda supports true streaming via **Function URL `RESPONSE_STREAM` invoke
+mode**, which allows the function to write bytes incrementally.  To use this
+mode from a standard ASGI application the packaging must change: the runtime
+is no longer driven by a Mangum handler but by a long-lived web server that
+AWSLWA proxies.
+
+The **AWS Lambda Web Adapter (AWSLWA)** project (account `753240598075`,
+Apache 2.0) solves this cleanly:
+
+1. It runs as a Lambda Extension inside the same execution environment.
+2. It starts the application (`run.sh`) before the first invocation.
+3. Each Lambda event is translated into an HTTP request forwarded to the
+   local port (8080).
+4. With `AWS_LWA_INVOKE_MODE=response_stream` it pipes the HTTP response
+   body back to the caller chunk-by-chunk, enabling true SSE.
+
+Alternatives considered:
+
+* **Custom streaming handler** — writing raw Lambda response-streaming code
+  bypasses FastAPI entirely and loses routing, auth middleware, and type
+  safety.  High maintenance burden.
+* **Separate streaming Lambda** — a second function for streaming endpoints
+  doubles the infra surface for no architectural gain.
+* **API Gateway** — lacks native SSE support; WebSocket-based workarounds
+  are significantly more complex.
+
+## Decision
+
+1. **Replace Mangum** with AWSLWA + uvicorn.
+   * Lambda handler set to `run.sh` (starts `uvicorn starter.api.main:app
+     --host 0.0.0.0 --port 8080`).
+   * AWSLWA layer `arn:aws:lambda:{region}:753240598075:layer:LambdaAdapterLayerX86:24`
+     (v0.8.4) added to the function.
+   * `run.sh` is bundled into the Lambda asset alongside the Python package.
+
+2. **Function URL invoke mode → `RESPONSE_STREAM`.**  
+   All Function URL traffic flows through AWSLWA; non-streaming endpoints
+   are unaffected because AWSLWA buffers and returns them normally.
+
+3. **Add `bedrock:InvokeModelWithResponseStream`** to the Lambda IAM policy
+   alongside the existing `bedrock:InvokeModel`.
+
+4. **SSE event schema** (defined in `bedrock.converse_stream`):
+   * `data: {"type": "delta", "text": "..."}` — incremental token.
+   * `data: {"type": "done", "stop_reason": "...", "input_tokens": N,
+     "output_tokens": M}` — final event.
+
+5. **CloudFront note**: the `/api/*` CloudFront behaviour routes to the
+   Function URL.  CloudFront may buffer SSE when its own response buffering
+   is active.  For low-latency streaming use the Function URL directly
+   (available in the `ApiFunctionUrl` CFN output).  A future ADR can address
+   a CloudFront bypass path or a dedicated streaming behaviour if needed.
+
+## Consequences
+
+* **Mangum is retained** in `pyproject.toml` and `api/main.py` as a
+  documented fallback for local development (`lambda_handler` is still valid
+  for unit testing).  It is no longer invoked in the deployed Lambda.
+* **Cold-start overhead** increases slightly because uvicorn must finish
+  starting before the first request is handled.  AWSLWA waits up to
+  `AWS_LWA_READINESS_CHECK_TIMEOUT` (default 3 s) for a successful health
+  probe on `/health` before accepting traffic.
+* **Streaming is opt-in per endpoint.**  Existing `POST /api/agents/echo`
+  is unchanged.  The new `POST /api/agents/echo/stream` endpoint returns
+  `text/event-stream`.
+* **AWSLWA version pinning**: the layer ARN in `starter_stack.py` contains
+  an explicit version suffix.  Update it when a new AWSLWA release is
+  available.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,3 +26,4 @@ What are the trade-offs, follow-on work, or constraints this decision creates?
 | ADR | Title | Status |
 |---|---|---|
 | [0001](0001-bedrock-converse-api.md) | Bedrock Converse API as the agent LLM interface | Accepted |
+| [0002](0002-streaming-lambda-web-adapter.md) | Streaming via AWS Lambda Web Adapter | Accepted |

--- a/infra/stacks/starter_stack.py
+++ b/infra/stacks/starter_stack.py
@@ -220,10 +220,25 @@ class AgentCoreStarterStack(cdk.Stack):
                             "UV_CACHE_DIR=/tmp/uv-cache uv export --no-hashes --no-group dev --no-group infra -o /tmp/requirements.txt",
                             "pip install -r /tmp/requirements.txt -t /asset-output --quiet --no-cache-dir",
                             "cp -r src/starter /asset-output/starter",
+                            # run.sh is the AWSLWA entrypoint — must be executable at Lambda root
+                            "cp run.sh /asset-output/run.sh",
+                            "chmod +x /asset-output/run.sh",
                         ]
                     ),
                 ],
             ),
+        )
+
+        # ----------------------------------------------------------------
+        # AWS Lambda Web Adapter layer
+        # Enables streaming responses via Function URL RESPONSE_STREAM mode.
+        # Update the version suffix when a new AWSLWA release is available:
+        # https://github.com/awslabs/aws-lambda-web-adapter/releases
+        # ----------------------------------------------------------------
+        awslwa_layer = lambda_.LayerVersion.from_layer_version_arn(
+            self,
+            "AwsLambdaWebAdapterLayer",
+            f"arn:aws:lambda:{self.region}:753240598075:layer:LambdaAdapterLayerX86:24",
         )
 
         # JWT issuer URL embedded in tokens — must be unique per environment.
@@ -313,7 +328,7 @@ class AgentCoreStarterStack(cdk.Stack):
         )
         api_role.add_to_policy(
             iam.PolicyStatement(
-                actions=["bedrock:InvokeModel"],
+                actions=["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
                 resources=[
                     f"arn:aws:bedrock:{self.region}::foundation-model/anthropic.claude-sonnet-4-6",
                     f"arn:aws:bedrock:{self.region}::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -325,13 +340,23 @@ class AgentCoreStarterStack(cdk.Stack):
             self,
             "ApiFunction",
             runtime=lambda_.Runtime.PYTHON_3_12,
-            handler="starter.api.main.lambda_handler",
+            # run.sh is the AWSLWA entrypoint — it starts uvicorn on port 8080.
+            # AWSLWA intercepts Lambda invocations and proxies them as HTTP requests.
+            handler="run.sh",
             code=lambda_code,
             role=api_role,
-            environment=common_env,
+            environment={
+                **common_env,
+                # Tell AWSLWA to use response-streaming mode so SSE responses
+                # are streamed through the Function URL without buffering.
+                "AWS_LWA_INVOKE_MODE": "response_stream",
+                # AWSLWA looks for the web server on this port (default 8080).
+                "PORT": "8080",
+            },
+            layers=[awslwa_layer],
             memory_size=512,
             timeout=cdk.Duration.seconds(30),
-            description=f"AgentCore Starter management API (FastAPI) [{env_name}]",
+            description=f"AgentCore Starter management API (FastAPI + AWSLWA) [{env_name}]",
             tracing=lambda_.Tracing.ACTIVE,
         )
 
@@ -352,6 +377,8 @@ class AgentCoreStarterStack(cdk.Stack):
 
         api_url = api_fn.add_function_url(
             auth_type=lambda_.FunctionUrlAuthType.NONE,
+            # RESPONSE_STREAM allows AWSLWA to stream SSE responses without buffering.
+            invoke_mode=lambda_.InvokeMode.RESPONSE_STREAM,
             cors=lambda_.FunctionUrlCorsOptions(
                 allowed_origins=["*"],
                 allowed_methods=[lambda_.HttpMethod.ALL],

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Entrypoint for AWS Lambda Web Adapter (AWSLWA).
+# AWSLWA intercepts Lambda invocations, translates them to HTTP requests,
+# and forwards them to this web server running on port 8080.
+# With AWS_LWA_INVOKE_MODE=response_stream and Function URL RESPONSE_STREAM
+# mode, SSE responses are streamed directly to the caller.
+exec uvicorn starter.api.main:app --host 0.0.0.0 --port 8080

--- a/src/starter/agents/bedrock.py
+++ b/src/starter/agents/bedrock.py
@@ -1,7 +1,9 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
 from __future__ import annotations
 
+import json
 import os
+from collections.abc import Iterator
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
@@ -47,6 +49,48 @@ def _bedrock_client() -> BedrockRuntimeClient:
     if region:
         kwargs["region_name"] = region
     return boto3.client("bedrock-runtime", **kwargs)  # type: ignore[return-value]
+
+
+def converse_stream(request: ConverseRequest) -> Iterator[str]:
+    """Yield SSE-formatted chunks from a Bedrock streaming conversation.
+
+    Each yielded string is a complete ``data: ...\\n\\n`` SSE event.  Two
+    event types are emitted:
+
+    * ``{"type": "delta", "text": "..."}`` — one incremental text token.
+    * ``{"type": "done", "stop_reason": "...", "input_tokens": N,
+      "output_tokens": M}`` — final event after the model finishes.
+    """
+    client = _bedrock_client()
+    messages = [{"role": m.role, "content": [{"text": m.content}]} for m in request.messages]
+    kwargs: dict = {
+        "modelId": get_model_id(),
+        "messages": messages,
+        "inferenceConfig": {"maxTokens": request.max_tokens},
+    }
+    if request.system:
+        kwargs["system"] = [{"text": request.system}]
+
+    response = client.converse_stream(**kwargs)
+    input_tokens = 0
+    output_tokens = 0
+    stop_reason = ""
+
+    for event in response["stream"]:
+        if "contentBlockDelta" in event:
+            text = event["contentBlockDelta"]["delta"].get("text", "")
+            if text:
+                yield f"data: {json.dumps({'type': 'delta', 'text': text})}\n\n"
+        elif "messageStop" in event:
+            stop_reason = event["messageStop"].get("stopReason", "")
+        elif "metadata" in event:
+            usage = event["metadata"].get("usage", {})
+            input_tokens = usage.get("inputTokens", 0)
+            output_tokens = usage.get("outputTokens", 0)
+
+    yield (
+        f"data: {json.dumps({'type': 'done', 'stop_reason': stop_reason, 'input_tokens': input_tokens, 'output_tokens': output_tokens})}\n\n"
+    )
 
 
 def converse(request: ConverseRequest) -> ConverseResponse:

--- a/src/starter/api/agents.py
+++ b/src/starter/api/agents.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from starter.agents.bedrock import BedrockMessage, ConverseRequest, converse
+from starter.agents.bedrock import BedrockMessage, ConverseRequest, converse, converse_stream
 from starter.api._auth import require_mgmt_user
 
 router = APIRouter()
@@ -46,3 +48,27 @@ def echo(
         input_tokens=result.input_tokens,
         output_tokens=result.output_tokens,
     )
+
+
+@router.post("/agents/echo/stream")
+def echo_stream(
+    body: EchoRequest,
+    _claims: dict[str, Any] = Depends(require_mgmt_user),
+) -> StreamingResponse:
+    """Streaming echo endpoint — returns an SSE stream of Bedrock reply tokens.
+
+    Each ``data:`` event is a JSON object with ``type`` equal to ``"delta"``
+    (incremental text) or ``"done"`` (final event with token counts).
+
+    Replace or extend this scaffold with your own streaming agent logic.
+    """
+
+    def _stream() -> Iterator[str]:
+        yield from converse_stream(
+            ConverseRequest(
+                messages=[BedrockMessage(role="user", content=body.message)],
+                system=body.system,
+            )
+        )
+
+    return StreamingResponse(_stream(), media_type="text/event-stream")

--- a/tests/unit/test_agents_api.py
+++ b/tests/unit/test_agents_api.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
-"""Unit tests for the /api/agents/echo endpoint."""
+"""Unit tests for the /api/agents/echo and /api/agents/echo/stream endpoints."""
 
 from __future__ import annotations
 
+import json
 import os
+from collections.abc import Iterator
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -68,3 +70,64 @@ def test_echo_forwards_system_prompt() -> None:
 
     assert len(captured) == 1
     assert captured[0].system == "Be concise."
+
+
+# ---------------------------------------------------------------------------
+# /api/agents/echo/stream
+# ---------------------------------------------------------------------------
+
+
+def _fake_stream(request) -> Iterator[str]:
+    yield f"data: {json.dumps({'type': 'delta', 'text': 'Hi'})}\n\n"
+    yield f"data: {json.dumps({'type': 'done', 'stop_reason': 'end_turn', 'input_tokens': 5, 'output_tokens': 3})}\n\n"
+
+
+def test_echo_stream_requires_auth() -> None:
+    resp = client.post("/api/agents/echo/stream", json={"message": "Hi"})
+    assert resp.status_code in (401, 403)
+
+
+def test_echo_stream_returns_event_stream_content_type() -> None:
+    with patch("starter.api.agents.converse_stream", side_effect=_fake_stream):
+        resp = client.post(
+            "/api/agents/echo/stream",
+            json={"message": "Hi"},
+            headers=_auth_headers(),
+        )
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+
+
+def test_echo_stream_yields_delta_and_done_events() -> None:
+    with patch("starter.api.agents.converse_stream", side_effect=_fake_stream):
+        resp = client.post(
+            "/api/agents/echo/stream",
+            json={"message": "Hi"},
+            headers=_auth_headers(),
+        )
+
+    events = [line for line in resp.text.split("\n\n") if line.startswith("data: ")]
+    assert len(events) == 2
+    delta = json.loads(events[0][len("data: ") :])
+    assert delta == {"type": "delta", "text": "Hi"}
+    done = json.loads(events[1][len("data: ") :])
+    assert done["type"] == "done"
+    assert done["stop_reason"] == "end_turn"
+
+
+def test_echo_stream_forwards_system_prompt() -> None:
+    captured: list = []
+
+    def _capture(req) -> Iterator[str]:
+        captured.append(req)
+        yield f"data: {json.dumps({'type': 'done', 'stop_reason': 'end_turn', 'input_tokens': 1, 'output_tokens': 1})}\n\n"
+
+    with patch("starter.api.agents.converse_stream", side_effect=_capture):
+        client.post(
+            "/api/agents/echo/stream",
+            json={"message": "Hi", "system": "Be terse."},
+            headers=_auth_headers(),
+        )
+
+    assert len(captured) == 1
+    assert captured[0].system == "Be terse."

--- a/tests/unit/test_agents_bedrock.py
+++ b/tests/unit/test_agents_bedrock.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
 from __future__ import annotations
 
+import json
 import os
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ from starter.agents.bedrock import (
     ConverseResponse,
     _bedrock_client,
     converse,
+    converse_stream,
     get_model_id,
 )
 
@@ -134,3 +136,95 @@ def test_converse_message_shape() -> None:
         {"role": "assistant", "content": [{"text": "Hi"}]},
         {"role": "user", "content": [{"text": "Bye"}]},
     ]
+
+
+# ---------------------------------------------------------------------------
+# converse_stream
+# ---------------------------------------------------------------------------
+
+
+def _stream_events(*events) -> dict:
+    return {"stream": list(events)}
+
+
+def test_converse_stream_yields_delta_and_done() -> None:
+    mock_client = MagicMock()
+    mock_client.converse_stream.return_value = _stream_events(
+        {"contentBlockDelta": {"delta": {"text": "Hello"}}},
+        {"contentBlockDelta": {"delta": {"text": " world"}}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+    )
+
+    with patch("starter.agents.bedrock._bedrock_client", return_value=mock_client):
+        chunks = list(
+            converse_stream(ConverseRequest(messages=[BedrockMessage(role="user", content="Hi")]))
+        )
+
+    assert len(chunks) == 3
+    assert json.loads(chunks[0][len("data: ") :]) == {"type": "delta", "text": "Hello"}
+    assert json.loads(chunks[1][len("data: ") :]) == {"type": "delta", "text": " world"}
+    done = json.loads(chunks[2][len("data: ") :])
+    assert done["type"] == "done"
+    assert done["stop_reason"] == "end_turn"
+    assert done["input_tokens"] == 10
+    assert done["output_tokens"] == 5
+
+
+def test_converse_stream_sse_format() -> None:
+    mock_client = MagicMock()
+    mock_client.converse_stream.return_value = _stream_events(
+        {"contentBlockDelta": {"delta": {"text": "Hi"}}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 1}}},
+    )
+
+    with patch("starter.agents.bedrock._bedrock_client", return_value=mock_client):
+        chunks = list(
+            converse_stream(ConverseRequest(messages=[BedrockMessage(role="user", content="X")]))
+        )
+
+    for chunk in chunks:
+        assert chunk.startswith("data: ")
+        assert chunk.endswith("\n\n")
+
+
+def test_converse_stream_with_system_prompt() -> None:
+    mock_client = MagicMock()
+    mock_client.converse_stream.return_value = _stream_events(
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 2}}},
+    )
+
+    with patch("starter.agents.bedrock._bedrock_client", return_value=mock_client):
+        list(
+            converse_stream(
+                ConverseRequest(
+                    messages=[BedrockMessage(role="user", content="Hi")],
+                    system="Be brief.",
+                )
+            )
+        )
+
+    call_kwargs = mock_client.converse_stream.call_args[1]
+    assert call_kwargs["system"] == [{"text": "Be brief."}]
+
+
+def test_converse_stream_skips_empty_text_delta() -> None:
+    mock_client = MagicMock()
+    mock_client.converse_stream.return_value = _stream_events(
+        {"contentBlockDelta": {"delta": {}}},  # no "text" key
+        {"contentBlockDelta": {"delta": {"text": ""}}},  # empty string
+        {"contentBlockDelta": {"delta": {"text": "ok"}}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 2, "outputTokens": 1}}},
+    )
+
+    with patch("starter.agents.bedrock._bedrock_client", return_value=mock_client):
+        chunks = list(
+            converse_stream(ConverseRequest(messages=[BedrockMessage(role="user", content="X")]))
+        )
+
+    # Only "ok" delta + done
+    assert len(chunks) == 2
+    assert json.loads(chunks[0][len("data: ") :])["text"] == "ok"


### PR DESCRIPTION
## Summary

- Adds `converse_stream()` to `bedrock.py` — wraps `bedrock-runtime.converse_stream()` and yields `data: {...}\n\n` SSE events: one `delta` event per token, one `done` event with token counts and stop reason.
- Adds `POST /api/agents/echo/stream` endpoint returning `StreamingResponse(media_type="text/event-stream")`.
- Switches Lambda from Mangum to AWS Lambda Web Adapter (AWSLWA) + uvicorn so SSE responses are streamed end-to-end without buffering.
- Adds `run.sh` AWSLWA entrypoint and wires up CDK: AWSLWA layer, `handler="run.sh"`, Function URL `RESPONSE_STREAM` invoke mode, `AWS_LWA_INVOKE_MODE=response_stream`.
- Adds `bedrock:InvokeModelWithResponseStream` to IAM alongside the existing `InvokeModel`.
- Documents the decision in ADR-0002.

## Approach

**Why AWSLWA over Mangum for streaming:** Mangum collects the full response before returning it to Lambda, so `StreamingResponse` is silently buffered. AWSLWA starts a long-lived uvicorn process and pipes HTTP response bytes back through the Function URL `RESPONSE_STREAM` channel chunk-by-chunk. There is no Mangum-compatible alternative that supports true SSE.

**CloudFront note:** The `/api/*` CloudFront behaviour routes to the Function URL. CloudFront may buffer SSE responses. For reliable real-time streaming use the Function URL directly (available in the `ApiFunctionUrl` CFN output). ADR-0002 records this as a follow-on item.

**Mangum retained:** `lambda_handler` in `main.py` is kept for local testing via `TestClient`. It is no longer invoked by the deployed Lambda (AWSLWA owns the entrypoint), but removing it would break any existing test that imports it directly.

**Coverage:** 100% on all changed Python modules.