### PR TITLE
fix(auth): enforce ALLOWED_EMAILS allowlist on mgmt callback

### DIFF
--- a/infra/stacks/starter_stack.py
+++ b/infra/stacks/starter_stack.py
@@ -174,7 +174,7 @@ class AgentCoreStarterStack(cdk.Stack):
             "AllowedEmails",
             parameter_name=_ssm_path("allowed-emails"),
             string_value="[]",
-            description=f"JSON array of Google email addresses allowed to access AgentCore Starter ({env_name}); empty = allow all",
+            description=f"JSON array of Google email addresses allowed to access AgentCore Starter ({env_name}); empty = deny all (must be populated post-deploy)",
             tier=ssm.ParameterTier.STANDARD,
         )
         allowed_emails_param.apply_removal_policy(cdk.RemovalPolicy.RETAIN)

--- a/src/starter/auth/google.py
+++ b/src/starter/auth/google.py
@@ -21,6 +21,10 @@ from urllib.parse import urlencode
 import httpx
 from jose import jwt as jose_jwt
 
+from starter.logging_config import get_logger
+
+logger = get_logger(__name__)
+
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
 GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
@@ -53,8 +57,14 @@ def _google_client_secret() -> str:
     )
 
 
-@functools.lru_cache(maxsize=1)
 def _allowed_emails() -> frozenset[str]:
+    """Load the allowlist from env or SSM on every call.
+
+    Not cached: under deny-all semantics, operators populate the SSM
+    parameter post-deploy and need the running Lambda to pick up the
+    new value without waiting for a cold start. Logins are infrequent,
+    so the per-call SSM read is acceptable.
+    """
     if val := os.environ.get("ALLOWED_EMAILS"):
         return frozenset(json.loads(val))
     try:  # pragma: no cover
@@ -62,7 +72,12 @@ def _allowed_emails() -> frozenset[str]:
             os.environ.get("ALLOWED_EMAILS_PARAM", "/agentcore-starter/allowed-emails")
         )
         return frozenset(json.loads(raw))
-    except Exception:  # pragma: no cover
+    except Exception as exc:  # pragma: no cover
+        logger.warning(
+            "Failed to load ALLOWED_EMAILS from SSM (%s); denying all logins. "
+            "Check the SSM parameter exists and contains a valid JSON array.",
+            exc,
+        )
         return frozenset()  # empty = deny all (safer default)
 
 

--- a/src/starter/auth/google.py
+++ b/src/starter/auth/google.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import functools
 import json
 import os
+import time
 from typing import Any
 from urllib.parse import urlencode
 
@@ -24,6 +25,12 @@ from jose import jwt as jose_jwt
 from starter.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+# Short TTL on the allowlist so a single login doesn't double-read SSM
+# (gate + role both fetch) while still letting operators populate the
+# parameter post-deploy without forcing a Lambda cold-start.
+_ALLOWED_EMAILS_TTL_SECONDS = 60
+_allowed_emails_cache: tuple[float, frozenset[str]] | None = None
 
 GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
@@ -58,27 +65,58 @@ def _google_client_secret() -> str:
 
 
 def _allowed_emails() -> frozenset[str]:
-    """Load the allowlist from env or SSM on every call.
+    """Load the allowlist from env or SSM, with a short TTL cache.
 
-    Not cached: under deny-all semantics, operators populate the SSM
-    parameter post-deploy and need the running Lambda to pick up the
-    new value without waiting for a cold start. Logins are infrequent,
-    so the per-call SSM read is acceptable.
+    Fails closed (deny-all) on any load or parse error so a misconfigured
+    parameter never silently grants access. Errors are logged so the
+    operator can see why logins are being rejected.
     """
+    global _allowed_emails_cache
+    now = time.monotonic()
+    if _allowed_emails_cache is not None:
+        cached_at, cached = _allowed_emails_cache
+        if now - cached_at < _ALLOWED_EMAILS_TTL_SECONDS:
+            return cached
+
+    value: frozenset[str]
     if val := os.environ.get("ALLOWED_EMAILS"):
-        return frozenset(json.loads(val))
-    try:  # pragma: no cover
-        raw = _ssm_param(
-            os.environ.get("ALLOWED_EMAILS_PARAM", "/agentcore-starter/allowed-emails")
-        )
-        return frozenset(json.loads(raw))
-    except Exception as exc:  # pragma: no cover
-        logger.warning(
-            "Failed to load ALLOWED_EMAILS from SSM (%s); denying all logins. "
-            "Check the SSM parameter exists and contains a valid JSON array.",
-            exc,
-        )
-        return frozenset()  # empty = deny all (safer default)
+        try:
+            parsed = json.loads(val)
+            if not isinstance(parsed, list):
+                raise ValueError("ALLOWED_EMAILS must be a JSON array")
+            value = frozenset(parsed)
+        except Exception as exc:
+            logger.warning(
+                "Failed to parse ALLOWED_EMAILS env var (%s); denying all logins. "
+                "Expected a JSON array of email strings.",
+                exc,
+            )
+            value = frozenset()
+    else:
+        try:  # pragma: no cover
+            raw = _ssm_param(
+                os.environ.get("ALLOWED_EMAILS_PARAM", "/agentcore-starter/allowed-emails")
+            )
+            parsed = json.loads(raw)
+            if not isinstance(parsed, list):
+                raise ValueError("ALLOWED_EMAILS SSM value must be a JSON array")
+            value = frozenset(parsed)
+        except Exception as exc:  # pragma: no cover
+            logger.warning(
+                "Failed to load ALLOWED_EMAILS from SSM (%s); denying all logins. "
+                "Check the SSM parameter exists and contains a valid JSON array.",
+                exc,
+            )
+            value = frozenset()
+
+    _allowed_emails_cache = (now, value)
+    return value
+
+
+def _reset_allowed_emails_cache() -> None:
+    """Clear the TTL cache; for use in tests."""
+    global _allowed_emails_cache
+    _allowed_emails_cache = None
 
 
 def google_authorization_url(state: str, callback_uri: str) -> str:

--- a/src/starter/auth/google.py
+++ b/src/starter/auth/google.py
@@ -7,7 +7,7 @@ Uses Google as an identity provider for human-facing management UI login.
 Configuration (env vars or SSM parameters):
   GOOGLE_CLIENT_ID / GOOGLE_CLIENT_ID_PARAM
   GOOGLE_CLIENT_SECRET / GOOGLE_CLIENT_SECRET_PARAM
-  ALLOWED_EMAILS / ALLOWED_EMAILS_PARAM  (JSON array; empty = allow all)
+  ALLOWED_EMAILS / ALLOWED_EMAILS_PARAM  (JSON array; empty = deny all)
 """
 
 from __future__ import annotations
@@ -63,7 +63,7 @@ def _allowed_emails() -> frozenset[str]:
         )
         return frozenset(json.loads(raw))
     except Exception:  # pragma: no cover
-        return frozenset()  # empty = allow all (open)
+        return frozenset()  # empty = deny all (safer default)
 
 
 def google_authorization_url(state: str, callback_uri: str) -> str:
@@ -125,12 +125,12 @@ async def verify_google_id_token(id_token: str) -> dict[str, Any]:  # pragma: no
 def is_email_allowed(email: str) -> bool:
     """Return True if the email is permitted to access the application.
 
-    An empty allowlist means open access (allow all verified Google accounts).
+    An empty allowlist denies all access. This is the safer default: a
+    freshly-deployed stack ships with ``ALLOWED_EMAILS="[]"`` and must
+    not grant management access to any verified Google account until the
+    deployer explicitly populates the list.
     """
-    allowed = _allowed_emails()
-    if not allowed:
-        return True
-    return email in allowed
+    return email in _allowed_emails()
 
 
 def is_admin_email(email: str) -> bool:

--- a/src/starter/auth/mgmt_auth.py
+++ b/src/starter/auth/mgmt_auth.py
@@ -27,6 +27,7 @@ from starter.auth.google import (
     exchange_google_code,
     google_authorization_url,
     is_admin_email,
+    is_email_allowed,
     verify_google_id_token,
 )
 from starter.auth.tokens import ISSUER, issue_mgmt_jwt
@@ -137,6 +138,10 @@ async def mgmt_callback(
         raise HTTPException(status_code=400, detail="Google email is not verified")
 
     email: str = claims["email"]
+    if not is_email_allowed(email):
+        logger.warning("Management login rejected — email not in allowlist: %s", email)
+        raise HTTPException(status_code=403, detail="Email not authorised")
+
     display_name: str = claims.get("name", email.split("@")[0])
 
     user = _make_user(email, display_name)

--- a/tests/unit/test_auth_google.py
+++ b/tests/unit/test_auth_google.py
@@ -20,7 +20,6 @@ from starter.auth.google import (  # noqa: E402
 def _clear_caches():
     _google_client_id.cache_clear()
     _google_client_secret.cache_clear()
-    _allowed_emails.cache_clear()
 
 
 def setup_function():

--- a/tests/unit/test_auth_google.py
+++ b/tests/unit/test_auth_google.py
@@ -67,9 +67,10 @@ def test_is_email_allowed_when_not_in_list(monkeypatch):
     assert is_email_allowed("other@test.com") is False
 
 
-def test_is_email_allowed_empty_list_allows_all(monkeypatch):
+def test_is_email_allowed_empty_list_denies_all(monkeypatch):
+    """Empty allowlist denies all — safer default for freshly-deployed stacks."""
     monkeypatch.setenv("ALLOWED_EMAILS", "[]")
-    assert is_email_allowed("anyone@example.com") is True
+    assert is_email_allowed("anyone@example.com") is False
 
 
 def test_is_admin_email_when_listed(monkeypatch):

--- a/tests/unit/test_auth_google.py
+++ b/tests/unit/test_auth_google.py
@@ -11,6 +11,7 @@ from starter.auth.google import (  # noqa: E402
     _allowed_emails,
     _google_client_id,
     _google_client_secret,
+    _reset_allowed_emails_cache,
     google_authorization_url,
     is_admin_email,
     is_email_allowed,
@@ -20,6 +21,7 @@ from starter.auth.google import (  # noqa: E402
 def _clear_caches():
     _google_client_id.cache_clear()
     _google_client_secret.cache_clear()
+    _reset_allowed_emails_cache()
 
 
 def setup_function():
@@ -80,3 +82,27 @@ def test_is_admin_email_when_listed(monkeypatch):
 def test_is_admin_email_when_not_listed(monkeypatch):
     monkeypatch.setenv("ALLOWED_EMAILS", '["admin@test.com"]')
     assert is_admin_email("user@test.com") is False
+
+
+def test_allowed_emails_invalid_json_denies_all(monkeypatch):
+    """Malformed JSON in ALLOWED_EMAILS env must fail closed (deny all)."""
+    monkeypatch.setenv("ALLOWED_EMAILS", "not-json{")
+    assert _allowed_emails() == frozenset()
+
+
+def test_allowed_emails_non_array_denies_all(monkeypatch):
+    """Non-array JSON in ALLOWED_EMAILS env must fail closed (deny all)."""
+    monkeypatch.setenv("ALLOWED_EMAILS", '{"admin": "alice@example.com"}')
+    assert _allowed_emails() == frozenset()
+
+
+def test_allowed_emails_ttl_cache_returns_cached_value(monkeypatch):
+    """A second call within the TTL window returns the cached set even if
+    the env var changes — the cache absorbs intra-window churn so a single
+    login doesn't double-fetch.
+    """
+    monkeypatch.setenv("ALLOWED_EMAILS", '["alice@example.com"]')
+    first = _allowed_emails()
+    monkeypatch.setenv("ALLOWED_EMAILS", '["bob@example.com"]')
+    second = _allowed_emails()
+    assert first == second == frozenset({"alice@example.com"})

--- a/tests/unit/test_auth_mgmt.py
+++ b/tests/unit/test_auth_mgmt.py
@@ -10,7 +10,7 @@ os.environ.setdefault("STARTER_JWT_SECRET", "test-secret-for-unit-tests")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "test-google-client-id")
 
 from starter.api.main import app  # noqa: E402
-from starter.auth.google import _allowed_emails, _google_client_id  # noqa: E402
+from starter.auth.google import _google_client_id  # noqa: E402
 from starter.auth.mgmt_auth import (  # noqa: E402
     _consume_pending_state,
     _create_pending_state,
@@ -24,7 +24,6 @@ _client = TestClient(app, follow_redirects=False)
 
 def _clear_google_caches():
     _google_client_id.cache_clear()
-    _allowed_emails.cache_clear()
 
 
 def setup_function():

--- a/tests/unit/test_auth_mgmt.py
+++ b/tests/unit/test_auth_mgmt.py
@@ -115,7 +115,7 @@ def test_mgmt_callback_invalid_state():
 
 
 def test_mgmt_callback_success(monkeypatch):
-    monkeypatch.setenv("ALLOWED_EMAILS", "[]")
+    monkeypatch.setenv("ALLOWED_EMAILS", '["user@example.com"]')
     state = _create_pending_state()
     with (
         patch(
@@ -136,6 +136,124 @@ def test_mgmt_callback_success(monkeypatch):
         resp = _client.get(f"/auth/callback?code=authcode&state={state}")
     assert resp.status_code == 200
     assert "starter_mgmt_token" in resp.text
+
+
+def test_mgmt_callback_unlisted_email_with_populated_allowlist_returns_403(monkeypatch):
+    """Verified email not in a populated allowlist must be rejected with 403."""
+    monkeypatch.setenv("ALLOWED_EMAILS", '["admin@example.com"]')
+    state = _create_pending_state()
+    with (
+        patch(
+            "starter.auth.mgmt_auth.exchange_google_code",
+            new=AsyncMock(return_value="fake-id-token"),
+        ),
+        patch(
+            "starter.auth.mgmt_auth.verify_google_id_token",
+            new=AsyncMock(
+                return_value={
+                    "email": "stranger@example.com",
+                    "email_verified": True,
+                    "name": "Stranger",
+                }
+            ),
+        ),
+    ):
+        resp = _client.get(f"/auth/callback?code=authcode&state={state}")
+    assert resp.status_code == 403
+    assert "starter_mgmt_token" not in resp.text
+
+
+def test_mgmt_callback_unlisted_email_with_empty_allowlist_returns_403(monkeypatch):
+    """Empty allowlist must deny all verified emails (deny-all default).
+
+    Regression for SEC-1: a freshly-deployed stack ships with
+    ALLOWED_EMAILS="[]" and must not mint a JWT to any verified Google
+    account until the deployer explicitly populates the list.
+    """
+    monkeypatch.setenv("ALLOWED_EMAILS", "[]")
+    state = _create_pending_state()
+    with (
+        patch(
+            "starter.auth.mgmt_auth.exchange_google_code",
+            new=AsyncMock(return_value="fake-id-token"),
+        ),
+        patch(
+            "starter.auth.mgmt_auth.verify_google_id_token",
+            new=AsyncMock(
+                return_value={
+                    "email": "anyone@example.com",
+                    "email_verified": True,
+                    "name": "Anyone",
+                }
+            ),
+        ),
+    ):
+        resp = _client.get(f"/auth/callback?code=authcode&state={state}")
+    assert resp.status_code == 403
+    assert "starter_mgmt_token" not in resp.text
+
+
+def test_mgmt_callback_listed_admin_email_returns_admin_role(monkeypatch):
+    """Listed email passes the gate and receives role=admin."""
+    monkeypatch.setenv("ALLOWED_EMAILS", '["admin@example.com"]')
+    state = _create_pending_state()
+    with (
+        patch(
+            "starter.auth.mgmt_auth.exchange_google_code",
+            new=AsyncMock(return_value="fake-id-token"),
+        ),
+        patch(
+            "starter.auth.mgmt_auth.verify_google_id_token",
+            new=AsyncMock(
+                return_value={
+                    "email": "admin@example.com",
+                    "email_verified": True,
+                    "name": "Admin",
+                }
+            ),
+        ),
+        patch("starter.auth.mgmt_auth.issue_mgmt_jwt") as mock_issue,
+    ):
+        mock_issue.return_value = "stub-jwt"
+        resp = _client.get(f"/auth/callback?code=authcode&state={state}")
+    assert resp.status_code == 200
+    assert mock_issue.call_args.args[0]["role"] == "admin"
+
+
+def test_mgmt_callback_listed_non_admin_email_returns_user_role(monkeypatch):
+    """The allowlist gate must not re-derive role; role still flows from
+    is_admin_email().
+
+    Today both signals read from the same ``ALLOWED_EMAILS`` set, so any
+    listed email is also admin in production. This test mocks
+    ``is_admin_email`` to False to assert that the new gate did not collapse
+    the two checks — if the lists are ever split, role=user becomes a real
+    code path and this test is the regression guard.
+    """
+    monkeypatch.setenv("ALLOWED_EMAILS", '["user@example.com"]')
+    state = _create_pending_state()
+    with (
+        patch(
+            "starter.auth.mgmt_auth.exchange_google_code",
+            new=AsyncMock(return_value="fake-id-token"),
+        ),
+        patch(
+            "starter.auth.mgmt_auth.verify_google_id_token",
+            new=AsyncMock(
+                return_value={
+                    "email": "user@example.com",
+                    "email_verified": True,
+                    "name": "Regular User",
+                }
+            ),
+        ),
+        patch("starter.auth.mgmt_auth.is_admin_email", return_value=False),
+        patch("starter.auth.mgmt_auth.issue_mgmt_jwt") as mock_issue,
+    ):
+        mock_issue.return_value = "stub-jwt"
+        resp = _client.get(f"/auth/callback?code=authcode&state={state}")
+    assert resp.status_code == 200
+    assert mock_issue.call_args.args[0]["role"] == "user"
 
 
 def test_mgmt_callback_unverified_email(monkeypatch):

--- a/tests/unit/test_auth_mgmt.py
+++ b/tests/unit/test_auth_mgmt.py
@@ -10,7 +10,7 @@ os.environ.setdefault("STARTER_JWT_SECRET", "test-secret-for-unit-tests")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "test-google-client-id")
 
 from starter.api.main import app  # noqa: E402
-from starter.auth.google import _google_client_id  # noqa: E402
+from starter.auth.google import _google_client_id, _reset_allowed_emails_cache  # noqa: E402
 from starter.auth.mgmt_auth import (  # noqa: E402
     _consume_pending_state,
     _create_pending_state,
@@ -24,6 +24,7 @@ _client = TestClient(app, follow_redirects=False)
 
 def _clear_google_caches():
     _google_client_id.cache_clear()
+    _reset_allowed_emails_cache()
 
 
 def setup_function():


### PR DESCRIPTION
Closes #15.

## Summary

Live exploit fix: `mgmt_callback` previously issued a management JWT to any verified Google account regardless of the `ALLOWED_EMAILS` SSM parameter, so any third party with a verified Google account could reach the Function URL, sign in, and trigger paid Bedrock invocations against the deployer's AWS account.

`mgmt_callback` now calls `is_email_allowed()` after the `email_verified` check and raises HTTP 403 if the email is not in the allowlist. Empty allowlist semantics flipped from **allow-all** to **deny-all** — freshly-deployed stacks (which ship with `ALLOWED_EMAILS="[]"` in CDK) now reject everyone until the deployer explicitly populates the parameter.

## Files changed

- `src/starter/auth/google.py` — `is_email_allowed()` now denies on empty list; docstring + module header updated.
- `src/starter/auth/mgmt_auth.py` — call `is_email_allowed()` after the verified check, raise 403 with a warning log.
- `infra/stacks/starter_stack.py` — SSM parameter description updated to document the new deny-all semantic.
- `tests/unit/test_auth_google.py` — flipped existing `_empty_list_allows_all` test to `_empty_list_denies_all`.
- `tests/unit/test_auth_mgmt.py` — populated the allowlist in the existing `test_mgmt_callback_success` (would 403 otherwise) and added 4 regression tests covering the acceptance criteria.

## Approach notes

**Branch infrastructure**: this PR also pushed a new `development` branch (forked from `main`) — the repo previously had only `main`, but `CLAUDE.md` and the `issue-worker` protocol both expect a `development` branch as the base. Default-branch switch in GitHub settings (main → development) will be done manually post-merge.

**Bypass path unchanged**: the `STARTER_BYPASS_GOOGLE_AUTH=1` shortcut in `/auth/login` does not call `is_email_allowed()`. Bypass requires an env var only set in dev (`inv dev` only), so it's not part of the live-exploit path. Kept out of scope.

**Role derivation unchanged**: per the issue, `is_admin_email()` is left as-is. Currently both signals read from the same `ALLOWED_EMAILS` set, so any listed email is also admin in production. The new `test_mgmt_callback_listed_non_admin_email_returns_user_role` mocks `is_admin_email` to False to assert the gate did not collapse the two checks — if the lists are ever split, role=user becomes a real code path and that test is the regression guard.

**Copilot review (local)**: pre-push Copilot review flagged one finding outside this scope — JWT-in-HTML-body in `_html_redirect()`. That mechanism predates this change; the diff did not modify the redirect helper. Tracked separately.

**Local e2e**: not run — local stack isn't running. CI will cover the auth flow on the `development` deploy.

## Test plan

- [x] `uv run inv pre-push` (lint + typecheck + copyright + 117 unit + 355 frontend, all green)
- [x] `uv run inv synth` (CDK synth green; SSM description change picked up)
- [x] Regression tests assert 403 on both empty and populated-but-not-matching allowlists
- [ ] CI on this PR
- [ ] `development` branch deploy + e2e on merge