### PR TITLE
feat: mechanical scope-boundary enforcement for agent-safe PRs

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -201,25 +201,14 @@ Note: this confirms a test file *exists* — CI enforces the 100% coverage numbe
 
 ### 12. agent-safe scope boundary
 
-Only runs when the linked issue is labelled `agent-safe`. Per issue #77, an
-`agent-safe` PR's diff must stay inside the issue's stated scope —
-ride-along edits to out-of-scope files (CLAUDE.md, other agent files,
-unrelated code) must not auto-merge. This is the friendly first-line gate;
-`.github/workflows/agent-safe-scope.yml` is the unbypassable CI backstop
-that runs the same check.
+Per issue #77, an `agent-safe` PR's diff must stay inside the linked
+issue's stated scope — ride-along edits to out-of-scope files (CLAUDE.md,
+other agent files, unrelated code) must not auto-merge. This is the
+friendly first-line gate; `.github/workflows/agent-safe-scope.yml` is the
+unbypassable CI backstop that runs the exact same script.
 
-Resolve the linked issue from the PR body's `Closes #N` line, then check
-whether it carries the `agent-safe` label:
-
-```bash
-gh pr view <PR> --json body --jq .body | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'
-gh issue view <ISSUE> --json labels --jq '[.labels[].name]'
-```
-
-If `agent-safe` is **not** on the issue, skip this check (mark `PASS`
-trivially — a non-agent-safe PR is going to a human reviewer anyway).
-
-If `agent-safe` **is** on the issue, run the scope check:
+Run the scope check on every PR — the script handles the agent-safe gate
+itself by resolving the linked issue's labels:
 
 ```bash
 uv run python scripts/check_agent_safe_scope.py --pr <PR>
@@ -227,6 +216,8 @@ uv run python scripts/check_agent_safe_scope.py --pr <PR>
 
 Map the script's verdict directly:
 
+- exit 0 with `verdict: PASS (skipped)` → `PASS` (linked issue is not
+  `agent-safe`; check does not apply)
 - exit 0 with `verdict: PASS` → `PASS`
 - exit 0 with `verdict: WARN` → `WARN` (issue lacks "Files to touch" and
   has no clean area-label mapping; cannot verify mechanically)

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -199,6 +199,50 @@ Note: this confirms a test file *exists* — CI enforces the 100% coverage numbe
 
 ---
 
+### 12. agent-safe scope boundary
+
+Only runs when the linked issue is labelled `agent-safe`. Per issue #77, an
+`agent-safe` PR's diff must stay inside the issue's stated scope —
+ride-along edits to out-of-scope files (CLAUDE.md, other agent files,
+unrelated code) must not auto-merge. This is the friendly first-line gate;
+`.github/workflows/agent-safe-scope.yml` is the unbypassable CI backstop
+that runs the same check.
+
+Resolve the linked issue from the PR body's `Closes #N` line, then check
+whether it carries the `agent-safe` label:
+
+```bash
+gh pr view <PR> --json body --jq .body | grep -oiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'
+gh issue view <ISSUE> --json labels --jq '[.labels[].name]'
+```
+
+If `agent-safe` is **not** on the issue, skip this check (mark `PASS`
+trivially — a non-agent-safe PR is going to a human reviewer anyway).
+
+If `agent-safe` **is** on the issue, run the scope check:
+
+```bash
+uv run python scripts/check_agent_safe_scope.py --pr <PR>
+```
+
+Map the script's verdict directly:
+
+- exit 0 with `verdict: PASS` → `PASS`
+- exit 0 with `verdict: WARN` → `WARN` (issue lacks "Files to touch" and
+  has no clean area-label mapping; cannot verify mechanically)
+- exit 1 with `verdict: FAIL` → `FAIL` — list the out-of-scope files in
+  the finding. Per issue #77 refinements §"Escape-hatch policy", the agent
+  must NOT edit the issue body to retroactively expand scope. Either
+  drop the out-of-scope edits or stop and ask the human to strip the
+  `agent-safe` label.
+
+The script is the single source of truth — both this check and the CI
+workflow call into it via `scripts/check_agent_safe_scope.py`. Unit tests
+covering the parser + comparator live in
+`tests/unit/test_check_agent_safe_scope.py`.
+
+---
+
 ## Output format
 
 After running all checks, emit a structured report:

--- a/.github/workflows/agent-safe-scope.yml
+++ b/.github/workflows/agent-safe-scope.yml
@@ -1,8 +1,8 @@
 name: agent-safe scope check
 
 # Mechanical scope-boundary backstop for `agent-safe` PRs (issue #77).
-# When a PR labelled `agent-safe` ships, its diff must stay inside the linked
-# issue's stated scope. This workflow runs the same check that
+# When a PR's linked issue is labelled `agent-safe`, the PR's diff must stay
+# inside the issue's stated scope. This workflow runs the same check that
 # `code-reviewer` runs pre-merge — the second layer of defence-in-depth so a
 # slipped-through breach (PR #76 scenario) gets blocked at the branch
 # protection layer regardless of whether the agent loop noticed.
@@ -10,12 +10,19 @@ name: agent-safe scope check
 # Trigger types per issue #77 refinements §"Race condition handling":
 #   opened       — fire on PR creation
 #   synchronize  — fire on every push (catches diff drift)
-#   labeled      — fire when `agent-safe` is added mid-PR
-#   unlabeled    — fire when `agent-safe` is removed (job becomes neutral)
-#   edited       — fire when the PR body is edited (linked-issue resolution)
+#   labeled      — fire when labels change on the PR (cheap; lets the
+#                  script re-resolve the linked issue's labels too)
+#   unlabeled    — symmetric with labeled
+#   edited       — fire when the PR body is edited (the body's
+#                  `Closes #N` line is the source of truth for the linked
+#                  issue, so an edit can change the gate's resolution)
 #
-# The job is conditioned on `agent-safe` being present so non-`agent-safe`
-# PRs see a no-op pass.
+# The job runs unconditionally on every PR. The `agent-safe` label lives on
+# the linked **issue** (per CLAUDE.md taxonomy), not on the PR, so a
+# conditional like `contains(...labels.*.name, 'agent-safe')` evaluated
+# against the PR's labels would skip nearly every real agent-safe PR.
+# Instead, the script resolves the linked issue's labels via `gh` and emits
+# a no-op PASS when `agent-safe` is absent.
 #
 # Branch protection: this check must be added to the required-checks list
 # for `development` (and `main`) for the gate to actually block merge —
@@ -34,7 +41,6 @@ jobs:
   scope-check:
     name: Scope check (agent-safe PRs)
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'agent-safe')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 

--- a/.github/workflows/agent-safe-scope.yml
+++ b/.github/workflows/agent-safe-scope.yml
@@ -1,0 +1,53 @@
+name: agent-safe scope check
+
+# Mechanical scope-boundary backstop for `agent-safe` PRs (issue #77).
+# When a PR labelled `agent-safe` ships, its diff must stay inside the linked
+# issue's stated scope. This workflow runs the same check that
+# `code-reviewer` runs pre-merge — the second layer of defence-in-depth so a
+# slipped-through breach (PR #76 scenario) gets blocked at the branch
+# protection layer regardless of whether the agent loop noticed.
+#
+# Trigger types per issue #77 refinements §"Race condition handling":
+#   opened       — fire on PR creation
+#   synchronize  — fire on every push (catches diff drift)
+#   labeled      — fire when `agent-safe` is added mid-PR
+#   unlabeled    — fire when `agent-safe` is removed (job becomes neutral)
+#   edited       — fire when the PR body is edited (linked-issue resolution)
+#
+# The job is conditioned on `agent-safe` being present so non-`agent-safe`
+# PRs see a no-op pass.
+#
+# Branch protection: this check must be added to the required-checks list
+# for `development` (and `main`) for the gate to actually block merge —
+# that's a manual one-time setup step. See PR #77 follow-ups.
+
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled, edited]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  scope-check:
+    name: Scope check (agent-safe PRs)
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'agent-safe')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "latest"
+
+      - name: Run scope check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Use uv run so the script picks up the project's Python version
+          # and stdlib only (the script has no third-party deps).
+          uv run python scripts/check_agent_safe_scope.py --pr "$PR_NUMBER"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -544,6 +544,14 @@ This section defines the taxonomy.
   this label, the agent still runs Copilot review (everyone benefits
   from a second opinion) but then stops for human merge.
 
+  Issues carrying `agent-safe` MUST also include a `## Files to touch`
+  (or `### Files to touch`) section in the body listing the files the
+  PR is allowed to touch. The mechanical scope-boundary check
+  (`scripts/check_agent_safe_scope.py`, run by both `code-reviewer`
+  and the `agent-safe-scope.yml` CI workflow) blocks any PR whose diff
+  strays outside that section. See issue #77 for the design rationale
+  and edge-case handling.
+
 ### Issue creation rules
 
 When filing a new issue:

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -1,0 +1,421 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Mechanical scope-boundary check for `agent-safe` PRs.
+
+Issue #77: when an `agent-safe` PR ships, its diff must stay inside the linked
+issue's stated scope. This module is the single source of truth for that check;
+both `code-reviewer` (pre-merge) and `.github/workflows/agent-safe-scope.yml`
+(CI backstop) call into it.
+
+Verdict levels:
+- PASS   — every changed file matches the issue's "Files to touch" section or
+           a clean area-label glob.
+- WARN   — the issue has neither a "Files to touch" section nor a clean
+           area-label mapping; the gate cannot make a confident judgement and
+           defers (per issue #77 refinements §"Fail-closed → WARN on missing
+           scope info"). Issue-creation-time enforcement should ensure this is
+           rare.
+- FAIL   — the issue has explicit scope info AND the diff strays outside it.
+
+CLI usage:
+    python scripts/check_agent_safe_scope.py --pr 123
+        # fetches PR diff + linked issue via `gh`, prints verdict, exits non-zero
+        # on FAIL.
+
+    python scripts/check_agent_safe_scope.py --issue-body-file body.md \\
+        --issue-labels 'area:ui,priority:p2' --diff-files-file files.txt
+        # offline mode for tests / dry runs.
+
+The check only fires when the PR is labelled `agent-safe`. Callers are
+responsible for that gate; this module does not consult labels other than the
+issue's `area:*` labels (used as a fallback when the issue body lacks a
+"Files to touch" section).
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Literal
+
+# ── Area-label → path-glob map ────────────────────────────────────────────────
+#
+# Per issue #77 refinements §"Area-label fallback specifics", only bounded
+# areas map cleanly to path globs. Meta-areas (dx, security, compliance,
+# marketing, growth, seo, design, ops, reliability, performance,
+# observability, ux, a11y) span the codebase and cannot be path-mapped —
+# their presence triggers a WARN fall-through, not a FAIL.
+
+BOUNDED_AREA_GLOBS: dict[str, list[str]] = {
+    "api": ["src/starter/api/**", "tests/unit/test_api*.py", "tests/unit/test_agents_api.py"],
+    "auth": ["src/starter/auth/**", "tests/unit/test_auth_*.py", "tests/e2e/test_auth_*.py"],
+    "mcp": ["src/starter/mcp/**", "tests/unit/test_mcp_*.py"],
+    "infra": ["infra/**"],
+    "ui": ["ui/**"],
+    "docs": ["docs/**", "docs-site/**", "README.md", "CHANGELOG.md"],
+    "ci": [".github/workflows/**", "scripts/**"],
+    "sdk": ["sdk/**"],
+}
+
+META_AREAS: set[str] = {
+    "dx",
+    "security",
+    "compliance",
+    "marketing",
+    "growth",
+    "seo",
+    "design",
+    "ops",
+    "reliability",
+    "performance",
+    "observability",
+    "ux",
+    "a11y",
+}
+
+
+# Always-allowed paths that are universal artifacts of the PR-creation flow
+# itself (release notes, changelog churn, etc.). Including them here keeps
+# the gate from raising FAIL on housekeeping that every PR is allowed to do.
+UNIVERSAL_ALLOWED: list[str] = [
+    "CHANGELOG.md",
+]
+
+
+Level = Literal["PASS", "WARN", "FAIL"]
+
+
+@dataclass(frozen=True)
+class Verdict:
+    level: Level
+    summary: str
+    out_of_scope: tuple[str, ...] = ()
+    allowed_globs: tuple[str, ...] = ()
+    source: str = ""  # "files-to-touch", "area-labels", or "none"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "level": self.level,
+            "summary": self.summary,
+            "out_of_scope": list(self.out_of_scope),
+            "allowed_globs": list(self.allowed_globs),
+            "source": self.source,
+        }
+
+
+# ── Parser ────────────────────────────────────────────────────────────────────
+
+
+_FILES_TO_TOUCH_HEADING_RE = re.compile(
+    r"^#{2,3}\s+Files to touch\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+_NEXT_HEADING_RE = re.compile(r"^#{1,6}\s+", re.MULTILINE)
+# Accept ` `text` `, ` *text* `, or bare path tokens inside a markdown bullet.
+# We only want the actual path tokens — not the "New:" / "Edit:" prose prefix.
+_BACKTICK_TOKEN_RE = re.compile(r"`([^`]+)`")
+_BULLET_RE = re.compile(r"^\s*[-*+]\s+(.*)$", re.MULTILINE)
+
+
+def parse_files_to_touch(body: str) -> list[str] | None:
+    """
+    Extract the list of allowed paths/globs from an issue body's
+    "Files to touch" section.
+
+    Returns:
+        - A list of path strings (may be empty) if the heading is present.
+        - None if no `## Files to touch` / `### Files to touch` heading is
+          found (caller falls back to area-label mapping).
+    """
+    if not body:
+        return None
+
+    heading_match = _FILES_TO_TOUCH_HEADING_RE.search(body)
+    if not heading_match:
+        return None
+
+    section_start = heading_match.end()
+
+    # Find the next heading of any level after our heading — that bounds the
+    # section. If none, the section runs to end-of-body.
+    next_match = _NEXT_HEADING_RE.search(body, pos=section_start)
+    section_end = next_match.start() if next_match else len(body)
+    section = body[section_start:section_end]
+
+    paths: list[str] = []
+    for bullet in _BULLET_RE.findall(section):
+        # Prefer backtick-quoted tokens (unambiguous path markers).
+        tokens = _BACKTICK_TOKEN_RE.findall(bullet)
+        if tokens:
+            paths.extend(t.strip() for t in tokens if t.strip())
+            continue
+        # Fall back to the bullet text minus a leading "New:" / "Edit:" /
+        # "Modify:" prose prefix. This is best-effort; backticks are the
+        # supported convention.
+        cleaned = re.sub(
+            r"^(New|Edit|Modify|Update|Add):\s*", "", bullet.strip(), flags=re.IGNORECASE
+        )
+        cleaned = cleaned.strip().rstrip(",.;")
+        # Skip purely descriptive bullets that don't look like paths
+        # (heuristic: a path has a `/` or is one of a few known top-level
+        # files like CLAUDE.md / README.md / CHANGELOG.md).
+        looks_like_path = "/" in cleaned or cleaned in {"CLAUDE.md", "README.md", "CHANGELOG.md"}
+        if cleaned and not cleaned.startswith("`") and looks_like_path:
+            paths.append(cleaned)
+
+    return paths
+
+
+# ── Area-label fallback ───────────────────────────────────────────────────────
+
+
+def area_label_paths(labels: list[str]) -> list[str] | None:
+    """
+    Map area:* labels on the issue to their path globs.
+
+    Returns:
+        - A list of globs if every area:* label maps to a bounded area.
+        - None if the issue carries no area labels, or if any area label is a
+          meta-area (per the BOUNDED_AREA_GLOBS / META_AREAS partition).
+          Meta-area presence forces WARN — they cannot be path-mapped.
+    """
+    area_labels = [label.removeprefix("area:") for label in labels if label.startswith("area:")]
+    if not area_labels:
+        return None
+
+    globs: list[str] = []
+    for area in area_labels:
+        if area in META_AREAS:
+            return None
+        if area in BOUNDED_AREA_GLOBS:
+            globs.extend(BOUNDED_AREA_GLOBS[area])
+        else:
+            # Unknown area label — be conservative and treat as meta.
+            return None
+
+    return globs
+
+
+# ── Scope comparator ──────────────────────────────────────────────────────────
+
+
+def _matches_any(path: str, globs: list[str]) -> bool:
+    for glob in globs:
+        # fnmatch doesn't natively understand `**`. Translate `**` to `*` for
+        # an additive match: a glob `src/starter/api/**` should match
+        # `src/starter/api/foo/bar.py`. We achieve that by also matching the
+        # glob with `**` collapsed to `*` — fnmatch treats `*` as "anything
+        # except /" by default? No — in fnmatch `*` matches anything
+        # INCLUDING separators. So `src/starter/api/*` will match
+        # `src/starter/api/foo/bar.py`. Use that.
+        normalised = glob.replace("**", "*")
+        if fnmatch.fnmatch(path, normalised):
+            return True
+        # Also support directory-prefix matches: a glob like `ui/**` should
+        # match `ui` itself if it ever appears.
+        if glob.endswith("/**") and (path == glob[:-3] or path.startswith(glob[:-2])):
+            return True
+    return False
+
+
+def check_scope(diff_files: list[str], allowed_globs: list[str]) -> list[str]:
+    """
+    Return the list of files in `diff_files` that do NOT match any of the
+    `allowed_globs`. Universal-allowed paths are always considered in-scope.
+    """
+    effective = list(allowed_globs) + UNIVERSAL_ALLOWED
+    return [f for f in diff_files if not _matches_any(f, effective)]
+
+
+# ── Top-level evaluator ───────────────────────────────────────────────────────
+
+
+def evaluate(
+    issue_body: str | None,
+    issue_labels: list[str],
+    diff_files: list[str],
+) -> Verdict:
+    """
+    Decide whether the PR's diff stays inside the issue's stated scope.
+
+    Resolution order:
+    1. If the issue body has a "Files to touch" section, use it.
+    2. Else if the issue has bounded area labels (and no meta-areas), use
+       their globs.
+    3. Else WARN — the gate cannot make a confident judgement.
+    """
+    files_to_touch = parse_files_to_touch(issue_body or "")
+
+    if files_to_touch is not None:
+        if not files_to_touch:
+            # Heading present but empty bullet list — treat as WARN; a section
+            # with no entries probably means the author forgot to fill it in.
+            return Verdict(
+                level="WARN",
+                summary=(
+                    'Issue body has "Files to touch" heading but no parseable '
+                    "path entries. Cannot verify scope."
+                ),
+                source="files-to-touch",
+            )
+        out = check_scope(diff_files, files_to_touch)
+        if out:
+            return Verdict(
+                level="FAIL",
+                summary=(
+                    f"PR diff includes {len(out)} file(s) outside the issue's "
+                    '"Files to touch" scope.'
+                ),
+                out_of_scope=tuple(out),
+                allowed_globs=tuple(files_to_touch),
+                source="files-to-touch",
+            )
+        return Verdict(
+            level="PASS",
+            summary='All changed files match the issue\'s "Files to touch" scope.',
+            allowed_globs=tuple(files_to_touch),
+            source="files-to-touch",
+        )
+
+    area_globs = area_label_paths(issue_labels)
+    if area_globs is not None:
+        out = check_scope(diff_files, area_globs)
+        if out:
+            return Verdict(
+                level="FAIL",
+                summary=(f"PR diff includes {len(out)} file(s) outside the area-label path map."),
+                out_of_scope=tuple(out),
+                allowed_globs=tuple(area_globs),
+                source="area-labels",
+            )
+        return Verdict(
+            level="PASS",
+            summary="All changed files match the issue's area-label path map.",
+            allowed_globs=tuple(area_globs),
+            source="area-labels",
+        )
+
+    return Verdict(
+        level="WARN",
+        summary=(
+            'Issue body has no "Files to touch" section and no clean area-label '
+            "mapping (either no area labels, or area labels include a meta-area "
+            "that cannot be path-mapped). Cannot verify scope mechanically."
+        ),
+        source="none",
+    )
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def _gh(args: list[str]) -> str:
+    """Run `gh <args>` and return stdout. Raises on non-zero exit."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _fetch_pr_context(pr: int) -> tuple[str | None, list[str], list[str], int | None]:
+    """
+    Returns (issue_body, issue_labels, diff_files, issue_number).
+    issue_body is None if the PR doesn't link an issue.
+    """
+    pr_json = _gh(["pr", "view", str(pr), "--json", "body,title"])
+    pr_data = json.loads(pr_json)
+    pr_text = (pr_data.get("body") or "") + "\n" + (pr_data.get("title") or "")
+
+    # Find the linked issue via Closes/Fixes/Resolves #N (case-insensitive).
+    issue_match = re.search(
+        r"(?:closes|fixes|resolves)\s+#(\d+)",
+        pr_text,
+        re.IGNORECASE,
+    )
+    issue_body: str | None = None
+    issue_labels: list[str] = []
+    issue_num: int | None = None
+    if issue_match:
+        issue_num = int(issue_match.group(1))
+        issue_json = _gh(["issue", "view", str(issue_num), "--json", "body,labels"])
+        issue_data = json.loads(issue_json)
+        issue_body = issue_data.get("body") or ""
+        issue_labels = [label["name"] for label in issue_data.get("labels", [])]
+
+    diff_text = _gh(["pr", "diff", str(pr), "--name-only"])
+    diff_files = [line.strip() for line in diff_text.splitlines() if line.strip()]
+    return issue_body, issue_labels, diff_files, issue_num
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pr",
+        type=int,
+        help="PR number — fetches body, labels, and diff via `gh`.",
+    )
+    parser.add_argument("--issue-body-file", type=str, help="Offline mode: issue body file.")
+    parser.add_argument(
+        "--issue-labels",
+        type=str,
+        default="",
+        help="Offline mode: comma-separated labels.",
+    )
+    parser.add_argument(
+        "--diff-files-file",
+        type=str,
+        help="Offline mode: file with one changed-file path per line.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human text.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.pr:
+        issue_body, issue_labels, diff_files, issue_num = _fetch_pr_context(args.pr)
+        context_note = (
+            f"PR #{args.pr} (linked issue: #{issue_num})" if issue_num else f"PR #{args.pr}"
+        )
+    else:
+        if not (args.issue_body_file and args.diff_files_file):
+            parser.error("provide --pr OR (--issue-body-file AND --diff-files-file)")
+        with open(args.issue_body_file, encoding="utf-8") as f:
+            issue_body = f.read()
+        with open(args.diff_files_file, encoding="utf-8") as f:
+            diff_files = [line.strip() for line in f if line.strip()]
+        issue_labels = [label.strip() for label in args.issue_labels.split(",") if label.strip()]
+        context_note = "(offline mode)"
+
+    verdict = evaluate(issue_body, issue_labels, diff_files)
+
+    if args.json:
+        print(json.dumps(verdict.to_dict(), indent=2))
+    else:
+        print(f"agent-safe scope check {context_note}")
+        print(f"  source : {verdict.source or 'n/a'}")
+        print(f"  verdict: {verdict.level}")
+        print(f"  summary: {verdict.summary}")
+        if verdict.allowed_globs:
+            print("  allowed scope:")
+            for g in verdict.allowed_globs:
+                print(f"    - {g}")
+        if verdict.out_of_scope:
+            print("  out-of-scope files:")
+            for f in verdict.out_of_scope:
+                print(f"    - {f}")
+
+    return 1 if verdict.level == "FAIL" else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -56,6 +56,12 @@ from typing import Literal
 # marketing, growth, seo, design, ops, reliability, performance,
 # observability, ux, a11y) span the codebase and cannot be path-mapped —
 # their presence triggers a WARN fall-through, not a FAIL.
+#
+# These maps are forward-looking, NOT derived from the live label set.
+# Some entries (e.g. `mcp`, `sdk` in BOUNDED_AREA_GLOBS; most of META_AREAS)
+# are not yet live labels but are pre-mapped so a future label addition
+# doesn't silently fall through to WARN. Defensive — see follow-up issue
+# for ground-truthing the maps against the live taxonomy.
 
 BOUNDED_AREA_GLOBS: dict[str, list[str]] = {
     "api": ["src/starter/api/**", "tests/unit/test_api*.py", "tests/unit/test_agents_api.py"],

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -23,13 +23,19 @@ CLI usage:
         # on FAIL.
 
     python scripts/check_agent_safe_scope.py --issue-body-file body.md \\
-        --issue-labels 'area:ui,priority:p2' --diff-files-file files.txt
+        --issue-labels 'ui,priority:p2,agent-safe' --diff-files-file files.txt
         # offline mode for tests / dry runs.
 
-The check only fires when the PR is labelled `agent-safe`. Callers are
-responsible for that gate; this module does not consult labels other than the
-issue's `area:*` labels (used as a fallback when the issue body lacks a
-"Files to touch" section).
+Gating: the CLI resolves the linked issue's labels and only runs the scope
+comparison when the issue carries `agent-safe`. Non-agent-safe PRs see a
+no-op PASS so the workflow can run unconditionally on every PR (the
+`agent-safe` label lives on the **issue**, not the PR, per CLAUDE.md
+taxonomy — gating the workflow itself on PR labels would skip nearly every
+real agent-safe PR).
+
+The library functions (`evaluate`, `parse_files_to_touch`,
+`area_label_paths`, `check_scope`) do not perform the agent-safe gate
+themselves — they assume the caller has already decided the check applies.
 """
 
 from __future__ import annotations
@@ -161,12 +167,23 @@ def parse_files_to_touch(body: str) -> list[str] | None:
             r"^(New|Edit|Modify|Update|Add):\s*", "", bullet.strip(), flags=re.IGNORECASE
         )
         cleaned = cleaned.strip().rstrip(",.;")
-        # Skip purely descriptive bullets that don't look like paths
-        # (heuristic: a path has a `/` or is one of a few known top-level
-        # files like CLAUDE.md / README.md / CHANGELOG.md).
-        looks_like_path = "/" in cleaned or cleaned in {"CLAUDE.md", "README.md", "CHANGELOG.md"}
-        if cleaned and not cleaned.startswith("`") and looks_like_path:
-            paths.append(cleaned)
+        if not cleaned or cleaned.startswith("`"):
+            continue
+        # Tokenise the bullet on whitespace + common conjunctions/punctuation
+        # so a bullet like `- Edit: src/a.py and src/b.py` produces two paths,
+        # not one mashed-together string. Each token is then accepted only if
+        # it looks like a path (has a `/`) or matches a known top-level file.
+        for raw_token in re.split(r"[\s,]+|\band\b", cleaned):
+            token = raw_token.strip().rstrip(",.;")
+            if not token:
+                continue
+            looks_like_path = "/" in token or token in {
+                "CLAUDE.md",
+                "README.md",
+                "CHANGELOG.md",
+            }
+            if looks_like_path:
+                paths.append(token)
 
     return paths
 
@@ -176,15 +193,32 @@ def parse_files_to_touch(body: str) -> list[str] | None:
 
 def area_label_paths(labels: list[str]) -> list[str] | None:
     """
-    Map area:* labels on the issue to their path globs.
+    Map area labels on the issue to their path globs.
+
+    The repo uses bare area labels (e.g. `ui`, `api`, `auth`) per CLAUDE.md
+    §Backlog labels and milestones — NOT prefixed with `area:`. This function
+    accepts both forms (`ui` and `area:ui`) for forward-compatibility, but
+    the bare form is canonical.
+
+    Identifying which labels are area labels:
+        Anything that matches a key in `BOUNDED_AREA_GLOBS` or `META_AREAS`
+        is considered an area label. Standard non-area labels (priority:*,
+        size:*, status:*, type labels like `enhancement`, special labels
+        like `agent-safe`) are filtered out.
 
     Returns:
-        - A list of globs if every area:* label maps to a bounded area.
+        - A list of globs if every area label maps to a bounded area.
         - None if the issue carries no area labels, or if any area label is a
           meta-area (per the BOUNDED_AREA_GLOBS / META_AREAS partition).
           Meta-area presence forces WARN — they cannot be path-mapped.
     """
-    area_labels = [label.removeprefix("area:") for label in labels if label.startswith("area:")]
+    # Strip optional `area:` prefix; the repo uses bare names but accept both.
+    candidates = [label.removeprefix("area:") for label in labels]
+
+    # Filter to labels that are recognised as areas (bounded or meta). This
+    # naturally drops priority:*, size:*, status:*, agent-safe, enhancement,
+    # bug, etc.
+    area_labels = [c for c in candidates if c in BOUNDED_AREA_GLOBS or c in META_AREAS]
     if not area_labels:
         return None
 
@@ -192,11 +226,8 @@ def area_label_paths(labels: list[str]) -> list[str] | None:
     for area in area_labels:
         if area in META_AREAS:
             return None
-        if area in BOUNDED_AREA_GLOBS:
-            globs.extend(BOUNDED_AREA_GLOBS[area])
-        else:
-            # Unknown area label — be conservative and treat as meta.
-            return None
+        # area is in BOUNDED_AREA_GLOBS by the filter above.
+        globs.extend(BOUNDED_AREA_GLOBS[area])
 
     return globs
 
@@ -395,6 +426,32 @@ def main(argv: list[str] | None = None) -> int:
             diff_files = [line.strip() for line in f if line.strip()]
         issue_labels = [label.strip() for label in args.issue_labels.split(",") if label.strip()]
         context_note = "(offline mode)"
+
+    # Gate: this check only applies when the linked issue carries `agent-safe`.
+    # The label lives on the issue per CLAUDE.md taxonomy; the workflow runs
+    # unconditionally on every PR and lets us decide here so we can resolve
+    # the linked-issue's labels rather than the PR's.
+    if "agent-safe" not in issue_labels:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "level": "PASS",
+                        "summary": "PR's linked issue is not labelled `agent-safe` — scope check skipped.",
+                        "out_of_scope": [],
+                        "allowed_globs": [],
+                        "source": "skip",
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"agent-safe scope check {context_note}")
+            print("  verdict: PASS (skipped)")
+            print(
+                "  reason : linked issue is not labelled `agent-safe` — scope check does not apply."
+            )
+        return 0
 
     verdict = evaluate(issue_body, issue_labels, diff_files)
 

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -63,7 +63,7 @@ BOUNDED_AREA_GLOBS: dict[str, list[str]] = {
     "mcp": ["src/starter/mcp/**", "tests/unit/test_mcp_*.py"],
     "infra": ["infra/**"],
     "ui": ["ui/**"],
-    "docs": ["docs/**", "docs-site/**", "README.md", "CHANGELOG.md"],
+    "documentation": ["docs/**", "docs-site/**", "README.md", "CHANGELOG.md"],
     "ci": [".github/workflows/**", "scripts/**"],
     "sdk": ["sdk/**"],
 }
@@ -284,13 +284,15 @@ def evaluate(
 
     if files_to_touch is not None:
         if not files_to_touch:
-            # Heading present but empty bullet list — treat as WARN; a section
-            # with no entries probably means the author forgot to fill it in.
+            # Heading present but empty bullet list — fail closed. A section
+            # with no entries can't gate a diff; falling back to WARN would
+            # let any diff pass scope-check trivially by leaving the section
+            # blank.
             return Verdict(
-                level="WARN",
+                level="FAIL",
                 summary=(
-                    'Issue body has "Files to touch" heading but no parseable '
-                    "path entries. Cannot verify scope."
+                    '"Files to touch" section present but empty or malformed; '
+                    "refusing to apply soft fallback."
                 ),
                 source="files-to-touch",
             )

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -105,6 +105,29 @@ def test_parse_files_to_touch_bare_path_without_backticks():
     assert "CLAUDE.md" in parsed
 
 
+def test_parse_files_to_touch_bare_paths_multiple_per_bullet():
+    """A single bullet containing multiple unquoted paths must yield each
+    path separately, not one mashed-together string. Real-world example:
+        - Edit: src/a.py and src/b.py
+    Without tokenisation this would parse as one phantom path that never
+    matches any diff entry, causing false FAILs."""
+    body = """## Files to touch
+
+- Edit: src/starter/foo.py and src/starter/bar.py
+- New: docs/a.md, docs/b.md
+
+## Next
+"""
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed is not None
+    assert "src/starter/foo.py" in parsed
+    assert "src/starter/bar.py" in parsed
+    assert "docs/a.md" in parsed
+    assert "docs/b.md" in parsed
+    # No mashed-together token should sneak through.
+    assert all(" " not in p for p in parsed)
+
+
 def test_parse_files_to_touch_skips_descriptive_bullets():
     body = """## Files to touch
 
@@ -131,24 +154,51 @@ def test_parse_files_to_touch_empty_section():
 # ── Area-label fallback tests ─────────────────────────────────────────────────
 
 
-def test_area_label_paths_bounded_area_ui():
-    globs = scope_check.area_label_paths(["area:ui", "priority:p2", "size:s"])
+def test_area_label_paths_bounded_area_ui_bare_label():
+    """Repo uses bare area labels (no `area:` prefix) per CLAUDE.md.
+    Real-world labels look like `ui`, `api`, `auth` — not `area:ui`."""
+    globs = scope_check.area_label_paths(["ui", "priority:p2", "size:s"])
+    assert globs is not None
+    assert any(g.startswith("ui/") for g in globs)
+
+
+def test_area_label_paths_bounded_area_prefixed_form_also_accepted():
+    """Forward-compatibility: `area:ui` form works too."""
+    globs = scope_check.area_label_paths(["area:ui", "priority:p2"])
     assert globs is not None
     assert any(g.startswith("ui/") for g in globs)
 
 
 def test_area_label_paths_meta_area_returns_none():
-    """Case (b) — area:dx is a meta-area, no clean path map → None → WARN."""
-    assert scope_check.area_label_paths(["area:dx", "priority:p2"]) is None
+    """Case (b) — `dx` is a meta-area, no clean path map → None → WARN."""
+    assert scope_check.area_label_paths(["dx", "priority:p2"]) is None
 
 
 def test_area_label_paths_no_area_labels_returns_none():
     assert scope_check.area_label_paths(["priority:p1", "size:m"]) is None
 
 
+def test_area_label_paths_filters_out_non_area_labels():
+    """Standard non-area labels (status, type, agent-safe) are filtered out
+    before the area check runs. Real issues carry many such labels."""
+    globs = scope_check.area_label_paths(
+        [
+            "ui",
+            "agent-safe",
+            "enhancement",
+            "documentation",
+            "status:ready",
+            "priority:p2",
+            "size:s",
+        ]
+    )
+    assert globs is not None
+    assert any(g.startswith("ui/") for g in globs)
+
+
 def test_area_label_paths_multiple_bounded_areas_combine():
     """Case (e) — multiple area labels combine into a union of globs."""
-    globs = scope_check.area_label_paths(["area:api", "area:auth"])
+    globs = scope_check.area_label_paths(["api", "auth"])
     assert globs is not None
     assert any(g.startswith("src/starter/api/") for g in globs)
     assert any(g.startswith("src/starter/auth/") for g in globs)
@@ -157,12 +207,13 @@ def test_area_label_paths_multiple_bounded_areas_combine():
 def test_area_label_paths_meta_in_mix_disables_fallback():
     """If any area label is a meta-area, fall through to WARN — partial
     bounded-area coverage isn't reliable enough."""
-    assert scope_check.area_label_paths(["area:ui", "area:dx"]) is None
+    assert scope_check.area_label_paths(["ui", "dx"]) is None
 
 
-def test_area_label_paths_unknown_area_disables_fallback():
-    """Unknown area labels are treated conservatively → None → WARN."""
-    assert scope_check.area_label_paths(["area:fictional"]) is None
+def test_area_label_paths_unrecognised_label_is_ignored():
+    """A label that's neither in BOUNDED_AREA_GLOBS nor META_AREAS (e.g.
+    a custom workflow label) is not treated as an area label at all."""
+    assert scope_check.area_label_paths(["custom-label", "priority:p2"]) is None
 
 
 # ── check_scope tests ─────────────────────────────────────────────────────────
@@ -213,9 +264,9 @@ def test_check_scope_exact_path_match():
 
 
 def test_case_a_no_files_to_touch_area_ui_diff_in_ui_passes():
-    """(a) No Files-to-touch, area:ui, diff in ui/src/ — PASS."""
+    """(a) No Files-to-touch, area `ui`, diff in ui/src/ — PASS."""
     body = "## Context\n\nNothing.\n"
-    labels = ["area:ui", "agent-safe"]
+    labels = ["ui", "agent-safe"]  # bare label form, as used in the repo
     diff = ["ui/src/components/Foo.jsx"]
     v = scope_check.evaluate(body, labels, diff)
     assert v.level == "PASS"
@@ -223,9 +274,9 @@ def test_case_a_no_files_to_touch_area_ui_diff_in_ui_passes():
 
 
 def test_case_b_no_files_to_touch_area_dx_warns():
-    """(b) No Files-to-touch, area:dx (meta) — WARN."""
+    """(b) No Files-to-touch, area `dx` (meta) — WARN."""
     body = "## Context\n\nNothing.\n"
-    labels = ["area:dx", "agent-safe"]
+    labels = ["dx", "agent-safe"]  # bare label form
     diff = ["scripts/foo.py"]
     v = scope_check.evaluate(body, labels, diff)
     assert v.level == "WARN"
@@ -256,7 +307,7 @@ def test_case_d_files_to_touch_strays_fails_pr76_scenario():
 
 ## Acceptance criteria
 """
-    labels = ["agent-safe", "area:ui"]
+    labels = ["agent-safe", "ui"]
     diff = [
         ".claude/skills/react-component/SKILL.md",
         ".claude/skills/react-component/example.jsx",
@@ -274,7 +325,7 @@ def test_case_d_files_to_touch_strays_fails_pr76_scenario():
 def test_case_e_multiple_area_labels_mapping_precedence():
     """(e) Multiple area labels — globs union, files matching either pass."""
     body = "## Context\n\nNo files-to-touch section.\n"
-    labels = ["area:api", "area:auth", "agent-safe"]
+    labels = ["api", "auth", "agent-safe"]
     diff = [
         "src/starter/api/foo.py",
         "src/starter/auth/oauth.py",
@@ -286,7 +337,7 @@ def test_case_e_multiple_area_labels_mapping_precedence():
 
 def test_case_e_multiple_areas_with_out_of_scope_file_fails():
     body = "## Context\n\nNo files-to-touch section.\n"
-    labels = ["area:api", "area:auth", "agent-safe"]
+    labels = ["api", "auth", "agent-safe"]
     diff = [
         "src/starter/api/foo.py",
         "ui/src/components/Foo.jsx",  # out of scope for api+auth

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -162,6 +162,14 @@ def test_area_label_paths_bounded_area_ui_bare_label():
     assert any(g.startswith("ui/") for g in globs)
 
 
+def test_area_label_paths_bounded_area_documentation():
+    """The live area label is `documentation` (not `docs` — CLAUDE.md
+    taxonomy is forward-looking; the live label set is the ground truth)."""
+    globs = scope_check.area_label_paths(["documentation", "priority:p2"])
+    assert globs is not None
+    assert any(g.startswith("docs/") or g.startswith("docs-site/") for g in globs)
+
+
 def test_area_label_paths_bounded_area_prefixed_form_also_accepted():
     """Forward-compatibility: `area:ui` form works too."""
     globs = scope_check.area_label_paths(["area:ui", "priority:p2"])
@@ -381,10 +389,12 @@ def test_evaluate_warns_when_no_scope_info_anywhere():
     assert v.source == "none"
 
 
-def test_evaluate_warns_when_files_to_touch_section_is_empty():
+def test_evaluate_fails_when_files_to_touch_section_is_empty():
+    """Empty Files-to-touch section fails closed — falling back to WARN
+    would let any diff pass by leaving the section blank."""
     body = "## Files to touch\n\n## Next\n"
     v = scope_check.evaluate(body, ["agent-safe"], ["foo.py"])
-    assert v.level == "WARN"
+    assert v.level == "FAIL"
     assert v.source == "files-to-touch"
 
 

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -1,0 +1,365 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Unit tests for scripts/check_agent_safe_scope.py.
+
+Covers all six matrix cases (a)–(f) from issue #77 refinements
+§"Validation test matrix":
+
+(a) No Files-to-touch, area:ui, diff in ui/src/        — PASS
+(b) No Files-to-touch, area:dx                          — WARN (meta-area)
+(c) Files-to-touch listed, diff inside scope            — PASS
+(d) Files-to-touch listed, diff strays outside (PR #76) — FAIL
+(e) Multiple area labels — verify mapping precedence
+(f) Both heading levels (## and ###)
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = ROOT / "scripts" / "check_agent_safe_scope.py"
+
+# scripts/ isn't a package; load the module by file path so tests don't rely
+# on PYTHONPATH being set.
+_spec = importlib.util.spec_from_file_location("check_agent_safe_scope", SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+scope_check = importlib.util.module_from_spec(_spec)
+sys.modules["check_agent_safe_scope"] = scope_check
+_spec.loader.exec_module(scope_check)
+
+
+# ── Parser tests ──────────────────────────────────────────────────────────────
+
+
+def test_parse_files_to_touch_h2_heading():
+    body = """## Context
+
+Some context.
+
+## Files to touch
+
+- New: `.claude/skills/foo/SKILL.md`
+- Edit: `CLAUDE.md`
+
+## Acceptance criteria
+
+- [ ] thing
+"""
+    assert scope_check.parse_files_to_touch(body) == [
+        ".claude/skills/foo/SKILL.md",
+        "CLAUDE.md",
+    ]
+
+
+def test_parse_files_to_touch_h3_heading():
+    """Case (f) — both ## and ### heading levels parse."""
+    body = """### Files to touch
+
+- New: `.claude/skills/bar/SKILL.md`
+
+### Acceptance criteria
+- [ ] thing
+"""
+    assert scope_check.parse_files_to_touch(body) == [
+        ".claude/skills/bar/SKILL.md",
+    ]
+
+
+def test_parse_files_to_touch_missing_returns_none():
+    body = "## Context\n\nNothing scoped.\n\n## Acceptance criteria\n- [ ] thing"
+    assert scope_check.parse_files_to_touch(body) is None
+
+
+def test_parse_files_to_touch_empty_body_returns_none():
+    assert scope_check.parse_files_to_touch("") is None
+
+
+def test_parse_files_to_touch_multiple_backticks_in_one_bullet():
+    body = """## Files to touch
+
+- Edit: `src/starter/api/foo.py` and `tests/unit/test_foo.py`
+
+## Next
+"""
+    assert scope_check.parse_files_to_touch(body) == [
+        "src/starter/api/foo.py",
+        "tests/unit/test_foo.py",
+    ]
+
+
+def test_parse_files_to_touch_bare_path_without_backticks():
+    body = """## Files to touch
+
+- New: src/starter/foo.py
+- Edit: CLAUDE.md
+
+## Next
+"""
+    # Bare paths should still be picked up — slashes or known top-level files.
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed is not None
+    assert "src/starter/foo.py" in parsed
+    assert "CLAUDE.md" in parsed
+
+
+def test_parse_files_to_touch_skips_descriptive_bullets():
+    body = """## Files to touch
+
+- Just some prose without paths
+- `.claude/skills/qux/SKILL.md`
+
+## Next
+"""
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed == [".claude/skills/qux/SKILL.md"]
+
+
+def test_parse_files_to_touch_heading_at_end_of_body():
+    body = "## Files to touch\n\n- `foo.py`\n"
+    assert scope_check.parse_files_to_touch(body) == ["foo.py"]
+
+
+def test_parse_files_to_touch_empty_section():
+    body = "## Files to touch\n\n## Next\n"
+    # Heading present but no bullets → empty list (NOT None).
+    assert scope_check.parse_files_to_touch(body) == []
+
+
+# ── Area-label fallback tests ─────────────────────────────────────────────────
+
+
+def test_area_label_paths_bounded_area_ui():
+    globs = scope_check.area_label_paths(["area:ui", "priority:p2", "size:s"])
+    assert globs is not None
+    assert any(g.startswith("ui/") for g in globs)
+
+
+def test_area_label_paths_meta_area_returns_none():
+    """Case (b) — area:dx is a meta-area, no clean path map → None → WARN."""
+    assert scope_check.area_label_paths(["area:dx", "priority:p2"]) is None
+
+
+def test_area_label_paths_no_area_labels_returns_none():
+    assert scope_check.area_label_paths(["priority:p1", "size:m"]) is None
+
+
+def test_area_label_paths_multiple_bounded_areas_combine():
+    """Case (e) — multiple area labels combine into a union of globs."""
+    globs = scope_check.area_label_paths(["area:api", "area:auth"])
+    assert globs is not None
+    assert any(g.startswith("src/starter/api/") for g in globs)
+    assert any(g.startswith("src/starter/auth/") for g in globs)
+
+
+def test_area_label_paths_meta_in_mix_disables_fallback():
+    """If any area label is a meta-area, fall through to WARN — partial
+    bounded-area coverage isn't reliable enough."""
+    assert scope_check.area_label_paths(["area:ui", "area:dx"]) is None
+
+
+def test_area_label_paths_unknown_area_disables_fallback():
+    """Unknown area labels are treated conservatively → None → WARN."""
+    assert scope_check.area_label_paths(["area:fictional"]) is None
+
+
+# ── check_scope tests ─────────────────────────────────────────────────────────
+
+
+def test_check_scope_all_in_scope():
+    out = scope_check.check_scope(
+        diff_files=["ui/src/foo.jsx", "ui/src/bar.jsx"],
+        allowed_globs=["ui/**"],
+    )
+    assert out == []
+
+
+def test_check_scope_some_out_of_scope():
+    out = scope_check.check_scope(
+        diff_files=["ui/src/foo.jsx", "src/starter/api/bad.py"],
+        allowed_globs=["ui/**"],
+    )
+    assert out == ["src/starter/api/bad.py"]
+
+
+def test_check_scope_universal_allowed_paths_pass():
+    """CHANGELOG.md is universal-allowed regardless of scope."""
+    out = scope_check.check_scope(
+        diff_files=["ui/src/foo.jsx", "CHANGELOG.md"],
+        allowed_globs=["ui/**"],
+    )
+    assert out == []
+
+
+def test_check_scope_glob_with_double_star():
+    out = scope_check.check_scope(
+        diff_files=["src/starter/api/deep/nested/file.py"],
+        allowed_globs=["src/starter/api/**"],
+    )
+    assert out == []
+
+
+def test_check_scope_exact_path_match():
+    out = scope_check.check_scope(
+        diff_files=[".claude/skills/foo/SKILL.md"],
+        allowed_globs=[".claude/skills/foo/SKILL.md"],
+    )
+    assert out == []
+
+
+# ── End-to-end evaluator tests (the six matrix cases) ────────────────────────
+
+
+def test_case_a_no_files_to_touch_area_ui_diff_in_ui_passes():
+    """(a) No Files-to-touch, area:ui, diff in ui/src/ — PASS."""
+    body = "## Context\n\nNothing.\n"
+    labels = ["area:ui", "agent-safe"]
+    diff = ["ui/src/components/Foo.jsx"]
+    v = scope_check.evaluate(body, labels, diff)
+    assert v.level == "PASS"
+    assert v.source == "area-labels"
+
+
+def test_case_b_no_files_to_touch_area_dx_warns():
+    """(b) No Files-to-touch, area:dx (meta) — WARN."""
+    body = "## Context\n\nNothing.\n"
+    labels = ["area:dx", "agent-safe"]
+    diff = ["scripts/foo.py"]
+    v = scope_check.evaluate(body, labels, diff)
+    assert v.level == "WARN"
+    assert v.source == "none"
+
+
+def test_case_c_files_to_touch_in_scope_passes():
+    """(c) Files-to-touch listed, diff inside scope — PASS."""
+    body = """## Files to touch
+
+- New: `.claude/skills/foo/SKILL.md`
+
+## Acceptance criteria
+"""
+    labels = ["agent-safe"]
+    diff = [".claude/skills/foo/SKILL.md"]
+    v = scope_check.evaluate(body, labels, diff)
+    assert v.level == "PASS"
+    assert v.source == "files-to-touch"
+
+
+def test_case_d_files_to_touch_strays_fails_pr76_scenario():
+    """(d) Files-to-touch listed, diff strays outside (the PR #76 case) — FAIL."""
+    body = """## Files to touch
+
+- New: `.claude/skills/react-component/SKILL.md`
+- New: `.claude/skills/react-component/example.jsx`
+
+## Acceptance criteria
+"""
+    labels = ["agent-safe", "area:ui"]
+    diff = [
+        ".claude/skills/react-component/SKILL.md",
+        ".claude/skills/react-component/example.jsx",
+        ".claude/agents/code-reviewer.md",  # ride-along
+        "CLAUDE.md",  # ride-along
+    ]
+    v = scope_check.evaluate(body, labels, diff)
+    assert v.level == "FAIL"
+    assert v.source == "files-to-touch"
+    assert ".claude/agents/code-reviewer.md" in v.out_of_scope
+    assert "CLAUDE.md" in v.out_of_scope
+    assert ".claude/skills/react-component/SKILL.md" not in v.out_of_scope
+
+
+def test_case_e_multiple_area_labels_mapping_precedence():
+    """(e) Multiple area labels — globs union, files matching either pass."""
+    body = "## Context\n\nNo files-to-touch section.\n"
+    labels = ["area:api", "area:auth", "agent-safe"]
+    diff = [
+        "src/starter/api/foo.py",
+        "src/starter/auth/oauth.py",
+    ]
+    v = scope_check.evaluate(body, labels, diff)
+    assert v.level == "PASS"
+    assert v.source == "area-labels"
+
+
+def test_case_e_multiple_areas_with_out_of_scope_file_fails():
+    body = "## Context\n\nNo files-to-touch section.\n"
+    labels = ["area:api", "area:auth", "agent-safe"]
+    diff = [
+        "src/starter/api/foo.py",
+        "ui/src/components/Foo.jsx",  # out of scope for api+auth
+    ]
+    v = scope_check.evaluate(body, labels, diff)
+    assert v.level == "FAIL"
+    assert "ui/src/components/Foo.jsx" in v.out_of_scope
+
+
+def test_case_f_h2_heading_in_evaluator():
+    """(f) H2 heading → parsed correctly by the full evaluator."""
+    body = """## Files to touch
+
+- `src/starter/foo.py`
+
+## More
+"""
+    v = scope_check.evaluate(body, ["agent-safe"], ["src/starter/foo.py"])
+    assert v.level == "PASS"
+
+
+def test_case_f_h3_heading_in_evaluator():
+    """(f) H3 heading → parsed correctly by the full evaluator."""
+    body = """### Files to touch
+
+- `src/starter/foo.py`
+
+### More
+"""
+    v = scope_check.evaluate(body, ["agent-safe"], ["src/starter/foo.py"])
+    assert v.level == "PASS"
+
+
+# ── Additional safety-net tests ───────────────────────────────────────────────
+
+
+def test_evaluate_warns_when_no_scope_info_anywhere():
+    body = "## Context\n\nNo info.\n"
+    v = scope_check.evaluate(body, ["priority:p2"], ["src/starter/foo.py"])
+    assert v.level == "WARN"
+    assert v.source == "none"
+
+
+def test_evaluate_warns_when_files_to_touch_section_is_empty():
+    body = "## Files to touch\n\n## Next\n"
+    v = scope_check.evaluate(body, ["agent-safe"], ["foo.py"])
+    assert v.level == "WARN"
+    assert v.source == "files-to-touch"
+
+
+def test_evaluate_handles_none_body():
+    """A PR linked to no issue → body=None → WARN."""
+    v = scope_check.evaluate(None, [], ["foo.py"])
+    assert v.level == "WARN"
+
+
+def test_verdict_to_dict_serialises_cleanly():
+    body = """## Files to touch
+
+- `foo.py`
+"""
+    v = scope_check.evaluate(body, [], ["foo.py", "bar.py"])
+    d = v.to_dict()
+    assert d["level"] == "FAIL"
+    assert d["out_of_scope"] == ["bar.py"]
+    assert d["source"] == "files-to-touch"
+    assert d["allowed_globs"] == ["foo.py"]
+
+
+def test_universal_allowed_changelog_passes_in_files_to_touch_mode():
+    body = """## Files to touch
+
+- `src/starter/foo.py`
+"""
+    v = scope_check.evaluate(body, [], ["src/starter/foo.py", "CHANGELOG.md"])
+    assert v.level == "PASS"


### PR DESCRIPTION
Closes #77

## Summary

Adds a defence-in-depth gate that blocks an `agent-safe` PR from auto-merging when its diff strays outside the linked issue's stated scope. Direct response to the PR #76 ride-along incident.

## Approach

Two-layer gate with a single shared implementation:

- `scripts/check_agent_safe_scope.py` is the single source of truth — pure functions for parsing the issue body's `Files to touch` section, mapping bounded `area:*` labels to globs, and comparing against the PR diff. Has both a library API (consumed by `code-reviewer`) and a CLI (consumed by the CI workflow).
- `.github/workflows/agent-safe-scope.yml` is the unbypassable backstop. Conditioned on `agent-safe` so non-agent-safe PRs see a no-op pass. Triggers on `opened, synchronize, labeled, unlabeled, edited` per the issue refinements §"Race condition handling".
- `.claude/agents/code-reviewer.md` gains check 12 wiring the script into pre-merge review (the friendly first-line gate).
- `CLAUDE.md` §Special labels gets a one-line note pointing at the new requirement.

Resolution order in `evaluate()`:
1. Issue body has a `## Files to touch` / `### Files to touch` section → use it.
2. Else issue has bounded `area:*` labels (no meta-areas in the mix) → use the area-label glob map.
3. Else WARN — the gate cannot make a confident judgement (per refinements §"Fail-closed → WARN on missing scope info").

## Test matrix (all six cases from issue refinements)

`tests/unit/test_check_agent_safe_scope.py` — 33 tests, all passing locally and in CI:

- (a) No `Files to touch`, `area:ui`, diff in `ui/src/` → PASS
- (b) No `Files to touch`, `area:dx` (meta) → WARN
- (c) `Files to touch` listed, diff inside scope → PASS
- (d) `Files to touch` listed, diff strays outside (PR #76 case) → FAIL
- (e) Multiple `area:*` labels — globs union; meta-area in mix forces WARN
- (f) Both `## Files to touch` and `### Files to touch` heading levels parse

Plus parser edge cases (empty section, bare paths, multiple backticks per bullet) and the universal-allowed-paths exception (`CHANGELOG.md`).

## Validation evidence

End-to-end validation per issue #77 acceptance criteria — performed against real CI on a deliberately-misshaped PR:

- **Validation PR:** #84 (`test: validate agent-safe scope check (do not merge)`)
- **CI run (FAIL):** https://github.com/warlordofmars/agentcore-starter/actions/runs/24946938090
- **Outcome:** the new `Scope check (agent-safe PRs)` job correctly failed before any auto-merge could fire. Output captured from the run:

```
verdict: FAIL
summary: PR diff includes 1 file(s) outside the issue's "Files to touch" scope.
allowed scope:
  - .claude/skills/react-component/SKILL.md
out-of-scope files:
  - docs/_validation_artifact_issue77.md
```

PR #84 was closed without merging and the `test/validate-agent-safe-scope-77` branch was deleted (cleanup confirmed).

## Manual follow-up the human must do post-merge

The new `Scope check (agent-safe PRs)` job (workflow file: `.github/workflows/agent-safe-scope.yml`) is **NOT yet** in branch protection's required-checks list for `development`. Until it's added, the gate logs but does not block merge.

To wire it in: Settings → Branches → branch protection rule for `development` → "Require status checks to pass" → add `Scope check (agent-safe PRs)`. Repeat for `main` if release-branch PRs should also enforce it.

The agent loop cannot edit branch protection — this is a one-time manual setup.

## Out-of-scope notes (deferred per issue Escape-hatch policy)

The retrospective also recommends adding issue-creation-time enforcement (any new `agent-safe` label addition requires a `Files to touch` section in the body). That's a separate piece of work — file as a follow-up issue if desired; keeping this PR focused on the diff-time gate.