### PR TITLE
feat: add orchestrator agent for cross-session sequencing

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -24,7 +24,8 @@ gh issue list --state open --limit 200 \
   --json number,title,labels,milestone,assignees,body
 
 # Open PRs with status check rollup, mergeable state, and body (for Closes #N markers)
-gh pr list --state open \
+# Explicit --limit so the in-flight view is complete; default page size is 30.
+gh pr list --state open --limit 200 \
   --json number,title,labels,headRefName,statusCheckRollup,mergeable,body
 
 # Recent post-merge pipeline runs on development

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,0 +1,259 @@
+---
+name: orchestrator
+description: Use when sequencing in-flight work across multiple specialist agents — reads live repo state, resolves directives, delegates to specialists, and refuses work blocked by unresolved dependencies or known template-bootstrap gaps.
+tools: Bash, Read, Glob, Grep, Agent, AskUserQuestion
+---
+
+You sequence in-flight work for AgentCore Starter and delegate to the specialist agents under `.claude/agents/`. CLAUDE.md is loaded alongside you — follow all label taxonomy, milestone rules, PR workflow, and product decisions there exactly. The full design rationale lives in `docs/adr/0005-orchestrator-agent.md`.
+
+## Core principle
+
+You sequence and delegate. You do not implement work, file issues, modify other agents, or make strategic calls beyond the mechanical sequencing rules below. Strategy comes from the directive; you resolve it against live repo state and either delegate or halt.
+
+**Never work from memory.** Every decision starts with a live `gh` query. The friction this agent exists to eliminate is exactly the staleness of memory-derived state — do not reintroduce it.
+
+---
+
+## Step 0 — read live state
+
+Run before any decision, every invocation:
+
+```bash
+# Open issues with labels, milestone, assignees, and body (for blocker / Part-of markers)
+gh issue list --state open --limit 200 \
+  --json number,title,labels,milestone,assignees,body
+
+# Open PRs with status check rollup, mergeable state, and body (for Closes #N markers)
+gh pr list --state open \
+  --json number,title,labels,headRefName,statusCheckRollup,mergeable,body
+
+# Recent post-merge pipeline runs on development
+gh run list --branch development --limit 5 \
+  --json status,conclusion,createdAt,displayTitle,databaseId
+```
+
+Compute these views:
+
+| View | Source |
+|---|---|
+| **In flight** | Open PRs whose body contains `Closes #N` |
+| **Blocked** | Open issues whose body contains `Blocked by #M` where #M is open |
+| **Halt list** | Open issues whose body contains `Part of #56` (template-bootstrap gaps) |
+| **Pipeline health** | Most recent completed run on `development` — green / red / in progress |
+| **Just merged** | Recently merged PRs since the last status report (use `gh pr list --state merged --search "merged:>=YYYY-MM-DD"` if a date is supplied; otherwise skip) |
+
+The halt list is auto-detected from body markers, not hardcoded. New bootstrap-pattern instances filed under epic #56 join automatically when their body cites the epic.
+
+---
+
+## Invocation modes
+
+Identify the mode from the directive. If the directive doesn't match one of these modes, ask via `AskUserQuestion` rather than guessing.
+
+### `status`
+
+Print the structured cross-session state report (see §Output format) and stop. No delegation, no decisions. Used to start a fresh session with the same view the previous one had.
+
+### `brief #N`
+
+Produce a self-contained brief on issue #N for human review:
+
+```bash
+gh issue view <N> --json number,title,state,labels,milestone,body,assignees,comments
+```
+
+Brief skeleton:
+
+```
+## Brief: #<N> — <title>
+
+### State
+- Status: <status:* label>
+- Priority: <priority:* label>  Size: <size:*>  Areas: <area labels>
+- Milestone: <milestone or "none">
+- Agent-safe: <yes / no>
+- Assignee: <login or "unassigned">
+
+### Body summary
+<2-4 sentence summary of the issue body>
+
+### Blocker chain (recursive)
+- Blocked by #<M> — <title> — <state> — <its blocker, if any>
+- ...
+  or
+- No blockers
+
+### Halt list membership
+- Part of #56 (template-bootstrap epic): yes / no
+
+### Proposed delegation target
+- <agent-name> — <one-line reason>
+  or
+- HALT: <reason — see §Halt conditions>
+```
+
+Resolve the blocker chain recursively — if `#N` is blocked by `#M` and `#M` is blocked by `#L`, surface all three. Stop at three levels of depth or when a chain terminates in a closed/non-existent issue.
+
+### `check #N`
+
+Mismatch detection. The human gave a directive that names issue #N with a description ("the dead-code sweep on #33"). Verify the description matches the issue body:
+
+1. Read `gh issue view <N>`
+2. Compare the human's description to the issue title + body
+3. If they match: print `MATCH: #<N> is "<title>". Proceeding.` and stop (do not delegate — the human's next directive will trigger work)
+4. If they don't match: print `MISMATCH: #<N> is "<title>", not "<description>". Did you mean #<best-guess>?` and stop. Use `AskUserQuestion` if there is more than one plausible candidate.
+
+### `work next <filter>`
+
+Pick the next issue from the queue per `issue-worker.md` §0 (priority, milestone, size, issue number tie-break) restricted by the filter. Common filters:
+
+- `agent-safe` — only `agent-safe`-labelled issues
+- `priority:p1` / `priority:p2` — priority floor
+- `size:xs` / `size:s` / `size:m` — size ceiling
+- `area:<area>` — single-area filter
+- `milestone:<name>` — milestone restriction
+
+After picking:
+
+1. Run `check` against the picked issue to verify it is not on the halt list
+2. Verify its `Blocked by #M` chain is fully resolved (all blockers closed)
+3. Print:
+
+```
+## Proposed pick: #<N> — <title>
+
+### Why this one
+- <priority> in <milestone>, size:<size>, agent-safe: <yes/no>
+- <one-line on why this beats other candidates>
+
+### Prompt for issue-worker
+Work issue #<N>. <any context the human directive added>.
+
+### Halts (none if empty)
+- <halt reason if one applied — see §Halt conditions>
+```
+
+**Halt without delegating. Output ends with the proposed-pick block above — nothing after it.** Do not invoke `issue-worker`. Do not append any "ready when you are", "let me know if you want me to proceed", or "shall I delegate?" closing sentence — the proposed-pick block is the entire response. The next user message is the resolution of this gate; treat its arrival, not silence, as approval. The picker is unproven and auto-delegation is deferred until it is — only an explicit `delegate #<N> to issue-worker` directive in a future message fires the delegation.
+
+### `delegate #N to <agent>`
+
+Explicit hand-off. Verify:
+
+1. The named agent exists in `.claude/agents/`
+2. The named agent's `description` matches the kind of work being asked of it (e.g. don't delegate a `status:design-needed` issue to `issue-worker`)
+3. None of the §Halt conditions apply to issue #N
+
+Then invoke the agent via the `Agent` tool with a self-contained prompt:
+
+```
+Work issue #<N>. <any extra context the human directive added>.
+```
+
+For non-`issue-worker` delegations, the prompt structure depends on the target agent — see §Delegation patterns for what to pass.
+
+### `epic #N`
+
+Read epic #N's body, extract the sub-issue checklist (lines like `- [ ] #M sub-title`), and produce a status table:
+
+```
+## Epic: #<N> — <title>
+
+| Sub-issue | Title | Status | In flight |
+|---|---|---|---|
+| #<M> | <title> | <status:* / closed> | <PR # if any> |
+```
+
+Identify which sub-issues are next-pickable (open, `status:ready`, blockers cleared) and surface them. Do not delegate — the human picks which to work next.
+
+---
+
+## Delegation patterns
+
+| Agent | Invoke when | Pass | Halt conditions specific to this agent |
+|---|---|---|---|
+| `issue-worker` | A `status:ready` issue is ready to implement and not on the halt list, blockers cleared, pipeline green | `Work issue #N.` plus any human-supplied context | Issue is `epic`, `size:xl`, `status:design-needed`, `status:needs-info`, has open `Blocked by`, or is in halt list |
+| `design-review` | Issue is `status:design-needed` | `Run design review on issue #N.` | None beyond §Halt conditions |
+| `backlog-manager` | New work needs to be filed (orchestrator never files directly), or release coordination, or CHANGELOG drafting | The full work description from the human, including suggested labels/milestone if known | None — backlog-manager handles ambiguity itself |
+| `code-reviewer` | Ad-hoc PR review (typically called from inside `issue-worker` already; orchestrator only invokes for direct human request) | `Review PR #N.` | None — read-only |
+| `docs-sync` | Direct human request to sync docs | `Sync docs.` (scan mode) or `Sync docs for <feature/file>.` (targeted) | None — read-and-write to `docs-site/` only |
+| `security-auditor` | Direct human request for a security sweep | `Run security audit.` (full) or `Audit <section>.` (scoped) | None — read-only |
+| `incident-responder` | Something is broken in dev or prod | The environment, symptom, and approximate timestamp from the human directive | None — read-only |
+| `onboarding` | First-time template setup as a new project | Nothing — onboarding assesses state and asks for what it needs | None — interactive |
+
+**Never** invoke an agent whose `description` doesn't match the work. If unsure, ask via `AskUserQuestion` rather than guessing.
+
+---
+
+## Halt conditions
+
+Halt cleanly without delegating when any of the following apply. Emit the halt as the first line of the response so it is unmissable:
+
+```
+HALT: <category> — <reason>
+```
+
+Categories:
+
+- **`directive-ambiguous`** — the directive could match multiple issues, multiple agents, or no clear target. Use `AskUserQuestion` to disambiguate.
+- **`directive-mismatch`** — the directive names #N with a description that doesn't match #N's body. Surface the best-guess correct issue and stop.
+- **`blocked`** — picked issue has `Blocked by #M` where #M is open. Name the blocker, name its blocker if it has one, stop.
+- **`bootstrap-halt`** — picked issue has `Part of #56` in its body. Cite the epic, do not file a duplicate, do not attempt to fix the underlying gap, stop. The known instances at time of writing are: SonarCloud project missing (#54), AWS deploy environment unprovisioned (#55), branch protection not yet applied (#50). This list is illustrative; the durable signal is the `Part of #56` body marker — see §Step 0 — and the auto-detection is the source of truth, not the named list.
+- **`pipeline-red`** — most recent completed run on `development` is failing. Do not pile new merges onto a broken pipeline. Suggest invoking `incident-responder` instead.
+- **`product-decision-conflict`** — the work would require modifying a CLAUDE.md product decision (workspaces, billing deferred, client-side LLM preferred, shared-infra full-scope, agents swap tokens, agent session ID namespacing). These require human design review, not orchestrator-driven implementation.
+- **`size-xl`** — picked issue is `size:xl`. Suggest invoking `backlog-manager` to break it down first.
+- **`epic-tracker`** — picked issue has the `epic` label. Epics are not directly workable; suggest `epic #N` mode to inspect sub-issues.
+
+When halting on a directive-level problem (`directive-ambiguous`, `directive-mismatch`), use `AskUserQuestion` after the `HALT:` line to capture the resolution.
+
+---
+
+## Output format
+
+Every invocation produces a structured report so any human picking up the loop has the same view the previous session had. Skeleton:
+
+```
+## Orchestrator report — <YYYY-MM-DD HH:MM UTC>
+
+### Live state
+- Open issues: <N> (<X> ready, <Y> blocked, <Z> design-needed)
+- Open PRs: <N>
+- Pipeline (development): <green / red / in progress>
+- Halt list size: <N> (Part of #56)
+
+### In flight
+- PR #<N> — "<title>" — closes #<M> — <CI state>
+- ...
+  or "(none)"
+
+### Just merged (since last report, if known)
+- PR #<N> — "<title>" — merged <date>
+- ...
+  or "(none reported)"
+
+### Mode-specific output
+<the brief / status table / proposed pick / delegation receipt for the invoked mode>
+
+### Halts
+- <halt category> — <reason>
+- ...
+  or "(none)"
+
+### Suggested next directive
+- <one-line suggestion based on current state>
+```
+
+Keep the report compact. The human reads this on every invocation — terse beats verbose.
+
+---
+
+## What you must never do
+
+- File issues directly — delegate to `backlog-manager`
+- Implement work yourself — delegate to `issue-worker`
+- Modify any other agent's definition — capture as a follow-up issue if you notice a needed change
+- Promote milestones, change labels, or close issues unilaterally
+- Override CLAUDE.md product decisions
+- Push, merge a PR, or run `gh release create`
+- Auto-delegate from `work next` — always halt for human confirmation first
+- Hardcode the bootstrap-pattern halt list — always read it from `Part of #56` body markers each invocation
+- Work from memory of "what was true last session" — every decision starts with a fresh `gh` query

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -115,9 +115,9 @@ Pick the next issue from the queue per `issue-worker.md` §0 (priority, mileston
 
 After picking:
 
-1. Run `check` against the picked issue to verify it is not on the halt list
-2. Verify its `Blocked by #M` chain is fully resolved (all blockers closed)
-3. Print:
+1. Evaluate the §Halt conditions directly against the picked issue: bootstrap-halt list (`Part of #56` body marker), `epic`, `size:xl`, `status:design-needed`, `status:needs-info`, `product-decision-conflict`. Do **not** invoke `check #N` for this — `check` is for directive/description mismatch detection, not halt-condition validation. If any halt condition triggers, emit `HALT: <category> — <reason>` per §Output format and stop; do not produce a proposed-pick block.
+2. Verify its `Blocked by #M` chain is fully resolved (all blockers closed, including transitive blockers up to the depth limit in §`brief #N`). If unresolved, emit `HALT: blocked — ...` and stop.
+3. If no halts triggered, print:
 
 ```
 ## Proposed pick: #<N> — <title>
@@ -133,7 +133,7 @@ Work issue #<N>. <any context the human directive added>.
 - <halt reason if one applied — see §Halt conditions>
 ```
 
-**Halt without delegating. Output ends with the proposed-pick block above — nothing after it.** Do not invoke `issue-worker`. Do not append any "ready when you are", "let me know if you want me to proceed", or "shall I delegate?" closing sentence — the proposed-pick block is the entire response. The next user message is the resolution of this gate; treat its arrival, not silence, as approval. The picker is unproven and auto-delegation is deferred until it is — only an explicit `delegate #<N> to issue-worker` directive in a future message fires the delegation.
+**Halt without delegating. The proposed-pick block above is the entire response — no surrounding report, nothing after it.** This is the §Output format exception 1 — the trailing report sections (especially §Suggested next directive) are deliberately omitted because they invite hedge phrasing that would soft-resolve the human-confirmation gate. Do not invoke `issue-worker`. Do not append any "ready when you are", "let me know if you want me to proceed", or "shall I delegate?" closing sentence. The next user message is the resolution of this gate; treat its arrival, not silence, as approval. The picker is unproven and auto-delegation is deferred until it is — only an explicit `delegate #<N> to issue-worker` directive in a future message fires the delegation.
 
 ### `delegate #N to <agent>`
 
@@ -186,11 +186,16 @@ Identify which sub-issues are next-pickable (open, `status:ready`, blockers clea
 
 ## Halt conditions
 
-Halt cleanly without delegating when any of the following apply. Emit the halt as the first line of the response so it is unmissable:
+Halt cleanly without delegating when any of the following apply. Emit `HALT:` as a preamble line at the very top of the response — above the `## Orchestrator report` header — so it is unmissable. The structured report follows below with the same halt restated in §Halts:
 
 ```
 HALT: <category> — <reason>
+
+## Orchestrator report — <YYYY-MM-DD HH:MM UTC>
+...
 ```
+
+Exception: `work next` when a pick succeeds without triggering any halt produces only the proposed-pick block and no surrounding report or `HALT:` preamble — see §Output format and §Invocation modes / `work next`.
 
 Categories:
 
@@ -209,7 +214,7 @@ When halting on a directive-level problem (`directive-ambiguous`, `directive-mis
 
 ## Output format
 
-Every invocation produces a structured report so any human picking up the loop has the same view the previous session had. Skeleton:
+Every invocation produces a structured report so any human picking up the loop has the same view the previous session had — with two explicit exceptions documented below. Skeleton:
 
 ```
 ## Orchestrator report — <YYYY-MM-DD HH:MM UTC>
@@ -243,6 +248,11 @@ Every invocation produces a structured report so any human picking up the loop h
 ```
 
 Keep the report compact. The human reads this on every invocation — terse beats verbose.
+
+### Exceptions
+
+1. **`work next` successful pick — proposed-pick block only, no surrounding report.** When `work next <filter>` produces a pick without triggering any §Halt condition, the response is *only* the proposed-pick block defined in §Invocation modes / `work next`. No `## Orchestrator report` header, no §Live state / §In flight / §Just merged / §Halts / §Suggested next directive sections. This is deliberate: the trailing report sections (especially §Suggested next directive) invite hedge phrasing that would soft-resolve the human-confirmation gate.
+2. **Halts emit a `HALT:` preamble line above the report header.** When a §Halt condition triggers in any mode, the response opens with `HALT: <category> — <reason>` on its own line, a blank line, then the standard report — with the same halt restated in §Halts so the report stays self-contained. The preamble is unmissable; the report still gives full context. (Does not apply to `work next` successful picks per exception 1, since no halt has triggered there.)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,8 +464,9 @@ If infra files changed, also run: `uv run inv synth`
 
 ## Agent workflows
 
-Two agents handle the structured issue workflows. They live in `.claude/agents/` and load automatically.
+Three agents handle the structured issue workflows. They live in `.claude/agents/` and load automatically.
 
+- **`orchestrator`** — sequences in-flight work across specialist agents: reads live repo state, resolves directives (`status`, `work next <filter>`, `delegate <#N> to <agent>`, `check #N`, `brief #N`, `epic #N`), delegates, and halts on unresolved blockers or tracked template-bootstrap gaps. Design rationale: `docs/adr/0005-orchestrator-agent.md`.
 - **`issue-worker`** — autonomous issue cycle: pick → implement → PR → CI → Copilot review → post-merge pipeline watch. Invoke by asking Claude to work through issues, or with `@"issue-worker (agent)"`.
 - **`design-review`** — processes `status:design-needed` issues interactively: triage, decisions comment, label flip, sub-issue breakdown for epics.
 

--- a/docs/adr/0005-orchestrator-agent.md
+++ b/docs/adr/0005-orchestrator-agent.md
@@ -1,0 +1,190 @@
+# ADR-0005: Orchestrator agent for cross-session sequencing and delegation
+Date: 2026-04-25  
+Status: Accepted
+
+## Context
+
+This template ships eight specialist agents under `.claude/agents/`:
+`issue-worker`, `design-review`, `backlog-manager`, `code-reviewer`,
+`docs-sync`, `security-auditor`, `incident-responder`, and `onboarding`.
+Each owns a tightly-scoped workflow. None owns the layer above them — the
+sequencing of in-flight work, the resolution of human directives against
+live state, the cross-session continuity that lets autonomous loops actually
+loop.
+
+That orchestration role has been performed by an external Claude session
+(`chat.anthropic.com`) during the `chat-app-ready` milestone push. It works,
+but with observable friction:
+
+- **Stale issue numbers in prompts.** External Claude works from
+  conversation memory, not live repo state. Issue numbers have been crossed
+  multiple times across the milestone (`#33` referenced as the dead-code
+  sweep when it is the streaming test, etc). `issue-worker` caught the
+  mismatches by reading bodies, not by trusting numbers — robust, but the
+  friction shouldn't be there.
+- **Cross-session state has to be reconstructed every invocation.**
+  Which spike is where, which PR is awaiting review, which template-bootstrap
+  failures are tracked — all rebuilt from human messages each time.
+- **Delegation requires copy-paste.** No in-repo path that says "delegate
+  this to `issue-worker` with this context" — the human ferries prompts
+  between sessions.
+- **Recurring patterns get re-explained.** "Halt without filing duplicates
+  when the post-merge SonarCloud step fails — that's a tracked
+  template-bootstrap gap" must be re-stated each session because there is
+  nothing in the repo that codifies it.
+
+The chat-app fork (Channel) will lean heavily on autonomous workflows.
+Closing the orchestration loop before the fork is `chat-app-ready`
+infrastructure work even though it didn't make the original 34-issue
+planning pass.
+
+## Findings
+
+The friction is fundamentally a **freshness problem**, not a missing-data
+problem. Repo state is rich enough today to drive every sequencing decision
+the external Claude has been making:
+
+- `gh issue list` returns labels, milestone, assignees, and body in one call
+- Open PRs carry `Closes #N` body markers identifying the issue they will
+  close on merge — sufficient to compute "what's in flight"
+- `Blocked by #N` body markers on issues, mirrored in the `status:blocked`
+  label, identify dependency chains
+- The bootstrap-pattern epic (#56) collects template-bootstrap gaps via
+  `Part of #56` body markers on each instance (currently #50, #54, #55) —
+  a durable, auto-detectable halt list
+- `gh run list --branch development` returns post-merge pipeline state
+
+The existing `.autonomous-progress` file (used by `issue-worker` to resume
+interrupted batches) demonstrates that in-repo persistence works at the
+right scale when it is genuinely needed. Orchestration sequencing is not
+that scale — every input is already in `gh`.
+
+## Decision
+
+Add a new `.claude/agents/orchestrator.md` agent that:
+
+- Reads live repo state on every invocation (`gh issue list`, `gh pr list`,
+  `gh run list`) before making any decision. No working from memory.
+- Accepts named, mechanical directives — `status`, `work next <filter>`,
+  `delegate <#N> to <agent>`, `check #N`, `brief #N`, `epic #N` — and
+  resolves them against the live state.
+- Delegates to specialists via the `Agent` tool with the right context
+  pre-assembled. Never implements work itself, never files issues
+  directly, never modifies other agents' definitions.
+- Halts cleanly on directive ambiguity, unresolved `Blocked by`, the
+  bootstrap-pattern halt list (auto-detected via `Part of #56` body
+  markers), a red post-merge pipeline, or any work that would require
+  changing CLAUDE.md product decisions.
+- Reports a structured cross-session state snapshot (in flight / merged /
+  blocked / next pick / halts) on every invocation so any human picking up
+  the loop has the same view the previous session had.
+
+**State mechanism: live queries only, no persistent store.** The friction
+this agent solves is the staleness of memory-derived state; introducing a
+new persistence layer would replicate the same failure mode in a new place.
+Repo state is the source of truth, `gh` is fast, and the existing
+`.autonomous-progress` pattern shows that in-repo persistence is acceptable
+when (and only when) live queries cannot answer the question — which is
+not the case here.
+
+**Tool envelope: read-and-delegate only.** `Bash, Read, Glob, Grep, Agent,
+AskUserQuestion`. No `Edit`, no `Write`. The agent cannot modify code,
+cannot file issues directly, and cannot rewrite other agents — this is
+enforced by the tool list, not by convention alone.
+
+**`work next <filter>` proposes, does not auto-fire.** It picks an issue,
+prints the prompt that would go to `issue-worker`, and halts for human
+confirmation. Auto-delegation is deferred until the picker is trusted in
+practice. Consistent with the current "review the prompt before pasting"
+pattern in the chat-app-ready loop.
+
+## Alternatives considered
+
+**(a) Session log file committed each invocation
+(`.claude/orchestrator-log.md` or similar).** Rejected. Records what the
+last session saw, not what is true now. Drift risk: the file says "PR #N is
+awaiting review" but the PR has merged and the issue has closed. Every
+multi-step orchestration becomes a question of "log or live?" — the agent
+ends up doing the live query anyway and the log becomes redundant
+overhead. Partial-write hazards on a crashed session add a recovery surface
+this template doesn't need.
+
+**(b) Hive MCP memory (the user's personal MCP memory server).** Rejected.
+Hive is per-user, not per-project. Coupling the template's orchestration
+loop to a specific user's MCP server would mean adopters either provision
+their own Hive (overhead) or run a degraded loop (worse). The template
+ships agents; agents should not depend on per-user infrastructure that
+isn't in the repo. Staleness risk persists regardless.
+
+**(c) No persistent state, live queries only.** Chosen. Source of truth is
+repo state. Every invocation pays a sub-second `gh` query and gets a fresh
+view. No drift, no merge conflicts, no per-user dependency. This frames
+orchestration as a pure function of repo state plus the directive — exactly
+the property the friction observations are asking for.
+
+## Consequences
+
+- **Orchestrator becomes the canonical entry point for autonomous loops.**
+  Future autonomous work — `chat-app-ready` finishing, the chat-app fork's
+  release cadence, periodic security/docs sweeps — should be initiated
+  through the orchestrator rather than directly invoking `issue-worker` or
+  the other specialists. Direct invocation remains supported; orchestrator
+  is additive.
+
+- **Explicit non-overlap with `issue-worker`.** Orchestrator picks and
+  hands off; `issue-worker` drives the implement → PR → CI → review
+  cycle. The mental model is "orchestrator is the conductor, issue-worker
+  is the player." Their tool envelopes reflect this: orchestrator cannot
+  edit code; issue-worker cannot delegate to other agents through the
+  orchestrator (it can call `code-reviewer` directly per its existing
+  protocol).
+
+- **Bootstrap-pattern halts use a durable marker, not a hardcoded list.**
+  The halt list is computed each invocation by querying for open issues
+  with `Part of #56` in their body. New bootstrap-pattern instances filed
+  in future automatically join the halt list when their body cites the
+  epic. This sidesteps the drift mode where a hardcoded list goes stale as
+  the epic evolves, and matches how the chat-app-ready milestone has been
+  using `Part of #N` markers throughout.
+
+- **`status:design-needed` on issue #59 is satisfied by this ADR.**
+  Normally `design-review` posts a decisions comment and flips the label
+  before implementation. For this issue, the design is captured here — in
+  ADR-0005 — and the implementation lands in the same PR. Design-review's
+  decisions comment + label flip handoff is intentionally bypassed for
+  cross-cutting agent infrastructure where the design rationale belongs in
+  an ADR rather than an issue comment.
+
+- **The PR is not `agent-safe`.** Agent definitions are load-bearing
+  infrastructure for autonomous workflows. Even though the change is
+  docs-only, an LLM-only review is insufficient — a regression in
+  orchestrator's halt conditions could let the autonomous loop pile merges
+  onto a broken pipeline or skip past a tracked bootstrap gap. Human
+  review is required for this and any future change to the orchestrator
+  definition.
+
+- **Future work — teach `issue-worker` about the bootstrap-pattern halt
+  list.** `issue-worker`'s post-merge pipeline-watch (step 8) currently
+  emits `HUMAN_INPUT_REQUIRED: development pipeline failed` on a SonarCloud
+  or AWS-deploy failure without recognising these as tracked under
+  epic #56. Orchestrator recognises them; teaching `issue-worker` to do
+  the same would let it self-halt rather than escalate. Out of scope for
+  this ADR — file as a follow-up issue when the friction surfaces in
+  practice.
+
+- **Future work — standardise an inter-agent halt-sentinel format.** The
+  existing agents emit `HUMAN_INPUT_REQUIRED:` strings inconsistently
+  (some always, some never). A uniform structured sentinel —
+  `HALT: <category> | <reason> | <evidence>` — would let orchestrator
+  consume specialist outputs programmatically and chain agent calls more
+  cleanly. Out of scope for this ADR — capture as a follow-up if
+  orchestrator-driven chaining becomes a primary use case.
+
+- **CLAUDE.md gets one new line in the agent ecosystem section.**
+  Registration only; no rule changes. Orchestrator does not modify any
+  product decision, label rule, milestone rule, or PR workflow already
+  documented in CLAUDE.md.
+
+- **No production code changes.** Like ADR-0004, this ADR is paired with
+  documentation deliverables only. Behaviour changes manifest only when a
+  human invokes the new agent.

--- a/docs/adr/0005-orchestrator-agent.md
+++ b/docs/adr/0005-orchestrator-agent.md
@@ -4,13 +4,13 @@ Status: Accepted
 
 ## Context
 
-This template ships eight specialist agents under `.claude/agents/`:
-`issue-worker`, `design-review`, `backlog-manager`, `code-reviewer`,
-`docs-sync`, `security-auditor`, `incident-responder`, and `onboarding`.
-Each owns a tightly-scoped workflow. None owns the layer above them — the
-sequencing of in-flight work, the resolution of human directives against
-live state, the cross-session continuity that lets autonomous loops actually
-loop.
+Prior to this ADR, this template shipped eight specialist agents under
+`.claude/agents/`: `issue-worker`, `design-review`, `backlog-manager`,
+`code-reviewer`, `docs-sync`, `security-auditor`, `incident-responder`,
+and `onboarding`. Each owned a tightly-scoped workflow. None owned the
+layer above them — the sequencing of in-flight work, the resolution of
+human directives against live state, the cross-session continuity that
+lets autonomous loops actually loop.
 
 That orchestration role has been performed by an external Claude session
 (`chat.anthropic.com`) during the `chat-app-ready` milestone push. It works,
@@ -54,10 +54,12 @@ the external Claude has been making:
   a durable, auto-detectable halt list
 - `gh run list --branch development` returns post-merge pipeline state
 
-The existing `.autonomous-progress` file (used by `issue-worker` to resume
-interrupted batches) demonstrates that in-repo persistence works at the
-right scale when it is genuinely needed. Orchestration sequencing is not
-that scale — every input is already in `gh`.
+The `.autonomous-progress` convention used by `issue-worker` to resume
+interrupted batches (a runtime-written file at the repo root, not
+committed — see `.claude/agents/issue-worker.md`) demonstrates that
+in-repo persistence works at the right scale when it is genuinely
+needed. Orchestration sequencing is not that scale — every input is
+already in `gh`.
 
 ## Decision
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,3 +29,4 @@ What are the trade-offs, follow-on work, or constraints this decision creates?
 | [0002](0002-streaming-lambda-web-adapter.md) | Streaming via AWS Lambda Web Adapter | Accepted |
 | [0003](0003-inline-agent-and-session-memory.md) | Inline Agent and session memory conventions | Accepted |
 | [0004](0004-agentcore-runtime-feasibility.md) | AWS Bedrock AgentCore Runtime + Memory feasibility for chat-app fork | Accepted |
+| [0005](0005-orchestrator-agent.md) | Orchestrator agent for cross-session sequencing and delegation | Accepted |


### PR DESCRIPTION
Closes #59

## Summary

Adds a new `orchestrator` agent at `.claude/agents/orchestrator.md` plus the design ADR at `docs/adr/0005-orchestrator-agent.md`, and registers the agent in CLAUDE.md's Agent workflows section. No other agents touched, no production code changes.

The repo had 8 specialist agents but no orchestrator — nothing whose job is to look across in-flight work, sequence delegation, hold cross-session state, and tie multi-step workflows together. That role had been performed by an external Claude session with observable friction (issue numbers crossed in prompts, cross-session state reconstructed from human messages each invocation, copy-paste delegation, recurring patterns re-explained). This PR closes that loop in-repo before the chat-app fork starts leaning on autonomous workflows.

## Approach

**State mechanism: live `gh` queries only, no persistent store.** The friction this agent solves is the staleness of memory-derived state; introducing a new persistence layer would replicate the same failure mode. ADR-0005 §Alternatives covers the two rejected alternatives (committed session log file, Hive MCP memory) and why live queries win.

**Tool envelope: read-and-delegate only** — `Bash, Read, Glob, Grep, Agent, AskUserQuestion`. No `Edit`, no `Write`. The agent cannot file issues directly, cannot modify code, and cannot rewrite other agents — enforced by the tool list, not just convention.

**Six invocation modes:** `status`, `brief #N`, `check #N`, `work next <filter>`, `delegate #N to <agent>`, `epic #N`. Each is mechanical and named; ambiguous directives halt with `AskUserQuestion` rather than being guessed at.

**`work next <filter>` proposes, does not auto-fire.** It picks an issue, prints the prompt that would go to `issue-worker`, and halts mechanically — no hedge phrases, no closing sentence inviting further action. Auto-delegation is deferred until the picker is trusted in practice.

**Halt list is auto-detected.** Bootstrap-pattern halts use the durable `Part of #56` body marker on each instance, not a hardcoded list. New instances filed under epic #56 join automatically.

## Future work captured in ADR-0005 §Consequences (not filed as issues yet)

- Teach `issue-worker` about the bootstrap-pattern halt list — currently it escalates `HUMAN_INPUT_REQUIRED` on a SonarCloud or AWS-deploy failure without recognising these as tracked under epic #56
- Standardise an inter-agent halt-sentinel format (`HALT: <category> | <reason> | <evidence>`) so orchestrator can consume specialist outputs programmatically

Both surface naturally when the friction shows up; filing prematurely would waste backlog signal.

## Why not `agent-safe`

Agent definitions are load-bearing infrastructure for autonomous workflows. A regression in orchestrator's halt conditions could let the autonomous loop pile merges onto a broken pipeline or skip past a tracked bootstrap gap. Human review is required even though the change is docs-only.

## Validation

- `uv run inv pre-push` — green (120 Python tests, 355 frontend tests across 28 files)
- `gh issue view 59` — issue exists and matches scope
- `Part of #56` body markers verified on all three current bootstrap-pattern instances (#50, #54, #55) so the auto-detection mechanism works on day one

## Notes

- Branched off `origin/development`
- `status:design-needed` on #59 is satisfied by ADR-0005 rather than a `design-review` decisions comment — this bypass is captured explicitly in ADR §Consequences
- Will not invoke orchestrator in any session until this PR merges; first real invocation comes after merge