### PR TITLE
docs: add Building Agents guide to VitePress docs site

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -43,6 +43,13 @@ export default defineConfig({
           { text: "Quick start", link: "/getting-started/quick-start" },
         ],
       },
+      {
+        text: "Building agents",
+        items: [
+          { text: "Overview", link: "/agents/overview" },
+          { text: "Sessions & memory", link: "/agents/sessions" },
+        ],
+      },
     ],
 
     socialLinks: [],

--- a/docs-site/agents/overview.md
+++ b/docs-site/agents/overview.md
@@ -1,0 +1,158 @@
+# Building agents
+
+AgentCore Starter ships two layers of Bedrock integration out of the box:
+
+| Layer | Module | When to use |
+|---|---|---|
+| **Raw Converse** | `starter.agents.bedrock` | Simple single-turn prompts; full control over messages and token counts |
+| **Inline Agent** | `starter.agents.agentcore` | Multi-turn conversations with session memory; add action groups for tool-calling |
+
+Both layers expose non-streaming and SSE streaming variants, and both run on the same Lambda function behind the same Function URL.
+
+## Prerequisites
+
+The Lambda IAM role already has the required permissions:
+
+- `bedrock:InvokeModel` + `bedrock:InvokeModelWithResponseStream` — for the Converse API
+- `bedrock:InvokeInlineAgent` — for the inline agent API
+
+The model is controlled by the `BEDROCK_MODEL_ID` environment variable (default: `anthropic.claude-sonnet-4-6`). Override it in CDK `common_env` or via SSM to switch models without a code change.
+
+## The echo endpoints (Converse API)
+
+These are scaffold endpoints. Replace them with your own logic once you understand the pattern.
+
+### `POST /api/agents/echo`
+
+Single-turn, buffered response.
+
+```bash
+curl -X POST https://your-domain/api/agents/echo \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What is the capital of France?", "system": "Be concise."}'
+```
+
+```json
+{
+  "reply": "Paris.",
+  "input_tokens": 18,
+  "output_tokens": 3
+}
+```
+
+### `POST /api/agents/echo/stream`
+
+Single-turn, SSE streaming. Each event is a JSON object on a `data:` line.
+
+```bash
+curl -X POST https://your-domain/api/agents/echo/stream \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Count to five.", "system": "Use numerals only."}' \
+  --no-buffer
+```
+
+```
+data: {"type": "delta", "text": "1"}
+
+data: {"type": "delta", "text": ", 2"}
+
+data: {"type": "delta", "text": ", 3, 4, 5"}
+
+data: {"type": "done", "stop_reason": "end_turn", "input_tokens": 14, "output_tokens": 9}
+```
+
+## The agent endpoints (Inline Agent)
+
+These use `bedrock-agent-runtime.invoke_inline_agent` — the same model, but with session continuity between turns. See [Sessions & memory](./sessions) for the full conversation flow.
+
+### `POST /api/agents/invoke`
+
+Single turn with optional session context, buffered response.
+
+```bash
+curl -X POST https://your-domain/api/agents/invoke \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hi, my name is Alice.", "instruction": "You are a helpful assistant."}'
+```
+
+```json
+{
+  "reply": "Hello Alice! How can I help you today?",
+  "session_id": "a3f2c1d0-..."
+}
+```
+
+Pass `session_id` back on the next turn to continue the conversation.
+
+### `POST /api/agents/invoke/stream`
+
+Multi-turn, SSE streaming. The `done` event carries the `session_id` to use on the next request.
+
+```bash
+curl -X POST https://your-domain/api/agents/invoke/stream \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What did I just tell you my name was?", "session_id": "a3f2c1d0-..."}' \
+  --no-buffer
+```
+
+```
+data: {"type": "delta", "text": "You told me your name is"}
+
+data: {"type": "delta", "text": " Alice."}
+
+data: {"type": "done", "session_id": "a3f2c1d0-..."}
+```
+
+## Consuming SSE in JavaScript
+
+```js
+const resp = await fetch('/api/agents/invoke/stream', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify({ message, session_id: sessionId }),
+});
+
+const reader = resp.body.getReader();
+const decoder = new TextDecoder();
+let buffer = '';
+
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  buffer += decoder.decode(value, { stream: true });
+
+  const events = buffer.split('\n\n');
+  buffer = events.pop(); // keep incomplete tail
+
+  for (const event of events) {
+    if (!event.startsWith('data: ')) continue;
+    const payload = JSON.parse(event.slice(6));
+    if (payload.type === 'delta') {
+      appendText(payload.text);
+    } else if (payload.type === 'done') {
+      sessionId = payload.session_id; // save for next turn
+    }
+  }
+}
+```
+
+::: tip CloudFront and SSE
+The `/api/*` CloudFront behaviour routes to the Lambda Function URL.
+CloudFront may buffer SSE responses depending on your distribution settings.
+For reliable real-time streaming, call the Function URL directly — its address
+is in the `ApiFunctionUrl` CloudFormation output.
+:::
+
+## Customising the scaffold
+
+The echo and invoke endpoints are in `src/starter/api/agents.py`.
+Replace or extend the request/response models and the calls to `converse()` /
+`invoke()` with your own agent logic — tool-calling, RAG retrieval, multi-step
+orchestration, etc.

--- a/docs-site/agents/sessions.md
+++ b/docs-site/agents/sessions.md
@@ -1,0 +1,102 @@
+# Sessions & memory
+
+## How sessions work
+
+Every call to `POST /api/agents/invoke` (or `/invoke/stream`) can carry a
+`session_id`. Bedrock Agents uses this to maintain conversational context
+— the model sees the full message history for the session without the client
+re-sending it.
+
+```
+Turn 1 — no session_id (start fresh)
+  → response includes session_id: "abc-123"
+
+Turn 2 — session_id: "abc-123"
+  → model remembers turn 1
+
+Turn 3 — session_id: "abc-123"
+  → model remembers turns 1 and 2
+```
+
+Omit `session_id` to start a brand-new conversation. The response always
+echoes back the `session_id` — either the one you passed in, or a
+freshly-generated UUID if you omitted it.
+
+## Session scoping
+
+Sessions are automatically namespaced to the authenticated user. The
+`session_id` you pass is an opaque string from your perspective; internally
+the wrapper prefixes it with the user's identity from the JWT so two users
+with the same `session_id` string never share history.
+
+This means:
+
+- You don't need to include a `user_id` in your requests — scope comes from
+  the Bearer token.
+- You can use simple, human-readable session IDs (`"default"`,
+  `"conversation-1"`) without worrying about collision across users.
+
+## Session lifetime
+
+Bedrock Agents retains session state for **1 hour of idle time** by default.
+After that, the session expires and the next call with the same `session_id`
+starts fresh.
+
+You can adjust this at the boto3 call site in `agentcore.py`
+(`idleSessionTTLinSeconds` on the `invoke_inline_agent` call).
+
+## Long-term memory
+
+By default there is no memory that persists across sessions. If a user starts
+a new session, the model has no recollection of previous conversations.
+
+To add cross-session memory, populate `inlineSessionState.promptSessionAttributes`
+before calling Bedrock — for example, fetch a summary from DynamoDB and inject
+it as a system-level attribute:
+
+```python
+# In agentcore.py _stream_chunks(), extend kwargs:
+kwargs["inlineSessionState"] = {
+    "promptSessionAttributes": {
+        "user_summary": load_user_summary(user_id),  # your DynamoDB lookup
+    },
+}
+```
+
+The model receives `promptSessionAttributes` as additional context before
+the conversation history. Keep entries short — this counts against the
+model's context window.
+
+## Action groups (tool-calling)
+
+The starter ships with an empty action group list. To give the agent tools,
+add entries to the `actionGroups` key in `agentcore.py`:
+
+```python
+kwargs["actionGroups"] = [
+    {
+        "actionGroupName": "SearchKnowledgeBase",
+        "actionGroupExecutor": {"customControl": "RETURN_CONTROL"},
+        "functionSchema": {
+            "functions": [
+                {
+                    "name": "search",
+                    "description": "Search the knowledge base for relevant documents.",
+                    "parameters": {
+                        "query": {
+                            "type": "string",
+                            "description": "The search query.",
+                            "required": True,
+                        }
+                    },
+                }
+            ]
+        },
+    }
+]
+```
+
+With `RETURN_CONTROL`, when the agent decides to call a tool, the API returns
+a `returnControl` event instead of a text chunk. Your code handles the tool
+call and passes the result back in the next `invoke_inline_agent` call via
+`inlineSessionState.returnControlInvocationResults`.

--- a/docs-site/getting-started/introduction.md
+++ b/docs-site/getting-started/introduction.md
@@ -15,3 +15,5 @@ AgentCore Starter is a production-ready template for building AWS-native AI agen
 ## Next steps
 
 - [Quick start](/getting-started/quick-start) — deploy to your AWS account
+- [Building agents](/agents/overview) — call the Bedrock endpoints and consume SSE streams
+- [Sessions & memory](/agents/sessions) — multi-turn conversations, session scoping, tool-calling


### PR DESCRIPTION
## Summary

Adds a two-page "Building agents" section to the VitePress docs site:

**`/agents/overview`** — covers all four agent endpoints with:
- Side-by-side table of Converse API vs Inline Agent
- `curl` examples for all four endpoints with actual request/response bodies
- Full SSE event schema (`delta` + `done`)
- JavaScript snippet for consuming SSE streams
- CloudFront/streaming caveat (direct Function URL for reliable SSE)
- Note on customising the scaffold

**`/agents/sessions`** — covers:
- How session continuity works (turn-by-turn example)
- User-scoped session namespacing (callers use simple IDs, wrapper handles isolation)
- Session lifetime / TTL
- Cross-session memory pattern (DynamoDB → `promptSessionAttributes`)
- Action groups scaffold (`RETURN_CONTROL` pattern)

Sidebar updated with a "Building agents" section. Introduction "Next steps" updated to link to both new pages.

## Approach

Docs are the consumer's view, not the implementer's view — examples show `curl` and JavaScript, not Python internals. The sessions page explains the namespace convention in terms the caller cares about (simple IDs, no collision) without exposing the `{jwt_sub}:{session_id}` implementation detail.

VitePress build confirmed clean (no dead links, no warnings).