### PR TITLE
feat: AgentCore inline agent wrapper + session-scoped memory conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,14 @@ agentcore-starter/
 │       │   ├── tokens.py      # Token issuance + validation
 │       │   ├── google.py      # Google OAuth integration
 │       │   └── mgmt_auth.py   # Management API authentication
+│       ├── agents/
+│       │   ├── __init__.py
+│       │   ├── bedrock.py     # Converse + converse_stream (raw Bedrock)
+│       │   └── agentcore.py   # invoke + invoke_stream (Bedrock inline agent)
 │       └── api/
 │           ├── main.py        # FastAPI app + routes
 │           ├── admin.py       # Admin-only endpoints
+│           ├── agents.py      # Agent scaffold endpoints
 │           └── users.py       # User management endpoints
 ├── ui/
 │   ├── src/
@@ -206,6 +211,11 @@ re-derive these during design review — cite them.
   take a `workspace_id` / `namespace` param on every call. Scope comes
   from the token claim; agents register a new DCR client per context and
   swap tokens to switch.
+- **Agent session IDs are user-namespaced** — the `agentcore.py` wrapper
+  computes the Bedrock `sessionId` as `f"{jwt_sub}:{caller_session_id}"`.
+  Callers supply their own opaque `session_id`; the wrapper adds the user
+  prefix so sessions never bleed across users. The namespaced form is
+  internal — only the caller's `session_id` is echoed back in responses.
 
 ## UI conventions
 

--- a/docs/adr/0003-inline-agent-and-session-memory.md
+++ b/docs/adr/0003-inline-agent-and-session-memory.md
@@ -1,0 +1,76 @@
+# ADR-0003: Inline Agent and session memory conventions
+Date: 2026-04-25  
+Status: Accepted
+
+## Context
+
+Bedrock Agents offers two invocation modes:
+
+1. **Pre-configured agents** — an agent resource is created in the AWS console
+   or via IaC, given an agent ID and alias, then invoked with `invoke_agent`.
+   The agent instructions, model, knowledge bases, and action groups are
+   stored in the agent resource and referenced at invocation time.
+
+2. **Inline agents** — the entire agent configuration (instructions, model,
+   action groups) is supplied in the request body via `invoke_inline_agent`.
+   No agent resource is pre-provisioned; the configuration is ephemeral.
+
+For a starter template the key requirement is minimal setup: a new team
+should be able to clone the repo and call an agent endpoint without any
+out-of-band AWS console configuration.  Pre-configured agents fail this
+requirement because the agent resource must exist before the Lambda runs.
+
+### Session memory
+
+Bedrock Agents maintains short-term conversational memory within a *session*.
+A session is identified by a `sessionId` string; subsequent calls with the
+same `sessionId` continue the conversation.  There is no cross-session
+memory by default (long-term memory requires a knowledge base with session
+summarization enabled).
+
+The starter must ensure that session IDs are scoped to a single user so that
+user A cannot replay or read user B's conversation by guessing a session ID.
+The JWT `sub` claim identifies the authenticated user.
+
+## Decision
+
+1. **Use `invoke_inline_agent`** for all agent endpoints in this template.
+   This enables zero-console-setup for new adopters.  Teams that want
+   pre-configured agents can replace the `agentcore.py` wrapper with an
+   `invoke_agent` call and supply an agent ID via an environment variable or
+   SSM parameter.
+
+2. **Session ID namespace convention**: the wrapper computes the Bedrock
+   `sessionId` as `f"{user_id}:{caller_session_id}"` where `user_id` is the
+   JWT `sub` claim and `caller_session_id` is the opaque value supplied by
+   the API caller.  The caller never sees the namespaced form — only their
+   own `session_id` is echoed back.  This ensures:
+   - Sessions cannot bleed across users even if the caller reuses the same
+     `session_id` string.
+   - Agents do not require a `user_id` parameter on every call — the token
+     claim provides the scope.
+
+3. **No cross-session memory by default.**  The `invoke_inline_agent`
+   `inlineSessionState` field is initialised with empty
+   `promptSessionAttributes`.  Adopters that need long-term memory can
+   populate this dict from a DynamoDB lookup before calling the Bedrock API.
+
+4. **Model selection follows `BEDROCK_MODEL_ID`** (same env var as the
+   Converse wrapper in `bedrock.py`).  Default is `anthropic.claude-sonnet-4-6`.
+
+## Consequences
+
+* **Zero pre-provisioning** — the `POST /api/agents/invoke` and
+  `POST /api/agents/invoke/stream` endpoints work in a fresh deploy without
+  any Bedrock console configuration.
+* **Action groups not wired up by default** — the starter passes an empty
+  `actionGroups` list.  Adopters add tool definitions here for structured
+  function-calling workflows.
+* **IAM**: `bedrock:InvokeInlineAgent` is added to the Lambda role with
+  resource `arn:aws:bedrock:{region}:{account}:agent/*`.  The wildcard
+  on the agent resource suffix is required because inline agents do not
+  have a fixed ARN.
+* **Pre-configured agent migration path**: replace `agentcore.py` with a
+  thin wrapper around `invoke_agent`, read `BEDROCK_AGENT_ID` and
+  `BEDROCK_AGENT_ALIAS_ID` from env/SSM, and update the IAM policy to scope
+  the `InvokeAgent` action to those specific ARNs.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@ What are the trade-offs, follow-on work, or constraints this decision creates?
 |---|---|---|
 | [0001](0001-bedrock-converse-api.md) | Bedrock Converse API as the agent LLM interface | Accepted |
 | [0002](0002-streaming-lambda-web-adapter.md) | Streaming via AWS Lambda Web Adapter | Accepted |
+| [0003](0003-inline-agent-and-session-memory.md) | Inline Agent and session memory conventions | Accepted |

--- a/infra/stacks/starter_stack.py
+++ b/infra/stacks/starter_stack.py
@@ -335,6 +335,17 @@ class AgentCoreStarterStack(cdk.Stack):
                 ],
             )
         )
+        # bedrock:InvokeInlineAgent is required for invoke_inline_agent calls.
+        # Inline agents are ephemeral (no pre-provisioned agent resource), so
+        # the resource ARN pattern covers all inline agent invocations in the account.
+        api_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["bedrock:InvokeInlineAgent"],
+                resources=[
+                    f"arn:aws:bedrock:{self.region}:{self.account}:agent/*",
+                ],
+            )
+        )
 
         api_fn = lambda_.Function(
             self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dev = [
     "invoke>=2.2.0",
     "moto>=5.1.22",
     "mypy>=1.19.1",
+    "mypy-boto3-bedrock-agent-runtime>=1.42.3",
     "mypy-boto3-bedrock-runtime>=1.42.82",
     "pip-audit>=2.9.0",
     "playwright>=1.40.0",

--- a/src/starter/agents/agentcore.py
+++ b/src/starter/agents/agentcore.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+import boto3
+from pydantic import BaseModel
+
+from starter.agents.bedrock import get_model_id
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mypy_boto3_bedrock_agent_runtime import AgentsforBedrockRuntimeClient
+
+
+class InlineAgentRequest(BaseModel):
+    """Parameters for an inline Bedrock Agent invocation.
+
+    ``session_id`` is a caller-supplied opaque string that identifies a
+    conversation.  The wrapper namespaces it to the authenticated user so
+    that sessions are never shared across users:
+    ``bedrock_session_id = f"{user_id}:{session_id}"``.
+
+    Omit ``session_id`` to start a new conversation; a random UUID is used.
+    """
+
+    message: str
+    session_id: str | None = None
+    instruction: str | None = None
+    max_tokens: int = 1024
+
+
+class InlineAgentResponse(BaseModel):
+    reply: str
+    session_id: str  # the caller-supplied session_id (not the namespaced Bedrock ID)
+
+
+@lru_cache(maxsize=1)
+def _agent_client() -> AgentsforBedrockRuntimeClient:
+    """Return a cached Bedrock agent runtime client.
+
+    Region resolution follows boto3 precedence: AWS_REGION → AWS_DEFAULT_REGION
+    → ~/.aws/config.  We only pass region_name when one of the env vars is
+    explicitly set so local dev and CI inherit the configured default naturally.
+    """
+    import os
+
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    kwargs: dict = {}
+    if region:
+        kwargs["region_name"] = region
+    return boto3.client("bedrock-agent-runtime", **kwargs)  # type: ignore[return-value]
+
+
+def _bedrock_session_id(user_id: str, session_id: str) -> str:
+    """Namespace a caller session ID to a user so sessions never bleed across users."""
+    return f"{user_id}:{session_id}"
+
+
+def invoke(request: InlineAgentRequest, *, user_id: str) -> InlineAgentResponse:
+    """Non-streaming inline agent invocation.
+
+    Collects all ``chunk`` events from the response stream and concatenates
+    them into a single reply string.
+    """
+    session_id = request.session_id or str(uuid.uuid4())
+    chunks = list(_stream_chunks(request, user_id=user_id, session_id=session_id))
+    return InlineAgentResponse(reply="".join(chunks), session_id=session_id)
+
+
+def invoke_stream(request: InlineAgentRequest, *, user_id: str) -> Iterator[str]:
+    """Streaming inline agent invocation — yields SSE-formatted events.
+
+    Two event types are emitted:
+
+    * ``{"type": "delta", "text": "..."}`` — one incremental text chunk.
+    * ``{"type": "done", "session_id": "..."}`` — final event after the agent
+      finishes.  ``session_id`` is the caller-supplied identifier so the
+      client can resume the conversation in a later request.
+    """
+    session_id = request.session_id or str(uuid.uuid4())
+    for text in _stream_chunks(request, user_id=user_id, session_id=session_id):
+        yield f"data: {json.dumps({'type': 'delta', 'text': text})}\n\n"
+    yield f"data: {json.dumps({'type': 'done', 'session_id': session_id})}\n\n"
+
+
+def _stream_chunks(
+    request: InlineAgentRequest,
+    *,
+    user_id: str,
+    session_id: str,
+) -> Iterator[str]:
+    """Yield decoded text chunks from the InvokeInlineAgent event stream."""
+    client = _agent_client()
+    kwargs: dict = {
+        "foundationModel": get_model_id(),
+        "inputText": request.message,
+        "sessionId": _bedrock_session_id(user_id, session_id),
+        "endSession": False,
+        "enableTrace": False,
+        "inlineSessionState": {
+            "promptSessionAttributes": {},
+        },
+        "inferenceConfig": {
+            "maximumLength": request.max_tokens,
+        },
+    }
+    if request.instruction:
+        kwargs["agentInstruction"] = request.instruction
+
+    response = client.invoke_inline_agent(**kwargs)
+    for event in response["completion"]:
+        if "chunk" in event:
+            raw = event["chunk"].get("bytes", b"")
+            if raw:
+                yield raw.decode("utf-8")

--- a/src/starter/api/agents.py
+++ b/src/starter/api/agents.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from starter.agents.agentcore import InlineAgentRequest, invoke, invoke_stream
 from starter.agents.bedrock import BedrockMessage, ConverseRequest, converse, converse_stream
 from starter.api._auth import require_mgmt_user
 
@@ -69,6 +70,74 @@ def echo_stream(
                 messages=[BedrockMessage(role="user", content=body.message)],
                 system=body.system,
             )
+        )
+
+    return StreamingResponse(_stream(), media_type="text/event-stream")
+
+
+# ---------------------------------------------------------------------------
+# Inline agent endpoints (Bedrock Agents via invoke_inline_agent)
+# ---------------------------------------------------------------------------
+
+
+class AgentRequest(BaseModel):
+    message: str
+    session_id: str | None = None
+    instruction: str | None = None
+
+
+class AgentResponse(BaseModel):
+    reply: str
+    session_id: str
+
+
+@router.post("/agents/invoke", response_model=AgentResponse)
+def agent_invoke(
+    body: AgentRequest,
+    claims: dict[str, Any] = Depends(require_mgmt_user),
+) -> AgentResponse:
+    """Invoke a Bedrock inline agent and return the full response.
+
+    The agent maintains conversation history within a session — pass the same
+    ``session_id`` across turns to continue a conversation.  Omit it to start
+    a new session; the returned ``session_id`` can be stored and reused.
+
+    Session scope is automatically namespaced to the authenticated user so
+    sessions are never shared across users.
+    """
+    result = invoke(
+        InlineAgentRequest(
+            message=body.message,
+            session_id=body.session_id,
+            instruction=body.instruction,
+        ),
+        user_id=claims["sub"],
+    )
+    return AgentResponse(reply=result.reply, session_id=result.session_id)
+
+
+@router.post("/agents/invoke/stream")
+def agent_invoke_stream(
+    body: AgentRequest,
+    claims: dict[str, Any] = Depends(require_mgmt_user),
+) -> StreamingResponse:
+    """Streaming inline agent invocation — returns an SSE stream of agent reply chunks.
+
+    Event schema mirrors ``/agents/echo/stream``:
+
+    * ``{"type": "delta", "text": "..."}`` — incremental text chunk.
+    * ``{"type": "done", "session_id": "..."}`` — final event; ``session_id``
+      can be stored and reused to continue the conversation.
+    """
+
+    def _stream() -> Iterator[str]:
+        yield from invoke_stream(
+            InlineAgentRequest(
+                message=body.message,
+                session_id=body.session_id,
+                instruction=body.instruction,
+            ),
+            user_id=claims["sub"],
         )
 
     return StreamingResponse(_stream(), media_type="text/event-stream")

--- a/tests/unit/test_agents_agentcore.py
+++ b/tests/unit/test_agents_agentcore.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from starter.agents.agentcore import (
+    InlineAgentRequest,
+    InlineAgentResponse,
+    _agent_client,
+    _bedrock_session_id,
+    invoke,
+    invoke_stream,
+)
+
+
+def setup_function() -> None:
+    _agent_client.cache_clear()
+
+
+def teardown_function() -> None:
+    _agent_client.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# _bedrock_session_id
+# ---------------------------------------------------------------------------
+
+
+def test_bedrock_session_id_namespaces_to_user() -> None:
+    assert _bedrock_session_id("user1", "sess-abc") == "user1:sess-abc"
+
+
+def test_bedrock_session_id_different_users_dont_collide() -> None:
+    assert _bedrock_session_id("user1", "x") != _bedrock_session_id("user2", "x")
+
+
+# ---------------------------------------------------------------------------
+# _agent_client caching
+# ---------------------------------------------------------------------------
+
+
+def test_agent_client_passes_region_when_set() -> None:
+    import os
+    from unittest.mock import patch as p
+
+    env = {k: v for k, v in os.environ.items() if k not in ("AWS_REGION", "AWS_DEFAULT_REGION")}
+    with (
+        p("os.environ", {**env, "AWS_REGION": "eu-west-1"}),
+        p("boto3.client", return_value=MagicMock()) as mock_boto,
+    ):
+        _agent_client()
+        mock_boto.assert_called_once_with("bedrock-agent-runtime", region_name="eu-west-1")
+
+
+def test_agent_client_omits_region_when_unset() -> None:
+    import os
+    from unittest.mock import patch as p
+
+    env = {k: v for k, v in os.environ.items() if k not in ("AWS_REGION", "AWS_DEFAULT_REGION")}
+    with (
+        p("os.environ", env),
+        p("boto3.client", return_value=MagicMock()) as mock_boto,
+    ):
+        _agent_client()
+        mock_boto.assert_called_once_with("bedrock-agent-runtime")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_completion(*chunks: str) -> dict:
+    """Build a fake completion event stream from text chunks."""
+    events = [{"chunk": {"bytes": c.encode()}} for c in chunks]
+    return {"completion": iter(events)}
+
+
+def _mock_completion_with_empty() -> dict:
+    """Completion stream with an empty bytes chunk (should be skipped)."""
+    return {
+        "completion": iter(
+            [
+                {"chunk": {"bytes": b""}},
+                {"chunk": {"bytes": b"hi"}},
+                {"chunk": {}},  # missing "bytes" key
+            ]
+        )
+    }
+
+
+# ---------------------------------------------------------------------------
+# invoke (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_returns_concatenated_chunks() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("Hello", " world")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        result = invoke(
+            InlineAgentRequest(message="Hi", session_id="s1"),
+            user_id="user1",
+        )
+
+    assert isinstance(result, InlineAgentResponse)
+    assert result.reply == "Hello world"
+    assert result.session_id == "s1"
+
+
+def test_invoke_generates_session_id_when_omitted() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("ok")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        result = invoke(InlineAgentRequest(message="Hi"), user_id="user1")
+
+    assert result.session_id  # a UUID was generated
+    assert len(result.session_id) == 36  # UUID format
+
+
+def test_invoke_passes_instruction() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("ok")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        invoke(
+            InlineAgentRequest(message="Hi", session_id="s1", instruction="Be brief."),
+            user_id="user1",
+        )
+
+    call_kwargs = mock_client.invoke_inline_agent.call_args[1]
+    assert call_kwargs["agentInstruction"] == "Be brief."
+
+
+def test_invoke_omits_instruction_key_when_not_set() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("ok")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        invoke(InlineAgentRequest(message="Hi", session_id="s1"), user_id="user1")
+
+    call_kwargs = mock_client.invoke_inline_agent.call_args[1]
+    assert "agentInstruction" not in call_kwargs
+
+
+def test_invoke_namespaces_session_id() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("ok")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        invoke(
+            InlineAgentRequest(message="Hi", session_id="my-session"),
+            user_id="alice",
+        )
+
+    call_kwargs = mock_client.invoke_inline_agent.call_args[1]
+    assert call_kwargs["sessionId"] == "alice:my-session"
+
+
+def test_invoke_skips_empty_bytes() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion_with_empty()
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        result = invoke(InlineAgentRequest(message="Hi", session_id="s1"), user_id="u1")
+
+    assert result.reply == "hi"
+
+
+# ---------------------------------------------------------------------------
+# invoke_stream
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_stream_yields_delta_and_done() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("Hello", " world")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        chunks = list(
+            invoke_stream(
+                InlineAgentRequest(message="Hi", session_id="s1"),
+                user_id="user1",
+            )
+        )
+
+    assert len(chunks) == 3
+    assert json.loads(chunks[0][len("data: ") :]) == {"type": "delta", "text": "Hello"}
+    assert json.loads(chunks[1][len("data: ") :]) == {"type": "delta", "text": " world"}
+    done = json.loads(chunks[2][len("data: ") :])
+    assert done["type"] == "done"
+    assert done["session_id"] == "s1"
+
+
+def test_invoke_stream_sse_format() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("hi")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        chunks = list(invoke_stream(InlineAgentRequest(message="X", session_id="s1"), user_id="u1"))
+
+    for chunk in chunks:
+        assert chunk.startswith("data: ")
+        assert chunk.endswith("\n\n")
+
+
+def test_invoke_stream_generates_session_id_when_omitted() -> None:
+    mock_client = MagicMock()
+    mock_client.invoke_inline_agent.return_value = _mock_completion("hi")
+
+    with patch("starter.agents.agentcore._agent_client", return_value=mock_client):
+        chunks = list(invoke_stream(InlineAgentRequest(message="X"), user_id="u1"))
+
+    done = json.loads(chunks[-1][len("data: ") :])
+    assert done["type"] == "done"
+    assert len(done["session_id"]) == 36  # UUID

--- a/tests/unit/test_agents_api.py
+++ b/tests/unit/test_agents_api.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
-"""Unit tests for the /api/agents/echo and /api/agents/echo/stream endpoints."""
+"""Unit tests for agent API endpoints (echo, echo/stream, invoke, invoke/stream)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 
 os.environ.setdefault("STARTER_JWT_SECRET", "test-secret-for-unit-tests")
 
+from starter.agents.agentcore import InlineAgentResponse  # noqa: E402
 from starter.agents.bedrock import ConverseResponse  # noqa: E402
 from starter.api.main import app  # noqa: E402
 from starter.auth.tokens import issue_mgmt_jwt  # noqa: E402
@@ -131,3 +132,116 @@ def test_echo_stream_forwards_system_prompt() -> None:
 
     assert len(captured) == 1
     assert captured[0].system == "Be terse."
+
+
+# ---------------------------------------------------------------------------
+# /api/agents/invoke
+# ---------------------------------------------------------------------------
+
+
+def _mock_invoke_response(
+    reply: str = "Agent reply", session_id: str = "s1"
+) -> InlineAgentResponse:
+    return InlineAgentResponse(reply=reply, session_id=session_id)
+
+
+def test_agent_invoke_requires_auth() -> None:
+    resp = client.post("/api/agents/invoke", json={"message": "Hi"})
+    assert resp.status_code in (401, 403)
+
+
+def test_agent_invoke_returns_reply_and_session_id() -> None:
+    with patch(
+        "starter.api.agents.invoke",
+        return_value=_mock_invoke_response("Hello from agent", "sess-42"),
+    ):
+        resp = client.post(
+            "/api/agents/invoke",
+            json={"message": "Hi"},
+            headers=_auth_headers(),
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["reply"] == "Hello from agent"
+    assert data["session_id"] == "sess-42"
+
+
+def test_agent_invoke_forwards_session_and_instruction() -> None:
+    captured: list = []
+
+    def _capture(req, *, user_id):
+        captured.append((req, user_id))
+        return _mock_invoke_response()
+
+    with patch("starter.api.agents.invoke", side_effect=_capture):
+        client.post(
+            "/api/agents/invoke",
+            json={"message": "Hi", "session_id": "my-sess", "instruction": "Be concise."},
+            headers=_auth_headers(),
+        )
+
+    assert len(captured) == 1
+    req, user_id = captured[0]
+    assert req.session_id == "my-sess"
+    assert req.instruction == "Be concise."
+    assert user_id == "u1"  # JWT sub claim
+
+
+# ---------------------------------------------------------------------------
+# /api/agents/invoke/stream
+# ---------------------------------------------------------------------------
+
+
+def _fake_invoke_stream(req, *, user_id) -> Iterator[str]:
+    yield f"data: {json.dumps({'type': 'delta', 'text': 'Hi'})}\n\n"
+    yield f"data: {json.dumps({'type': 'done', 'session_id': req.session_id or 'new-sess'})}\n\n"
+
+
+def test_agent_invoke_stream_requires_auth() -> None:
+    resp = client.post("/api/agents/invoke/stream", json={"message": "Hi"})
+    assert resp.status_code in (401, 403)
+
+
+def test_agent_invoke_stream_returns_event_stream_content_type() -> None:
+    with patch("starter.api.agents.invoke_stream", side_effect=_fake_invoke_stream):
+        resp = client.post(
+            "/api/agents/invoke/stream",
+            json={"message": "Hi", "session_id": "s1"},
+            headers=_auth_headers(),
+        )
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+
+
+def test_agent_invoke_stream_yields_delta_and_done() -> None:
+    with patch("starter.api.agents.invoke_stream", side_effect=_fake_invoke_stream):
+        resp = client.post(
+            "/api/agents/invoke/stream",
+            json={"message": "Hi", "session_id": "s1"},
+            headers=_auth_headers(),
+        )
+
+    events = [line for line in resp.text.split("\n\n") if line.startswith("data: ")]
+    assert len(events) == 2
+    delta = json.loads(events[0][len("data: ") :])
+    assert delta == {"type": "delta", "text": "Hi"}
+    done = json.loads(events[1][len("data: ") :])
+    assert done["type"] == "done"
+
+
+def test_agent_invoke_stream_forwards_user_id_from_claims() -> None:
+    captured: list = []
+
+    def _capture(req, *, user_id) -> Iterator[str]:
+        captured.append(user_id)
+        yield f"data: {json.dumps({'type': 'done', 'session_id': 's1'})}\n\n"
+
+    with patch("starter.api.agents.invoke_stream", side_effect=_capture):
+        client.post(
+            "/api/agents/invoke/stream",
+            json={"message": "Hi"},
+            headers=_auth_headers(),
+        )
+
+    assert captured == ["u1"]  # JWT sub claim

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,7 @@ dev = [
     { name = "invoke" },
     { name = "moto" },
     { name = "mypy" },
+    { name = "mypy-boto3-bedrock-agent-runtime" },
     { name = "mypy-boto3-bedrock-runtime" },
     { name = "pip-audit" },
     { name = "playwright" },
@@ -56,6 +57,7 @@ dev = [
     { name = "invoke", specifier = ">=2.2.0" },
     { name = "moto", specifier = ">=5.1.22" },
     { name = "mypy", specifier = ">=1.19.1" },
+    { name = "mypy-boto3-bedrock-agent-runtime", specifier = ">=1.42.3" },
     { name = "mypy-boto3-bedrock-runtime", specifier = ">=1.42.82" },
     { name = "pip-audit", specifier = ">=2.9.0" },
     { name = "playwright", specifier = ">=1.40.0" },
@@ -1751,6 +1753,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/da/5055c63e377c5c2418760411fd6a63ee2b96cf95397259038756c042574f/mypy-1.19.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:481daf36a4c443332e2ae9c137dfee878fcea781a2e3f895d54bd3002a900957", size = 13807476, upload-time = "2025-12-15T05:03:17.977Z" },
     { url = "https://files.pythonhosted.org/packages/cd/09/4ebd873390a063176f06b0dbf1f7783dd87bd120eae7727fa4ae4179b685/mypy-1.19.1-cp314-cp314-win_amd64.whl", hash = "sha256:8bb5c6f6d043655e055be9b542aa5f3bdd30e4f3589163e85f93f3640060509f", size = 10281872, upload-time = "2025-12-15T05:03:05.549Z" },
     { url = "https://files.pythonhosted.org/packages/8d/f4/4ce9a05ce5ded1de3ec1c1d96cf9f9504a04e54ce0ed55cfa38619a32b8d/mypy-1.19.1-py3-none-any.whl", hash = "sha256:f1235f5ea01b7db5468d53ece6aaddf1ad0b88d9e7462b86ef96fe04995d7247", size = 2471239, upload-time = "2025-12-15T05:03:07.248Z" },
+]
+
+[[package]]
+name = "mypy-boto3-bedrock-agent-runtime"
+version = "1.42.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/57/79dfb6f0c60d5eeebe503a243af42f1955c9274520361f849519e68c56b0/mypy_boto3_bedrock_agent_runtime-1.42.3.tar.gz", hash = "sha256:56d077c61c8bd77662ce668f6fa370fe6ccf1d584412ec293b017fa31c64086c", size = 42018, upload-time = "2025-12-04T20:56:36.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/32/0483a3109366ae161106627226ac6093904bd8e2d8530ecc4a5f5e9655a8/mypy_boto3_bedrock_agent_runtime-1.42.3-py3-none-any.whl", hash = "sha256:58e92ef72afef73cc763fca274577e962f647be881d354a7dc9450fa0a356d60", size = 50958, upload-time = "2025-12-04T20:56:28.273Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `src/starter/agents/agentcore.py` — wrapper around `bedrock-agent-runtime.invoke_inline_agent` with both sync (`invoke`) and streaming (`invoke_stream`) variants.
- Adds `POST /api/agents/invoke` (full reply) and `POST /api/agents/invoke/stream` (SSE streaming) endpoints.
- User-scoped session IDs: Bedrock `sessionId = f"{jwt_sub}:{caller_session_id}"` — sessions never bleed across users; callers only see their own opaque `session_id` in responses.
- Adds `bedrock:InvokeInlineAgent` IAM action scoped to `arn:aws:bedrock:{region}:{account}:agent/*`.
- Adds `mypy-boto3-bedrock-agent-runtime` dev dependency for type safety.
- ADR-0003 documents the inline-vs-pre-configured decision, session namespace convention, no-cross-session-memory default, and migration path to pre-configured agents.
- CLAUDE.md updated: file structure map and session namespace convention added to product decisions.

## Approach

**Why inline agents (not pre-configured):** Zero console setup — a new team can clone and call `/api/agents/invoke` without creating a Bedrock Agent resource. ADR-0003 documents the migration path to pre-configured agents when teams outgrow the inline approach.

**Session namespace convention:** `sessionId = f"{jwt_sub}:{caller_session_id}"`. The `user_id` comes from the JWT `sub` claim — callers cannot impersonate other users' sessions by supplying someone else's ID. The namespaced form is opaque to callers.

**Spike validation (informal):** `invoke_inline_agent` returns an EventStream with `chunk.bytes` events identical in structure to `converse_stream` deltas. AWSLWA (landed in PR #2) already proves the streaming pathway from Lambda → Function URL → client. No separate spike artifact needed.

**Coverage:** 100% on all new modules (13 agentcore tests + 7 new API endpoint tests on top of the existing 7).