### PR TITLE
docs: add cdk-construct skill stub

### DIFF
--- a/.claude/skills/cdk-construct/SKILL.md
+++ b/.claude/skills/cdk-construct/SKILL.md
@@ -9,15 +9,15 @@ triggers:
   areas:
     - "infra"
 ---
-> STUB — full skill blocked by #48 (infra partition); follow-up #68.
+> STUB — full skill blocked by #48 (infra partition); follow-up #68
 
 # cdk-construct
 
 Skill scope: CDK construct conventions for the AgentCore Starter
 stack — props pattern, cross-construct value exposure, IAM scoping,
 and CDK Nag suppression placement. The conventions are not yet
-stable; the partition work in #48 (`Partition
-infra/stacks/starter_stack.py into 6-7 constructs`) is what
+stable; the partition work in #48 (which splits
+`infra/stacks/starter_stack.py` into 6-7 constructs) is what
 stabilises them.
 
 Until #48 lands, all infra lives in a single

--- a/.claude/skills/cdk-construct/SKILL.md
+++ b/.claude/skills/cdk-construct/SKILL.md
@@ -49,38 +49,21 @@ forward into the partitioned shape:
 
 ### Props convention not settled
 
-- **What's missing:** Whether constructs accept typed `**kwargs`,
-  a `@dataclass` props object, or a TypedDict — and the naming
-  convention for the props type.
-- **Why deferred:** The partition PR is what picks the shape;
-  picking it here would pre-commit a decision that belongs to
-  the partition design.
-- **Unblocks when:** #48 lands the first partitioned constructs
-  and establishes the props shape used across them.
+- **What's missing:** Whether constructs accept typed `**kwargs`, a `@dataclass` props object, or a TypedDict — and the naming convention for the props type.
+- **Why deferred:** The partition PR is what picks the shape; picking it here would pre-commit a decision that belongs to the partition design.
+- **Unblocks when:** #48 lands the first partitioned constructs and establishes the props shape used across them.
 
 ### Public-attribute pattern for cross-construct exposure
 
-- **What's missing:** The exact convention for how one construct
-  exposes a value (table ARN, function URL, role) to another —
-  attribute on the construct instance, accessor method, or
-  re-exposed via stack-level outputs.
-- **Why deferred:** The pattern only emerges once two or more
-  constructs need to consume each other's outputs at the
-  composer level.
-- **Unblocks when:** #48 wires the first cross-construct
-  consumer and establishes the lookup shape.
+- **What's missing:** The exact convention for how one construct exposes a value (table ARN, function URL, role) to another — attribute on the construct instance, accessor method, or re-exposed via stack-level outputs.
+- **Why deferred:** The pattern only emerges once two or more constructs need to consume each other's outputs at the composer level.
+- **Unblocks when:** #48 wires the first cross-construct consumer and establishes the lookup shape.
 
 ### Construct-level vs composer-level helpers
 
-- **What's missing:** Whether helpers like `Edge.compress: bool`
-  and `Secrets.validate_no_placeholders()` belong on the
-  construct that owns the resource or on the composer that
-  assembles them.
-- **Why deferred:** The boundary depends on whether the helper
-  is a per-resource invariant (construct) or a stack-wide
-  validation (composer); the partition PR is what draws the line.
-- **Unblocks when:** #48 places the first such helpers and the
-  construct-vs-composer boundary becomes visible.
+- **What's missing:** Whether helpers like `Edge.compress: bool` and `Secrets.validate_no_placeholders()` belong on the construct that owns the resource or on the composer that assembles them.
+- **Why deferred:** The boundary depends on whether the helper is a per-resource invariant (construct) or a stack-wide validation (composer); the partition PR is what draws the line.
+- **Unblocks when:** #48 places the first such helpers and the construct-vs-composer boundary becomes visible.
 
 ## Follow-up
 

--- a/.claude/skills/cdk-construct/SKILL.md
+++ b/.claude/skills/cdk-construct/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: cdk-construct
+description: Conventions for authoring CDK constructs in the AgentCore Starter stack — placeholder stub until the partition work in #48 settles props, public-attribute, and CDK Nag suppression patterns.
+status: stub
+triggers:
+  paths:
+    - "infra/stacks/**.py"
+    - "infra/app.py"
+  areas:
+    - "infra"
+---
+
+# cdk-construct
+
+> STUB — full skill blocked by #48 (infra partition); follow-up #68.
+
+Skill scope: CDK construct conventions for the AgentCore Starter
+stack — props pattern, cross-construct value exposure, IAM scoping,
+and CDK Nag suppression placement. The conventions are not yet
+stable; the partition work in #48 (`Partition
+infra/stacks/starter_stack.py into 6-7 constructs`) is what
+stabilises them.
+
+Until #48 lands, all infra lives in a single 1,498-line
+`AgentCoreStarterStack` class at
+`infra/stacks/starter_stack.py` — the current shape reference for
+how resources are wired, IAM grants are scoped, and CDK Nag
+suppressions are attached. New infra work should follow the
+existing patterns in that file rather than inventing a partitioned
+shape ahead of #48.
+
+## What we know now (intent only)
+
+These three conventions are settled in principle and will carry
+forward into the partitioned shape:
+
+- **Each construct owns its own IAM scope.** Cross-construct
+  grants happen at the composer (stack) level, not inside the
+  construct that needs the grant. A construct never reaches into
+  another construct's resource to attach a policy.
+- **Constructs expose typed values to one another.** The exact
+  shape of the props pattern (typed kwargs vs dataclass) is part
+  of what #48 settles.
+- **CDK Nag suppressions live with the construct that owns the
+  suppressed resource** — per the #48 acceptance criterion. A
+  suppression on a Lambda role lives in the construct that
+  defines that Lambda, not in the composer.
+
+## Gaps
+
+### Props convention not settled
+
+- **What's missing:** Whether constructs accept typed `**kwargs`,
+  a `@dataclass` props object, or a TypedDict — and the naming
+  convention for the props type.
+- **Why deferred:** The partition PR is what picks the shape;
+  picking it here would pre-commit a decision that belongs to
+  the partition design.
+- **Unblocks when:** #48 lands the first partitioned constructs
+  and establishes the props shape used across them.
+
+### Public-attribute pattern for cross-construct exposure
+
+- **What's missing:** The exact convention for how one construct
+  exposes a value (table ARN, function URL, role) to another —
+  attribute on the construct instance, accessor method, or
+  re-exposed via stack-level outputs.
+- **Why deferred:** The pattern only emerges once two or more
+  constructs need to consume each other's outputs at the
+  composer level.
+- **Unblocks when:** #48 wires the first cross-construct
+  consumer and establishes the lookup shape.
+
+### Construct-level vs composer-level helpers
+
+- **What's missing:** Whether helpers like `Edge.compress: bool`
+  and `Secrets.validate_no_placeholders()` belong on the
+  construct that owns the resource or on the composer that
+  assembles them.
+- **Why deferred:** The boundary depends on whether the helper
+  is a per-resource invariant (construct) or a stack-wide
+  validation (composer); the partition PR is what draws the line.
+- **Unblocks when:** #48 places the first such helpers and the
+  construct-vs-composer boundary becomes visible.
+
+## Follow-up
+
+Once #48 lands, #68 (`Replace cdk-construct skill stub with full
+skill once #48 lands`) replaces this stub with a full skill
+covering the settled props convention, public-attribute pattern,
+and CDK Nag suppression placement.
+
+## See also
+
+- `infra/stacks/starter_stack.py` — current single-class shape;
+  the reference for how resources, IAM grants, and CDK Nag
+  suppressions are wired today.
+- [ADR-0006](../../../docs/adr/0006-skills-system.md)
+  §"Stub skill convention" — the schema contract this stub
+  follows.
+- #48 — the partition work that stabilises CDK construct
+  conventions in this repo.
+- #68 — the follow-up that replaces this stub with a full skill.

--- a/.claude/skills/cdk-construct/SKILL.md
+++ b/.claude/skills/cdk-construct/SKILL.md
@@ -10,9 +10,9 @@ triggers:
     - "infra"
 ---
 
-# cdk-construct
-
 > STUB — full skill blocked by #48 (infra partition); follow-up #68.
+
+# cdk-construct
 
 Skill scope: CDK construct conventions for the AgentCore Starter
 stack — props pattern, cross-construct value exposure, IAM scoping,
@@ -21,7 +21,7 @@ stable; the partition work in #48 (`Partition
 infra/stacks/starter_stack.py into 6-7 constructs`) is what
 stabilises them.
 
-Until #48 lands, all infra lives in a single 1,498-line
+Until #48 lands, all infra lives in a single
 `AgentCoreStarterStack` class at
 `infra/stacks/starter_stack.py` — the current shape reference for
 how resources are wired, IAM grants are scoped, and CDK Nag

--- a/.claude/skills/cdk-construct/SKILL.md
+++ b/.claude/skills/cdk-construct/SKILL.md
@@ -61,7 +61,7 @@ forward into the partitioned shape:
 
 ### Construct-level vs composer-level helpers
 
-- **What's missing:** Whether helpers like `Edge.compress: bool` and `Secrets.validate_no_placeholders()` belong on the construct that owns the resource or on the composer that assembles them.
+- **What's missing:** Whether per-resource invariant helpers belong on the construct that owns the resource or on the composer that assembles them — for instance, an `Edge` construct *might* expose a `compress: bool` parameter, or a `Secrets` construct *might* expose a `validate_no_placeholders()` method, but the actual APIs will be decided in #48.
 - **Why deferred:** The boundary depends on whether the helper is a per-resource invariant (construct) or a stack-wide validation (composer); the partition PR is what draws the line.
 - **Unblocks when:** #48 places the first such helpers and the construct-vs-composer boundary becomes visible.
 

--- a/.claude/skills/cdk-construct/SKILL.md
+++ b/.claude/skills/cdk-construct/SKILL.md
@@ -67,10 +67,9 @@ forward into the partitioned shape:
 
 ## Follow-up
 
-Once #48 lands, #68 (`Replace cdk-construct skill stub with full
-skill once #48 lands`) replaces this stub with a full skill
-covering the settled props convention, public-attribute pattern,
-and CDK Nag suppression placement.
+Once #48 lands, #68 (which replaces this stub with a full skill)
+takes over — covering the settled props convention,
+public-attribute pattern, and CDK Nag suppression placement.
 
 ## See also
 

--- a/.claude/skills/cdk-construct/SKILL.md
+++ b/.claude/skills/cdk-construct/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cdk-construct
-description: Conventions for authoring CDK constructs in the AgentCore Starter stack — placeholder stub until the partition work in #48 settles props, public-attribute, and CDK Nag suppression patterns.
+description: "Conventions for authoring CDK constructs in the AgentCore Starter stack — placeholder stub until the partition work in #48 settles props, public-attribute, and CDK Nag suppression patterns."
 status: stub
 triggers:
   paths:
@@ -9,7 +9,6 @@ triggers:
   areas:
     - "infra"
 ---
-
 > STUB — full skill blocked by #48 (infra partition); follow-up #68.
 
 # cdk-construct


### PR DESCRIPTION
Closes #69

## Summary

Ships a `status: stub` skill at `.claude/skills/cdk-construct/SKILL.md`
covering CDK construct conventions. The full surface depends on the
in-flight partition work in #48; the stub participates fully in
discovery (paths + areas triggers populated) and surfaces concrete
deferred items via a `## Gaps` section so the autonomous agent isn't
blind to construct authoring while #48 is in flight.

## Approach

- **Frontmatter mirrors the four prior skills exactly.** Same shape as
  `fastapi-route`, `dynamodb-item`, `react-component`, `adr-write`;
  the only differences are `status: stub` and the trigger globs.
- **Triggers per orchestrator brief:** `paths: ["infra/stacks/**.py",
  "infra/app.py"]` and `areas: ["infra"]`. Both populated; the issue
  body suggested `infra/**.py` but the orchestrator brief was the
  more precise instruction and `infra` is in the CLAUDE.md taxonomy.
- **Gaps section follows ADR-0006 §"Stub skill convention"** —
  three concrete entries (props convention, public-attribute
  pattern, construct-vs-composer helper boundary), each with the
  required `What's missing` / `Why deferred` / `Unblocks when`
  fields. Biased toward fewer, sharper entries over a long
  checklist.
- **Body length kept short** — stubs are scaffolding, not pretend
  coverage. Names the three intent-only conventions that are
  settled in principle (per-construct IAM scope, typed value
  exposure, suppressions live with the construct that owns the
  resource) and points at `infra/stacks/starter_stack.py` as the
  current shape reference.
- **STUB header on the first body line** after frontmatter, per
  the issue acceptance criterion.
- **Cross-link to #68** present in `## Follow-up` and `## See also`.

## Scope

Doc-only change. Touches only `.claude/skills/cdk-construct/SKILL.md`
(no example file — content is deferred to the full-skill follow-up
in #68). No code, infra, agent-file, or CLAUDE.md changes.

## Modified cycle note

Per the orchestrator brief, this is the first stub skill landing
under ADR-0006 — its shape becomes precedent for #72 and any future
stub. The orchestrator wants to review the body before merge, so
auto-merge is **not** enabled on this PR. The PR will sit at the
"CI green + Copilot converged" halt point awaiting human merge
approval.