### PR TITLE
feat: skills system foundation (ADR-0006 + agent discovery wiring)

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -18,6 +18,29 @@ gh pr diff <PR>               # full diff
 
 ---
 
+## Skill discovery
+
+Before running the checklist, scan `.claude/skills/` for skills whose triggers match this PR's diff. See ADR-0006 for the full skill contract; the scan logic below is this agent's implementation of it.
+
+```bash
+ls .claude/skills/*/SKILL.md 2>/dev/null
+```
+
+For each `SKILL.md` found, read its frontmatter and decide whether to load it. **Hybrid OR-match** — load the skill if **either** condition holds:
+
+- **Path match** — any glob in `triggers.paths` matches any file in the PR's `gh pr diff <PR> --name-only` output
+- **Area match** — any value in `triggers.areas` is one of the labels on the issue this PR closes (resolve via the `Closes #N` line in the PR body)
+
+If the PR doesn't close an issue, match `triggers.areas` against labels on the PR itself; if neither the PR nor a closed issue has labels, only path-based matching applies.
+
+Loading a skill means reading the full body of `SKILL.md` into your working context. Treat the body as an additional convention checklist source alongside the numbered checks below — if a loaded skill documents a convention that the diff violates, raise it as `FAIL` or `WARN` per the same severity rules used for CLAUDE.md conventions. Default severity for skill-documented violations is `WARN`. `FAIL` is reserved for skill-documented conventions explicitly marked as load-bearing or security-critical in the skill body.
+
+`status: stub` skills load the same way, but their `## Gaps` section identifies coverage the skill explicitly does **not** provide. Don't raise findings against gaps — they're known absences, not violations.
+
+The match is permissive on purpose. If no skills match, proceed to the checklist; the project-wide checks below still run on every PR regardless of skill coverage.
+
+---
+
 ## Checklist
 
 Run every check below. For each finding emit one of:

--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -65,6 +65,25 @@ gh pr list --search "issue-<number>" --state open      # must be empty
 
 If closed or already has an open PR, skip it and move to the next. If ambiguous, make a reasonable interpretation, document it in the PR description, and proceed.
 
+### 1.5. Scan and load matching skills
+
+Before branching, scan `.claude/skills/` for skills whose triggers match the current issue. See ADR-0006 for the full skill contract; the scan logic below is the agent's implementation of it.
+
+```bash
+ls .claude/skills/*/SKILL.md 2>/dev/null
+```
+
+For each `SKILL.md` found, read its frontmatter and decide whether to load it. **Hybrid OR-match** — load the skill if **either** condition holds:
+
+- **Path match** — any glob in `triggers.paths` matches a file path predicted to be touched by this issue (predict from the issue body's "Files to touch" section, the area labels, and the title)
+- **Area match** — any value in `triggers.areas` is one of the issue's labels
+
+Loading a skill means reading the full body of `SKILL.md` into your working context for the rest of this issue cycle. Treat the body as implementation guidance alongside CLAUDE.md.
+
+`status: stub` skills load the same way, but read the `## Gaps` section first — the gaps tell you what the skill does **not** cover. Don't assume coverage you've been explicitly told is missing.
+
+If no skills match, proceed to step 2. Borderline matches should err toward loading; the load-on-demand cost is small.
+
 ### 2. Branch
 
 Always branch off `origin/development`, never off another feature branch:

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,88 @@
+# Skills
+
+Task-shaped reference material that agents load on demand when an
+issue's context matches a skill's declared triggers. Skills capture
+domain knowledge an agent would otherwise re-derive (badly) on
+every relevant invocation. Skills *inform*; agents *do*.
+
+The format and discovery contract are settled in
+[ADR-0006](../../docs/adr/0006-skills-system.md). Read the ADR
+before adding or modifying a skill.
+
+## Layout
+
+```text
+.claude/skills/
+├── README.md                    # this file
+└── <skill-name>/
+    ├── SKILL.md                 # entrypoint with required frontmatter
+    └── <supporting-files>       # examples, fixtures, optional
+```
+
+One directory per skill. The `SKILL.md` entrypoint is the only
+file agents read during discovery; supporting files are linked
+from the body when needed.
+
+## Required frontmatter
+
+Every `SKILL.md` MUST declare:
+
+```yaml
+---
+name: <skill-name>           # matches directory name; kebab-case
+description: <one-line>      # surfaced when an agent considers loading
+status: full | stub          # honest signal of coverage
+triggers:
+  paths:                     # glob list; may be empty []
+    - "<glob>"
+  areas:                     # area-label list; may be empty []
+    - "<area>"
+---
+```
+
+At least one trigger entry must exist across `paths` and `areas`
+combined. A skill with no triggers can never load and is invalid.
+
+Skills MUST NOT add `load: always` or any other field that
+bypasses match-time loading — load-on-demand is what keeps the
+context-window budget tractable.
+
+## Discovery
+
+Consuming agents (`issue-worker`, `code-reviewer`) scan all
+`SKILL.md` files at a defined lifecycle point and load any whose
+triggers match the current issue. Match is **hybrid OR**: a skill
+loads if its path globs intersect the diff (or predicted diff) OR
+its areas intersect the issue's labels. See ADR-0006 §Discovery
+for the full rules.
+
+## When to add a new skill
+
+Soft rule:
+
+- Friction noticed twice → file an issue
+- Friction noticed three times → write the skill
+
+If the content benefits *every* issue (not just a particular
+shape), it belongs in `CLAUDE.md`, not in a skill.
+
+## Stubs
+
+A skill MAY ship as `status: stub` when its surface depends on
+in-flight work. Stubs participate fully in discovery but their
+body MUST contain a `## Gaps` section. Each gap entry MUST use
+this structure:
+
+````markdown
+### <gap title>
+
+- **What's missing:** <one line>
+- **Why deferred:** <one line>
+- **Unblocks when:** #<issue> [optional brief context]
+````
+
+Without this prescribed format, stubs degrade into
+wishful-thinking documents. With it, stubs are honest
+scaffolding pointing at real follow-up work. See
+[ADR-0006 §Stub skill convention](../../docs/adr/0006-skills-system.md)
+for the full rules.

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,8 @@ infra/cdk.out/
 .env
 .env.*
 
-# Claude Code — ignore personal settings/memory but track shared agent definitions
+# Claude Code — ignore personal settings/memory but track shared agent definitions and skills
 .claude/*
 !.claude/agents
+!.claude/skills
 .autonomous-progress

--- a/docs/adr/0006-skills-system.md
+++ b/docs/adr/0006-skills-system.md
@@ -1,0 +1,301 @@
+# ADR-0006: Skills system for agent-loaded reference material
+Date: 2026-04-25  
+Status: Accepted
+
+## Context
+
+Two pieces of project knowledge already live alongside the agents
+under `.claude/`:
+
+- **CLAUDE.md** — always-on conventions every agent invocation needs
+  (label taxonomy, copyright headers, PR workflow, product decisions).
+  ~574 lines, ~23K characters, loaded into every conversation.
+- **`.claude/agents/*.md`** — agent definitions describing *how* a
+  specialist works (lifecycle, tool envelope, halt conditions).
+
+A third category has surfaced repeatedly during the autonomous
+issue cycle and is currently re-derived by the model on every
+relevant invocation: **task-shaped reference material** — the
+recipe for adding a FastAPI route, the single-table key pattern
+for a new DynamoDB item type, the convention for writing an
+ADR. This material is not always-on (the next issue may touch a
+React component, not a route) and is not agent-behaviour (any
+agent benefits — `issue-worker`, `code-reviewer`, future
+specialists). Adding it to CLAUDE.md would bloat every
+conversation with content most invocations do not need.
+
+The autonomous loop has crossed the threshold where this
+re-derivation friction is observable rather than hypothetical
+(see #62 rationale). Six skills are already filed for the first
+wave (#64–#67, #69, #72) plus stubs for surfaces that depend on
+in-flight work (#48 partition, AgentCore Runtime integration).
+
+This ADR settles the format and discovery contract before any
+skill is written, so subsequent skill PRs inherit the pattern
+cheaply and the autonomous agent can trust it.
+
+## Decision
+
+Adopt a **load-on-demand, frontmatter-routed** skills system
+rooted at `.claude/skills/`. Each skill is a single directory
+containing a `SKILL.md` entrypoint with a prescriptive YAML
+frontmatter schema. Agents scan skill frontmatter at a defined
+lifecycle point, match against the current issue context, and
+inline matching skill bodies into their working context. Skill
+content is never always-on.
+
+### Skill file layout
+
+- One directory per skill: `.claude/skills/<skill-name>/`
+- Entrypoint: `<skill-name>/SKILL.md` — required, agents only
+  read this file during discovery
+- Supporting files (examples, fixtures) may live alongside in
+  the same directory; the skill body links to them as needed
+- Skill name in the directory matches the `name:` field in
+  frontmatter
+
+### Frontmatter schema (prescriptive, mechanically checkable)
+
+Every `SKILL.md` MUST declare these fields:
+
+```yaml
+---
+name: <skill-name>           # matches directory name; kebab-case
+description: <one-line>      # surfaced when an agent considers loading
+status: full | stub          # honest signal of coverage; stubs have ## Gaps
+triggers:
+  paths:                     # glob list; may be empty []
+    - "<glob>"
+  areas:                     # area-label list; may be empty []
+    - "<area>"
+---
+```
+
+`triggers.paths` and `triggers.areas` may each be empty, but at
+least one trigger entry must exist across the two — a skill that
+declares no triggers can never load and is invalid.
+
+The schema is closed. Skills MUST NOT add a `load: always` field
+or any other mechanism that bypasses match-time loading — the
+context-window budget only works if every skill obeys the
+load-on-demand rule.
+
+### Discovery trigger — hybrid OR-semantics
+
+An agent loads a skill when **any** of:
+
+- The current issue's diff (or predicted diff scope, when the
+  diff does not yet exist) intersects any glob in
+  `triggers.paths`
+- The current issue carries any label listed in
+  `triggers.areas`
+
+OR-semantics is permissive on purpose. False-positive cost is
+~5KB of extra context for one un-needed skill; false-negative
+cost is "the skill exists but never loads when it should." The
+former is recoverable per-invocation; the latter degrades the
+system silently.
+
+When the diff does not yet exist (e.g. `issue-worker` running
+before implementation), match `triggers.paths` against the
+issue body's "Files to touch" section, augmented by area labels
+and title heuristics. The prediction is best-effort;
+load-on-demand cost of false positives is small enough that
+aggressive matching is preferred to under-coverage.
+
+Match logic lives **in the skill's frontmatter**, not in the
+agent files. Routing rules are decentralized so a contributor
+reading `<skill-name>/SKILL.md` sees both what the skill teaches
+and when it applies. Centralizing match logic in
+`issue-worker.md` / `code-reviewer.md` would scatter the
+contract across files and force two-place edits whenever a
+skill's scope changes.
+
+### Loading mechanism — eager-load at match time
+
+Sequence executed by each consuming agent:
+
+1. Glob `.claude/skills/*/SKILL.md`
+2. Parse each skill's frontmatter
+3. Compute matches against current issue context (diff or
+   predicted scope + labels)
+4. Read the body of every matched skill into working context
+   before the agent's primary task begins
+5. The agent's primary task (implementation, review) runs with
+   skills inlined alongside CLAUDE.md
+
+One pass, deterministic, no LLM-driven retrieval. The pass
+costs one glob and N small reads — negligible relative to the
+issue cycle.
+
+### Relationship to CLAUDE.md
+
+The line is **frequency of applicability**:
+
+- **CLAUDE.md** — content that benefits every issue (label
+  taxonomy, copyright headers, PR workflow, product decisions)
+- **Skills** — content that benefits a specific kind of issue
+  (FastAPI route recipe, DynamoDB single-table key pattern,
+  ADR writing convention)
+
+When in doubt: if removing the content would degrade *every*
+agent invocation, it belongs in CLAUDE.md; if it would only
+degrade invocations of a particular shape, it belongs in a
+skill. CLAUDE.md does not shrink as part of this ADR — but new
+conventions filed after this lands should default to the
+skill side of the line and only graduate to CLAUDE.md if the
+"every issue" test holds.
+
+### Threshold for adding a new skill
+
+Soft rule, document in the skills README:
+
+- Friction noticed twice → file an issue under the skills epic
+  (or its successor)
+- Friction noticed three times → write the skill
+
+Stricter enforcement (counting mechanism, automated detection)
+would calcify too early. The soft rule matches how product
+decisions emerged in CLAUDE.md.
+
+### Stub skill convention
+
+A skill MAY ship as `status: stub` when its surface depends on
+in-flight work that is not yet ready (e.g. `cdk-construct`
+needs partition #48; `bedrock-agent` needs Runtime integration).
+Stubs participate fully in discovery — same frontmatter, same
+triggers — but their body MUST contain a `## Gaps` section.
+
+Each gap entry MUST use this structure:
+
+````markdown
+### <gap title>
+
+- **What's missing:** <one line>
+- **Why deferred:** <one line>
+- **Unblocks when:** #<issue> [optional brief context]
+````
+
+Without this prescribed format, stubs degrade into
+wishful-thinking documents that pretend coverage they do not
+have. With it, stubs are honest scaffolding that points the
+autonomous agent at real follow-up work, and the format is
+mechanically checkable by the future `skill-format-validator`
+CI job.
+
+### Agent integration — identical scan, role-specific consumption
+
+`issue-worker` and `code-reviewer` run the same match step
+against the same frontmatter schema. Divergence is in *how*
+the loaded body is consumed:
+
+- `issue-worker` reads matched skills as **implementation
+  guidance** during step §1.5 (between Understand and Branch),
+  using the issue body to predict diff scope
+- `code-reviewer` reads matched skills as a **convention
+  checklist source** in a new `## Skill discovery` section
+  between `## Invocation` and `## Checklist`, matching against
+  the actual diff (more precise than `issue-worker`'s
+  prediction since the diff exists)
+
+Single source of truth for skill format; no per-agent skill
+subset. Future agents that consume skills (e.g. `docs-sync`)
+inherit the same scan logic when their lifecycle warrants it.
+
+### Context-window discipline
+
+Always-on loading is the wrong default. CLAUDE.md is already
+~23K characters in every conversation; six skills at ~150
+lines each would compound that to ~5K extra lines per
+invocation regardless of relevance. Match-time scanning costs
+one glob per agent invocation (~50ms). The wrong default is
+permanent; the cheap scan is per-call. Load-on-demand is
+locked, and the frontmatter schema's prohibition of
+`load: always` enforces the discipline mechanically.
+
+## Alternatives considered
+
+**(a) Single flat `.claude/skills/<skill-name>.md` (no
+directory).** Tighter today, but forces a rename and
+restructure as soon as the first skill needs supporting
+material (example code, fixture data). Directory-per-skill
+costs nothing extra now and avoids the future churn.
+
+**(b) Always-on skills inlined into CLAUDE.md or a
+sibling.** Rejected. Every always-loaded skill compounds
+context cost across all conversations regardless of
+relevance, and CLAUDE.md is already substantial. The whole
+point of the system is that task-shaped reference material
+does not belong in always-on memory.
+
+**(c) Centralized routing in agent files (agent declares
+which skills apply to which work).** Rejected. Scatters the
+"when does this skill apply" contract across two agent
+files; doubles the edit cost when a skill's scope changes;
+hides the trigger from a contributor reading the skill
+directly. Skill-side routing keeps each skill
+self-contained and inspectable.
+
+**(d) AND-semantics for triggers (skill must match both
+path and area).** Rejected. Too many real cases match one
+side only — a chore issue touching API code carries `dx`
+not `api`; a label-only issue may not yet have a diff.
+False-negative cost (skill silently doesn't load) is worse
+than false-positive cost (one extra ~5KB skill in context).
+
+## Consequences
+
+- **Skills become the default home for new task-shaped
+  reference material.** New conventions filed after this ADR
+  default to a skill; CLAUDE.md additions need to clear the
+  "every issue benefits" bar. The product-decisions section
+  of CLAUDE.md remains the canonical home for durable
+  architectural decisions, not skills.
+
+- **Six skill issues become unblocked.** #64–#67, #69, #72
+  all carry `Blocked by #63`. Once this lands they enter the
+  ready queue. #69 and #72 land as stubs per the contract
+  above; #64–#67 land as `status: full`.
+
+- **Agent-file changes ship in this PR, not later.** Adding
+  the scan step retroactively after skills exist would mean
+  a window in which skills are written but not consumed.
+  Bundling the foundation prevents that drift.
+
+- **The `Skill` tool is not the loading mechanism.** Claude
+  Code's runtime `Skill` tool surfaces skills via the CLI
+  harness; this template's discovery runs inside subagents
+  via file reads. The two systems do not share runtime —
+  this ADR's contract governs only the in-repo
+  `.claude/skills/` directory consumed by this template's
+  agent definitions.
+
+- **PR is not `agent-safe`.** Touches `.claude/agents/*.md`
+  which control autonomous-agent behaviour. Same human-review
+  policy as ADR-0005's orchestrator definition. An LLM-only
+  review is insufficient because a regression in the scan
+  step (e.g. matching too aggressively) would silently bloat
+  every issue cycle's context.
+
+- **Future work — `skill-format-validator` CI check.** A
+  CI job that validates every `SKILL.md` against the
+  frontmatter schema, rejects skills declaring always-on
+  loading, and verifies stubs have a non-empty `## Gaps`
+  section meeting the three-line contract. Trivial to write
+  once the schema is locked, and prevents drift as the
+  catalogue grows. Out of scope for this PR — file when the
+  first wave of full skills lands and the schema has
+  survived contact with real authors. Same shape as
+  ADR-0005's "teach issue-worker about the bootstrap halt
+  list" follow-up.
+
+- **Future work — `docs-sync` skill consumption.** When
+  `docs-sync` next runs against changed agent or
+  documentation surfaces, teach it the same scan step. Out
+  of scope here; the bottleneck is `issue-worker` and
+  `code-reviewer` first.
+
+- **No production code changes.** Like ADR-0004 and
+  ADR-0005, this ADR ships docs + agent-definition updates
+  only. Behaviour changes manifest the next time an agent
+  runs against an issue whose triggers match a written skill.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,4 @@ What are the trade-offs, follow-on work, or constraints this decision creates?
 | [0003](0003-inline-agent-and-session-memory.md) | Inline Agent and session memory conventions | Accepted |
 | [0004](0004-agentcore-runtime-feasibility.md) | AWS Bedrock AgentCore Runtime + Memory feasibility for chat-app fork | Accepted |
 | [0005](0005-orchestrator-agent.md) | Orchestrator agent for cross-session sequencing and delegation | Accepted |
+| [0006](0006-skills-system.md) | Skills system for agent-loaded reference material | Accepted |


### PR DESCRIPTION
Closes #63

## Summary

Settles the format and discovery contract for `.claude/skills/` so the
six follow-up skill issues (#64–#67, #69, #72) inherit the pattern
cheaply rather than each re-litigating it.

## What's in this PR

- **ADR-0006** (`docs/adr/0006-skills-system.md`) — locks load-on-demand
  routing, prescriptive YAML frontmatter schema, hybrid OR-semantics
  for triggers, three-line `## Gaps` format for stubs, and the
  skill/CLAUDE.md boundary on frequency-of-applicability. Routing
  lives in skill frontmatter, not in agent files (decentralized,
  self-contained).
- **`issue-worker` §1.5** — new "Scan and load matching skills" step
  between Understand and Branch. Predicts diff scope from the issue
  body's "Files to touch" + area labels + title.
- **`code-reviewer` `## Skill discovery`** — new section between
  Invocation and Checklist. Matches against the actual diff (more
  precise than `issue-worker`'s prediction). Default severity for
  skill-documented violations is `WARN`; `FAIL` reserved for
  load-bearing or security-critical conventions.
- **`.claude/skills/README.md`** — directory overview with the
  prescribed `## Gaps` structure; links to ADR-0006.
- **`.gitignore`** — adds `!.claude/skills` exception alongside the
  existing `!.claude/agents` rule (without this, the directory is
  ignored by `.claude/*`).

## What's NOT in this PR

No skills are written here. This is foundation only. Skill content
lands in #64–#67, #69, #72.

## Approach

Bundling ADR + agent wiring in one PR (rather than splitting) puts
the design decisions and their concrete consumption side-by-side —
the ADR's contract is mechanically evident in the agent inserts,
which surfaces under-specification immediately. Same shape as #58
(ADR-0004) and #61 (ADR-0005 + orchestrator).

## Future work captured in ADR Consequences

- `skill-format-validator` CI check — file once first wave of full
  skills lands and the schema has survived contact with real authors
- `docs-sync` skill consumption — apply the same scan logic when
  the bottleneck moves there

## Not agent-safe

Touches `.claude/agents/*.md`. Same human-review policy as ADR-0005's
orchestrator definition — a regression in the scan step would
silently bloat every issue cycle's context.