### PR TITLE
chore: add bedrock-agent skill stub (#72)

### DIFF
--- a/.claude/skills/bedrock-agent/SKILL.md
+++ b/.claude/skills/bedrock-agent/SKILL.md
@@ -35,14 +35,16 @@ Runtime-shaped scaffolding ahead of the integration.
 These three points are settled by ADR-0004 and will carry forward
 into the full skill:
 
-- **Sidecar architecture is locked** (ADR-0004 §Decision 1 /
-  Option A). Runtime ships as a separate container; the FastAPI
+- **Sidecar architecture is locked** (ADR-0004 §"Decision A —
+  Runtime vs inline-agent" / migration Option A). Runtime ships
+  as a separate container; the FastAPI
   Lambda stays in the request path and calls
   `bedrock-agentcore.invoke_agent_runtime` from new
   `/api/chat/*` routes. Inline-agent on `/api/agents/*` is
   preserved for the template's pedagogical role (ADR-0003 remains
   in force).
-- **Memory and DynamoDB coexist** (ADR-0004 §Decision 2). Memory
+- **Memory and DynamoDB coexist** (ADR-0004 §"Decision B —
+  Memory vs DynamoDB"). Memory
   is not a transcript store — it handles LLM-extracted semantic
   recall (facts, summaries, preferences) and is invoked as a
   tool via `RetrieveMemoryRecords`. The raw turn-by-turn
@@ -77,7 +79,7 @@ integration work (#70) and is captured under §Gaps below.
 ### Inline-agent vs Runtime decision tree
 
 - **What's missing:** The concrete decision tree for when an agent endpoint should target inline-agent versus Runtime — including the streaming-protocol differences (Bedrock event stream `for event in response["completion"]:` vs HTTP/SSE `for line in response["response"].iter_lines():` per ADR-0004 §Findings #2) and the IAM-scope differences (`bedrock:InvokeInlineAgent` per ADR-0003 vs `bedrock-agentcore:InvokeAgentRuntime` per ADR-0004 §Findings #4).
-- **Why deferred:** ADR-0004 §Decision 1 assigns inline-agent to the template and Runtime to the chat-app fork, but the per-endpoint decision tree only becomes observable once both paths coexist in a realised fork.
+- **Why deferred:** ADR-0004 §"Decision A — Runtime vs inline-agent" assigns inline-agent to the template and Runtime to the chat-app fork, but the per-endpoint decision tree only becomes observable once both paths coexist in a realised fork.
 - **Unblocks when:** #70 ships both code paths in the chat-app fork; #71 codifies the decision tree against the realised integration.
 
 ### Memory strategy weighting and namespace template strings

--- a/.claude/skills/bedrock-agent/SKILL.md
+++ b/.claude/skills/bedrock-agent/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: bedrock-agent
+description: "Conventions for AgentCore Runtime + Memory integration on top of the inline-agent wrapper at src/starter/agents/inline_agent.py — placeholder stub until the chat-app fork's Runtime integration lands in #70 and is codified into a full skill in #71."
+status: stub
+triggers:
+  paths:
+    - "src/starter/agents/**.py"
+  areas:
+    - "api"
+---
+> STUB — Runtime + Memory conventions blocked by #70; follow-up #71
+
+# bedrock-agent
+
+Skill scope: agent-endpoint authoring conventions for the AgentCore
+Starter — specifically the AgentCore Runtime + Memory integration
+that ADR-0004 settles for the chat-app fork. The Runtime-side
+surface is not stable yet; the integration work in #70 is what
+produces the conventions this skill will codify in full once #71
+lands.
+
+The current shape on `main` is the inline-agent wrapper at
+`src/starter/agents/inline_agent.py` (per ADR-0003), which the
+template keeps unchanged. ADR-0004 §Decision A commits the
+chat-app fork to the **sidecar** pattern: a separate ARM64 Runtime
+container alongside the existing FastAPI Lambda, with both code
+paths coexisting (`/api/agents/*` inline-agent, pedagogical;
+`/api/chat/*` Runtime). New agent work in this repo before #70
+lands should follow the existing inline-agent pattern in
+`src/starter/agents/inline_agent.py` rather than inventing
+Runtime-shaped scaffolding ahead of the integration.
+
+## What we know now (intent only)
+
+These three points are settled by ADR-0004 and will carry forward
+into the full skill:
+
+- **Sidecar architecture is locked** (ADR-0004 §Decision 1 /
+  Option A). Runtime ships as a separate container; the FastAPI
+  Lambda stays in the request path and calls
+  `bedrock-agentcore.invoke_agent_runtime` from new
+  `/api/chat/*` routes. Inline-agent on `/api/agents/*` is
+  preserved for the template's pedagogical role (ADR-0003 remains
+  in force).
+- **Memory and DynamoDB coexist** (ADR-0004 §Decision 2). Memory
+  is not a transcript store — it handles LLM-extracted semantic
+  recall (facts, summaries, preferences) and is invoked as a
+  tool via `RetrieveMemoryRecords`. The raw turn-by-turn
+  transcript and the immutable audit log stay DynamoDB-backed.
+- **Memory namespace tenancy is encoded inside `actorId`**
+  (ADR-0004 §Findings #6, §Consequences). Namespace templates
+  accept only `{actorId}`, `{sessionId}`, `{strategyId}` —
+  custom variables are not supported. Workspace tenancy
+  therefore lives inside `actorId` as
+  `f"{workspace_id}:{user_id}"`, generalising the existing
+  inline-agent convention from CLAUDE.md §"Product decisions".
+  The encoding format must be locked in #37 before the first
+  Memory write because events are immutable.
+
+Everything else — the Runtime endpoint scaffolding, the
+streaming consumer pattern in production, IAM scoping at the
+construct level, the inline-agent-vs-Runtime decision tree, the
+Memory strategy weighting and namespace template strings, the
+`runtimeUserId` convention — awaits the chat-app fork's
+integration work (#70) and is captured under §Gaps below.
+
+## Gaps
+
+### Runtime endpoint scaffolding
+
+- **What's missing:** Concrete Runtime endpoint shape — the FastAPI route layout for `/api/chat/*`, the boto3 `invoke_agent_runtime` call site, the SSE consumer pattern (`for line in response["response"].iter_lines():` per ADR-0004 §Findings #2), and the `StreamingResponse` plumbing through AWS Lambda Web Adapter.
+- **Why deferred:** Runtime requires bring-your-own ARM64 container scaffolding (ECR build, `bedrock-agentcore-control.create_agent_runtime`, CDK construct); the conventions only stabilise once an actual integration ships.
+- **Unblocks when:** #70 lands the chat-app fork's Runtime integration; #71 then replaces this stub with a full skill drawn from the realised code paths.
+
+### Inline-agent vs Runtime decision tree
+
+- **What's missing:** The concrete decision tree for when an agent endpoint should target inline-agent versus Runtime — including the streaming-protocol differences (Bedrock event stream `for event in response["completion"]:` vs HTTP/SSE `for line in response["response"].iter_lines():` per ADR-0004 §Findings #2) and the IAM-scope differences (`bedrock:InvokeInlineAgent` per ADR-0003 vs `bedrock-agentcore:InvokeAgentRuntime` per ADR-0004 §Findings #4).
+- **Why deferred:** ADR-0004 §Decision 1 assigns inline-agent to the template and Runtime to the chat-app fork, but the per-endpoint decision tree only becomes observable once both paths coexist in a realised fork.
+- **Unblocks when:** #70 ships both code paths in the chat-app fork; #71 codifies the decision tree against the realised integration.
+
+### Memory strategy weighting and namespace template strings
+
+- **What's missing:** Which Memory strategies (`semantic`, `summary`, `userPreference`, `episodic`, `custom`) the chat-app fork uses by default, the per-strategy weighting, and the concrete namespace template strings (e.g. `workspaces/{actorId}/facts`, `workspaces/{actorId}/summaries/{sessionId}`).
+- **Why deferred:** Strategy choice is product-level (which recall behaviours the chat experience needs) and must be decided during chat-app fork planning; ADR-0004 documents the constraints (6 strategies per Memory, only `{actorId}` / `{sessionId}` / `{strategyId}` template variables) but does not pick weights.
+- **Unblocks when:** #70's design pass picks the default strategy set and namespace templates for the fork; #71 codifies them.
+
+### `runtimeUserId` vs JWT `sub` convention
+
+- **What's missing:** Whether `runtimeUserId` (a first-class field on `invoke_agent_runtime` per ADR-0004 §Findings #1) carries the JWT `sub`, the workspace-scoped `actorId` (`f"{workspace_id}:{user_id}"`), or some other encoding — and whether `runtimeSessionId` keeps the inline-agent's `f"{user_id}:{caller_session_id}"` shape per ADR-0003 or drops the user prefix because Memory's `actorId` already provides user scope (ADR-0004 §Consequences hints at the latter).
+- **Why deferred:** The convention only matters once Runtime is actually invoked from a request handler; it depends on whether per-call IAM scoping uses `runtimeUserId` or relies entirely on Memory's `bedrock-agentcore:namespacePath` condition keys.
+- **Unblocks when:** #70 wires the first `invoke_agent_runtime` call site and locks the `runtimeUserId` / `runtimeSessionId` shapes; #71 codifies them alongside the existing inline-agent session-namespacing convention from CLAUDE.md.
+
+### Workspace-ID encoding format for `actorId`
+
+- **What's missing:** The concrete workspace-ID format (UUID, slug, prefixed identifier) and the escaping rules for the `:` separator inside `actorId = f"{workspace_id}:{user_id}"`.
+- **Why deferred:** ADR-0004 §Consequences calls this a hard prerequisite that must be locked in #37 before any Memory write, because events are immutable and namespace records are rebuilt only on full re-extraction. The format is a workspace-primitive concern, not an agent-endpoint concern.
+- **Unblocks when:** #37 locks the workspace-ID encoding; #70 then consumes the locked format on first Memory write; #71 codifies the resulting `actorId` shape into this skill.
+
+## Follow-up
+
+Once #70 lands the chat-app fork's Runtime + Memory integration,
+#71 (which replaces this stub with a full skill) takes over —
+covering the realised endpoint scaffolding, the
+inline-agent-vs-Runtime decision tree, IAM scoping at the
+construct level, the locked `runtimeUserId` / `runtimeSessionId`
+conventions, and the chosen Memory strategy weighting and
+namespace template strings.
+
+## See also
+
+- `src/starter/agents/inline_agent.py` — the current
+  inline-agent wrapper (per ADR-0003); the `invoke` /
+  `invoke_stream` shape and the user-namespaced `sessionId` are
+  the reference today and remain in force for the template's
+  `/api/agents/*` path.
+- `src/starter/api/agents.py` — the FastAPI route handlers that
+  consume the inline-agent wrapper; route-handler conventions
+  (auth dependency, `StreamingResponse`, SSE event schema) live
+  in the `fastapi-route` skill, not here.
+- [ADR-0003](../../../docs/adr/0003-inline-agent-and-session-memory.md)
+  — inline-agent decision and the user-namespaced `sessionId`
+  convention; in force for the template's `/api/agents/*` path.
+- [ADR-0004](../../../docs/adr/0004-agentcore-runtime-feasibility.md)
+  — the architectural source for AgentCore Runtime + Memory in
+  the chat-app fork; the contract this skill graduates against.
+- [ADR-0006](../../../docs/adr/0006-skills-system.md)
+  §"Stub skill convention" — the schema contract this stub
+  follows.
+- CLAUDE.md §"Product decisions" — the user-namespaced
+  `sessionId` rule that Runtime/Memory generalises into the
+  workspace-scoped `actorId` per ADR-0004 §Consequences.
+- #70 — the chat-app fork's Runtime + Memory integration that
+  stabilises the conventions this skill codifies.
+- #71 — the follow-up that replaces this stub with a full skill.
+- #37 — the workspace primitive whose ID encoding must be
+  locked before Memory writes begin (ADR-0004 §Consequences hard
+  prerequisite).

--- a/.claude/skills/bedrock-agent/SKILL.md
+++ b/.claude/skills/bedrock-agent/SKILL.md
@@ -8,7 +8,7 @@ triggers:
   areas:
     - "api"
 ---
-> STUB — Runtime + Memory conventions blocked by #70; follow-up #71
+> STUB — Runtime conventions blocked by #70; follow-up #71
 
 # bedrock-agent
 

--- a/.claude/skills/bedrock-agent/SKILL.md
+++ b/.claude/skills/bedrock-agent/SKILL.md
@@ -49,7 +49,9 @@ into the full skill:
   transcript and the immutable audit log stay DynamoDB-backed.
 - **Memory namespace tenancy is encoded inside `actorId`**
   (ADR-0004 §Findings #6, §Consequences). Namespace templates
-  accept only `{actorId}`, `{sessionId}`, `{strategyId}` —
+  accept only `{actorId}`, `{sessionId}`, and
+  `{strategyId}` / `{memoryStrategyId}` (per ADR-0004
+  §Findings #3 — the two strategy-id forms are aliases) —
   custom variables are not supported. Workspace tenancy
   therefore lives inside `actorId` as
   `f"{workspace_id}:{user_id}"`, generalising the existing
@@ -81,7 +83,7 @@ integration work (#70) and is captured under §Gaps below.
 ### Memory strategy weighting and namespace template strings
 
 - **What's missing:** Which Memory strategies (`semantic`, `summary`, `userPreference`, `episodic`, `custom`) the chat-app fork uses by default, the per-strategy weighting, and the concrete namespace template strings (e.g. `workspaces/{actorId}/facts`, `workspaces/{actorId}/summaries/{sessionId}`).
-- **Why deferred:** Strategy choice is product-level (which recall behaviours the chat experience needs) and must be decided during chat-app fork planning; ADR-0004 documents the constraints (6 strategies per Memory, only `{actorId}` / `{sessionId}` / `{strategyId}` template variables) but does not pick weights.
+- **Why deferred:** Strategy choice is product-level (which recall behaviours the chat experience needs) and must be decided during chat-app fork planning; ADR-0004 documents the constraints (6 strategies per Memory, only `{actorId}` / `{sessionId}` / `{strategyId}` (a.k.a. `{memoryStrategyId}`) template variables) but does not pick weights.
 - **Unblocks when:** #70's design pass picks the default strategy set and namespace templates for the fork; #71 codifies them.
 
 ### `runtimeUserId` vs JWT `sub` convention


### PR DESCRIPTION
Closes #72

## Summary

Adds `.claude/skills/bedrock-agent/SKILL.md` as the sixth and final skill under the ADR-0006 first wave, shipping as `status: stub` per the §"Stub skill convention" since the AgentCore Runtime + Memory integration that codifies the surface (#70) hasn't begun.

## Approach

**Stub-specific precedent**: mirrored `.claude/skills/cdk-construct/SKILL.md` exactly — STUB blockquote on the line after frontmatter, frontmatter description YAML-quoted because it contains `#NNN` references, Gaps entries on single physical source lines (no soft wrap).

**Area-label tally evidence**: surveyed open + closed issues that touched `src/starter/agents/*` or are scoped to that path. Tally: `api` 6 (#17, #42, #33, #71, #72, #70), `dx` 3 (#27, #71, #72), `infra` 1 (#70), `ui` 1 (#38). `api` is the dominant label by a clear margin; the issue body's proposal of `areas: ["api"]` stands.

**"What we know now" decision**: included the section because three architectural points ARE settled by ADR-0004 with confidence — Decision 1/Option A (sidecar architecture), Decision 2 (Memory + DynamoDB coexist, Memory is not a transcript store), and the Memory namespace constraint that forces `actorId = f"{workspace_id}:{user_id}"`. Each entry cites ADR-0004 by section. Everything else is honestly deferred under §Gaps.

**Gaps citation chain**: each Gap entry frames the dependency as `#70 → #71 → this skill` — #70 is the upstream architectural work that produces the conventions, #71 is the direct unblocker that codifies them into a full skill. Five Gaps entries cover Runtime endpoint scaffolding, the inline-agent-vs-Runtime decision tree, Memory strategy weighting and namespace template strings, the `runtimeUserId` vs JWT `sub` convention, and the workspace-ID encoding format that #37 must lock.

**Scope**: only `.claude/skills/bedrock-agent/SKILL.md` was touched. No edits outside that path.

## Local quality gates

- `uv run inv pre-push` — pass (lint + typecheck + unit tests + frontend tests)
- Local Copilot review (`copilot -p /review`) — one WARN finding noted below; no FAIL items
- Local e2e — not run; doc-only change, not required per CLAUDE.md §"When to run local e2e tests"

## Copilot review WARN — deferred

`triggers.paths` only covers `src/starter/agents/**.py`, so edits to `src/starter/api/agents.py` (the route file) without an `api` label would miss this skill. Deferred because (a) the issue body explicitly specifies the path glob, (b) the `areas: ["api"]` trigger already covers the route-file scenario for any well-labelled issue (per ADR-0006's hybrid-OR semantics), and (c) the `fastapi-route` skill already governs route-handler conventions for `src/starter/api/**.py` — keeping path scopes non-overlapping reduces context-window cost on every API issue. If the false-negative case emerges in practice, expanding the path trigger here is a one-line follow-up.