### PR TITLE
docs: add fastapi-route skill

### DIFF
--- a/.claude/skills/fastapi-route/SKILL.md
+++ b/.claude/skills/fastapi-route/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: fastapi-route
+description: Conventions for adding a new FastAPI endpoint to the management API — file location, router wiring, auth dependency, streaming pattern, test layout, coverage gate.
+status: full
+triggers:
+  paths:
+    - "src/starter/api/**.py"
+  areas:
+    - "api"
+---
+
+# fastapi-route
+
+Adding a FastAPI endpoint to the AgentCore Starter management API
+follows seven conventions. Each is mechanically checkable against
+the existing `src/starter/api/` code; the canonical examples are
+cited inline by file and line range.
+
+## 1. File location
+
+Endpoints live in `src/starter/api/<area>.py` where `<area>`
+matches the issue's area label. The current router files are:
+
+- `src/starter/api/agents.py` — agent invocation endpoints
+- `src/starter/api/csp.py` — CSP violation report receiver
+- `src/starter/api/main.py` — app construction, middleware,
+  `/health`. Do **not** add domain endpoints here; route handlers
+  go in dedicated router files.
+
+A new functional area (e.g. `users`, `admin`) → new file
+`src/starter/api/<area>.py` with its own `APIRouter`. Do not
+extend an existing router with unrelated routes — area-per-file is
+the discoverability contract.
+
+## 2. Router wiring in `main.py`
+
+Every router file is included from `src/starter/api/main.py` with
+`app.include_router(...)`. The current registrations live at
+`src/starter/api/main.py:115-124`:
+
+```python
+# OAuth 2.1 well-known discovery endpoints (unauthenticated)
+app.include_router(oauth_router)
+
+# Management UI auth endpoints (unauthenticated — issues mgmt JWTs)
+app.include_router(mgmt_auth_router)
+
+# CSP report receiver — unauthenticated by design
+app.include_router(csp_router, prefix="/api")
+
+# Agent scaffold endpoints (require management JWT)
+app.include_router(agents_router, prefix="/api")
+```
+
+Conventions:
+
+- Authenticated domain routers carry `prefix="/api"`.
+- Auth and OAuth discovery routers do **not** carry `/api`
+  (they expose well-known paths).
+- Add a one-line comment above each `include_router` call stating
+  the auth posture (unauthenticated / requires mgmt JWT / etc.).
+- Import the router as `<area>_router` (alias on import) to keep
+  the registration block readable.
+
+## 3. Auth dependency pattern
+
+Two auth dependencies are exported from
+`src/starter/api/_auth.py`:
+
+- `require_mgmt_user` (`src/starter/api/_auth.py:16-29`) — validate
+  a management JWT issued by the Google OAuth login flow. Returns
+  the JWT claims dict. Use for any endpoint hit by the management
+  UI or by an authenticated user agent.
+- `require_admin` (`src/starter/api/_auth.py:32-38`) — composes
+  `require_mgmt_user` and additionally requires `role == "admin"`.
+  Use for admin-only endpoints (user management, dashboard).
+
+Wire either one through `Depends(...)`:
+
+```python
+from typing import Any
+from fastapi import Depends
+from starter.api._auth import require_mgmt_user
+
+@router.post("/agents/echo")
+def echo(
+    body: EchoRequest,
+    _claims: dict[str, Any] = Depends(require_mgmt_user),
+) -> EchoResponse:
+    ...
+```
+
+Naming convention: bind the claims to `_claims` (leading
+underscore) when the handler does not consume them, and to
+`claims` when it does — for example `claims["sub"]` for the
+caller's user id. See `src/starter/api/agents.py:31-35` (unused)
+versus `src/starter/api/agents.py:94-98` (consumed).
+
+OAuth 2.1 access-token-protected endpoints (RFC 7591 / MCP-style)
+are not yet wired; this skill will be extended when that surface
+lands. For now: every authenticated endpoint uses
+`require_mgmt_user` or `require_admin`.
+
+## 4. Streaming pattern
+
+Streaming endpoints return
+`StreamingResponse(generator(), media_type="text/event-stream")`.
+The canonical example is
+`src/starter/api/agents.py:54-75`:
+
+```python
+@router.post("/agents/echo/stream")
+def echo_stream(
+    body: EchoRequest,
+    _claims: dict[str, Any] = Depends(require_mgmt_user),
+) -> StreamingResponse:
+    def _stream() -> Iterator[str]:
+        yield from converse_stream(
+            ConverseRequest(
+                messages=[BedrockMessage(role="user", content=body.message)],
+                system=body.system,
+            )
+        )
+
+    return StreamingResponse(_stream(), media_type="text/event-stream")
+```
+
+The SSE event schema is fixed by ADR-0002 §Decision #4:
+
+- `data: {"type": "delta", "text": "..."}` — incremental token
+- `data: {"type": "done", ...}` — final event with
+  metadata (`stop_reason`, token counts, `session_id`, etc.)
+
+Each event terminates with `\n\n`. The downstream generator
+function (e.g. `converse_stream` in
+`src/starter/agents/bedrock.py:54-93`) is responsible for emitting
+the wire-format strings. The route handler's only job is to
+delegate to that generator and wrap it in `StreamingResponse`.
+
+Lambda streaming caveat: in production the function runs behind
+AWS Lambda Web Adapter with `AWS_LWA_INVOKE_MODE=response_stream`
+(see ADR-0002). CloudFront may buffer SSE; for low-latency
+streaming clients should connect to the Function URL directly.
+
+## 5. Test structure
+
+Every new endpoint requires unit tests. Tests live alongside the
+existing suites under `tests/unit/test_<area>_api.py`. The
+canonical pattern is in `tests/unit/test_agents_api.py`:
+
+- Construct a `TestClient(app)` once at module scope.
+- Set `STARTER_JWT_SECRET` via `os.environ.setdefault` *before*
+  importing the app, so JWT issuance/validation works.
+- Provide an `_auth_headers()` helper that issues a real
+  management JWT via `issue_mgmt_jwt(...)` — do not mock the auth
+  dependency itself; mock the AWS boundary (`boto3` clients,
+  `converse`, `invoke`) instead.
+- Cover, at minimum:
+  1. **Auth required** — call without headers, assert 401 or 403.
+  2. **Happy path** — patch the AWS boundary, assert response
+     body shape and forwarded fields.
+  3. **Argument forwarding** — capture the call to the mocked
+     boundary and assert the request payload was constructed
+     correctly (system prompt, session id, user id from claims).
+
+For streaming endpoints add two more:
+
+- **Content type** — assert
+  `"text/event-stream" in resp.headers["content-type"]`.
+- **Event sequence** — split the response body on `\n\n`, parse
+  each `data: ` payload as JSON, assert the schema (`type` field
+  is `delta` then `done`).
+
+If the endpoint reads or writes DynamoDB, add an integration test
+under `tests/integration/test_<area>_api.py` that exercises the
+real DynamoDB Local instance via the existing `conftest.py`
+fixtures.
+
+## 6. 100% coverage gate
+
+CI fails below 100% line coverage. Two pitfalls recur in API
+code:
+
+- **Anonymous functions inside `StreamingResponse`** — vitest-style
+  v8 counters do not apply on the Python side, but the inner
+  `_stream` closure does need at least one test that drives it to
+  completion (see
+  `tests/unit/test_agents_api.py:91-116` for the pattern).
+- **Untested error branches** — every `raise HTTPException(...)`
+  needs a test that triggers it, even for trivial validation
+  paths. If a branch is genuinely unreachable, mark the line with
+  `# pragma: no cover` and a one-line comment explaining why; do
+  not lower the gate.
+
+Run the gate locally before opening a PR:
+
+```bash
+uv run inv pre-push
+```
+
+This runs lint + typecheck + unit tests + frontend tests with the
+same coverage threshold CI enforces.
+
+## 7. Copyright header
+
+Every new Python file starts with the copyright header from
+CLAUDE.md §Copyright headers:
+
+```python
+# Copyright (c) 2026 John Carter. All rights reserved.
+```
+
+When editing an existing file in a new calendar year, append the
+year to the existing line — do not duplicate the header.
+
+The `scripts/check_copyright.py` linter runs in `inv pre-push`
+and CI; a missing or malformed header fails the build.
+
+## See also
+
+- [`example.py`](./example.py) — a complete copy-pasteable
+  endpoint module covering all seven conventions.
+- ADR-0002 §Decision #4 — SSE event schema authority
+  (`docs/adr/0002-streaming-lambda-web-adapter.md`).
+- CLAUDE.md §Auth — auth posture across the codebase.
+- CLAUDE.md §Testing — coverage gate, fixture conventions.

--- a/.claude/skills/fastapi-route/example.py
+++ b/.claude/skills/fastapi-route/example.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Reference example for the ``fastapi-route`` skill.
+
+This file is documentation, not application code — it lives under
+``.claude/skills/`` and is not imported by the running app or tests.
+Copy it into ``src/starter/api/<area>.py`` and adapt the names when
+adding a real endpoint.
+
+Mirrors every convention captured in ``SKILL.md``:
+
+1. File location — ``src/starter/api/<area>.py``
+2. Router wiring — registered from ``main.py`` with ``prefix="/api"``
+3. Auth dependency — ``Depends(require_mgmt_user)``
+4. Streaming pattern — ``StreamingResponse`` with the ADR-0002 event schema
+5. Test structure — companion ``tests/unit/test_<area>_api.py``
+6. Coverage gate — every branch has a corresponding test (see comments)
+7. Copyright header — the line above
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+
+from starter.api._auth import require_mgmt_user
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class WidgetCreateRequest(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class WidgetResponse(BaseModel):
+    id: str
+    name: str
+    owner_id: str
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming endpoint
+# ---------------------------------------------------------------------------
+
+
+@router.post("/widgets", response_model=WidgetResponse)
+def create_widget(
+    body: WidgetCreateRequest,
+    claims: dict[str, Any] = Depends(require_mgmt_user),
+) -> WidgetResponse:
+    """Create a widget owned by the authenticated user.
+
+    The handler shows the canonical shape: validate the body via the Pydantic
+    model, pull the caller's identity from ``claims["sub"]``, delegate to a
+    storage / domain function (omitted here), and return the typed response
+    model so FastAPI generates an accurate OpenAPI schema.
+    """
+    if not body.name.strip():
+        # Test triggers this branch with an empty-name payload — see
+        # ``test_create_widget_rejects_blank_name`` in the companion test file.
+        raise HTTPException(status_code=400, detail="name must not be blank")
+
+    # Replace this with a real call into ``starter.storage`` or wherever the
+    # widget is persisted.
+    widget_id = f"w-{body.name.lower().replace(' ', '-')}"
+    return WidgetResponse(id=widget_id, name=body.name, owner_id=claims["sub"])
+
+
+# ---------------------------------------------------------------------------
+# Streaming endpoint (SSE per ADR-0002 §Decision #4)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/widgets/stream")
+def stream_widgets(
+    _claims: dict[str, Any] = Depends(require_mgmt_user),
+) -> StreamingResponse:
+    """Stream widget events back to the caller as SSE.
+
+    Two event types per ADR-0002:
+
+    * ``{"type": "delta", "text": "..."}`` — incremental payload
+    * ``{"type": "done", ...}``           — final event with metadata
+
+    The route handler stays thin: it delegates to a generator that knows the
+    domain and wraps the result in ``StreamingResponse`` with the
+    ``text/event-stream`` media type. The downstream generator owns the wire
+    format; the handler does not build SSE strings itself.
+    """
+
+    def _stream() -> Iterator[str]:
+        # Real code yields from a domain helper (e.g. ``converse_stream`` in
+        # ``starter.agents.bedrock``). Inline two yields here so the example
+        # is self-contained.
+        yield f"data: {json.dumps({'type': 'delta', 'text': 'first'})}\n\n"
+        yield f"data: {json.dumps({'type': 'done', 'count': 1})}\n\n"
+
+    return StreamingResponse(_stream(), media_type="text/event-stream")
+
+
+# ---------------------------------------------------------------------------
+# Wiring (lives in src/starter/api/main.py, shown here for completeness)
+# ---------------------------------------------------------------------------
+#
+# from starter.api.widgets import router as widgets_router
+#
+# # Widget endpoints (require management JWT)
+# app.include_router(widgets_router, prefix="/api")
+#
+# ---------------------------------------------------------------------------
+# Companion tests live at tests/unit/test_widgets_api.py and cover:
+#   - test_create_widget_requires_auth        (no token → 401/403)
+#   - test_create_widget_returns_widget       (happy path, mocked storage)
+#   - test_create_widget_rejects_blank_name   (HTTPException branch)
+#   - test_stream_widgets_returns_event_stream_content_type
+#   - test_stream_widgets_yields_delta_then_done
+# See SKILL.md §5 for the full test pattern and §6 for the coverage gate.
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #64

## Summary

First skill written under the ADR-0006 contract. Adds
`.claude/skills/fastapi-route/` with a `SKILL.md` entrypoint plus a
copy-pasteable `example.py` reference module. The skill captures the
seven conventions every new API endpoint follows:

1. File location — `src/starter/api/<area>.py`
2. Router wiring in `src/starter/api/main.py:115-124`
3. Auth dependency (`require_mgmt_user` /
   `require_admin` from `src/starter/api/_auth.py:16-38`)
4. Streaming pattern — `StreamingResponse` per ADR-0002 §Decision #4
   (`src/starter/api/agents.py:54-75`)
5. Test structure — `tests/unit/test_<area>_api.py` mocked at the
   AWS boundary (`tests/unit/test_agents_api.py:91-116`)
6. 100% coverage gate
7. Copyright header

## Approach

- Frontmatter declares `paths: ["src/starter/api/**.py"]` and
  `areas: ["api"]`, matching the hybrid OR-discovery in
  `issue-worker.md` §1.5. Verified line-by-line against the
  agent definition before finalising.
- Every section is grounded in a real file + line range in
  `src/starter/api/`, not an abstract placeholder. Citations
  re-read post-write to confirm correctness.
- Issue body mentions `require_oauth_token` as a possible auth
  dependency — that surface does not yet exist in the codebase
  (only `require_mgmt_user` and `require_admin` are exported from
  `_auth.py`). The skill notes the OAuth-token surface as a
  future extension rather than fabricating an API. Documented
  here per the §1 ambiguity-resolution rule.
- `example.py` is documentation, not application code — it lives
  under `.claude/skills/` and is never imported. Carries the
  copyright header per project convention; not subject to the
  application coverage gate.
- Local Copilot pre-review (`copilot -p "/review"`) returned no
  actionable findings.
- `uv run inv pre-push` passes (lint, typecheck, unit tests,
  frontend tests, copyright check).
- Local e2e not run — doc-only change, no application code or
  routes touched.

Validation of the discovery flow happens organically the next
time `issue-worker` picks up an `api`-area issue.