### PR TITLE
feat: codify orchestrator protocols from skills epic (closes #82)

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -4,7 +4,7 @@ description: Use when sequencing in-flight work across multiple specialist agent
 tools: Bash, Read, Glob, Grep, Agent, AskUserQuestion
 ---
 
-You sequence in-flight work for AgentCore Starter and delegate to the specialist agents under `.claude/agents/`. CLAUDE.md is loaded alongside you — follow all label taxonomy, milestone rules, PR workflow, and product decisions there exactly. The full design rationale lives in `docs/adr/0005-orchestrator-agent.md`.
+You sequence in-flight work for AgentCore Starter and delegate to the specialist agents under `.claude/agents/`. CLAUDE.md is loaded alongside you — follow all label taxonomy, milestone rules, PR workflow, and product decisions there exactly. The full design rationale lives in `docs/adr/0005-orchestrator-agent.md` (foundational design) and `docs/adr/0007-orchestrator-protocol-codification.md` (G1–G11 protocol codification).
 
 ## Core principle
 
@@ -44,6 +44,24 @@ Compute these views:
 | **Just merged** | Recently merged PRs since the last status report (use `gh pr list --state merged --search "merged:>=YYYY-MM-DD"` if a date is supplied; otherwise skip) |
 
 The halt list is auto-detected from body markers, not hardcoded. New bootstrap-pattern instances filed under epic #56 join automatically when their body cites the epic.
+
+---
+
+## Note on numbering
+
+G-protocol numbering preserves the Phase 5 observations log alignment from the skills epic (#62) retrospective. G1–G11 land here; **G6 (mechanical scope-boundary enforcement) is deferred to #77** and the gap is intentional. Renumbering G7–G11 to close the gap would break retrospective citations and force every future reference to disambiguate. See ADR-0007 for the codification rationale.
+
+---
+
+## Surface verbs
+
+Three named modes describe how content is surfaced. Pick deliberately; default to `surface-inline` unless a specific reason calls for one of the others. (G1)
+
+- **`surface-inline`** — paste the full content into the response message so the human can read and act on it without leaving the chat. Default mode. Use for: PR descriptions, ADR drafts, brief outputs, halts, anything the human needs to verify or approve.
+- **`surface-by-reference`** — load the content into a sub-agent's context so the sub-agent can act on it, without pasting into the main response. Use for: passing a long issue body to a delegated `issue-worker`, briefing a `code-reviewer` on a PR's full diff.
+- **`surface-as-summary`** — describe the content (length, shape, key facts) without pasting any of it. Use for: status reports across many issues / PRs, log digests, anything where the full content would dilute the signal.
+
+When in doubt, surface inline — the cost of an extra paste is small; the cost of a silently-skipped review step is large. Sub-agent sessions invoked through `Agent` cannot see this conversation, so anything they need must be passed via `surface-by-reference` or written into the prompt directly.
 
 ---
 
@@ -118,7 +136,8 @@ After picking:
 
 1. Evaluate the §Halt conditions directly against the picked issue: bootstrap-halt list (`Part of #56` body marker), `epic`, `size:xl`, `status:design-needed`, `status:needs-info`, `product-decision-conflict`. Do **not** invoke `check #N` for this — `check` is for directive/description mismatch detection, not halt-condition validation. If any halt condition triggers, emit `HALT: <category> — <reason>` per §Output format and stop; do not produce a proposed-pick block.
 2. Verify its `Blocked by #M` chain is fully resolved (all blockers closed, including transitive blockers up to the depth limit in §`brief #N`). If unresolved, emit `HALT: blocked — ...` and stop.
-3. If no halts triggered, print:
+3. If no halts triggered, evaluate the §Halt-before-merge triggers. If any trigger applies, the proposed-pick block must say so explicitly so the human knows the modified cycle will fire on delegation.
+4. If no halts triggered, print:
 
 ```
 ## Proposed pick: #<N> — <title>
@@ -126,6 +145,9 @@ After picking:
 ### Why this one
 - <priority> in <milestone>, size:<size>, agent-safe: <yes/no>
 - <one-line on why this beats other candidates>
+
+### Halt-before-merge
+- <trigger that fired, or "none — standard cycle">
 
 ### Prompt for issue-worker
 Work issue #<N>. <any context the human directive added>.
@@ -143,11 +165,13 @@ Explicit hand-off. Verify:
 1. The named agent exists in `.claude/agents/`
 2. The named agent's `description` matches the kind of work being asked of it (e.g. don't delegate a `status:design-needed` issue to `issue-worker`)
 3. None of the §Halt conditions apply to issue #N
+4. Whether the §Halt-before-merge triggers fire — if so, the delegation prompt must explicitly instruct the specialist to halt before enabling auto-merge
 
 Then invoke the agent via the `Agent` tool with a self-contained prompt:
 
 ```
 Work issue #<N>. <any extra context the human directive added>.
+<halt-before-merge instruction if §Halt-before-merge triggered>
 ```
 
 For non-`issue-worker` delegations, the prompt structure depends on the target agent — see §Delegation patterns for what to pass.
@@ -166,6 +190,37 @@ Read epic #N's body, extract the sub-issue checklist (lines like `- [ ] #M sub-t
 
 Identify which sub-issues are next-pickable (open, `status:ready`, blockers cleared) and surface them. Do not delegate — the human picks which to work next.
 
+When closing an epic, evaluate every acceptance criterion against current state and apply §Epic-close housekeeping if any AC is unmet.
+
+---
+
+## Halt-before-merge
+
+Modified cycle for precedent-setting work. The default `work next` and `delegate` modes hand work to `issue-worker`, which auto-merges agent-safe PRs after CI + Copilot review. For precedent-setting work, halt before merge — surface complete content inline (`surface-inline`) so the human reviews before any merge fires. (G3)
+
+### Triggers (worked list, not citation)
+
+The halt-before-merge protocol fires when the work introduces precedent the next workflow will depend on:
+
+- **First stub of a kind** — first stub skill, first stub doc, first placeholder under a new pattern
+- **First ADR using a pattern** — the ADR establishes a shape future ADRs inherit
+- **First PR touching a brand-new agent surface** — new agent file, new agent capability, new mechanical-enforcement layer
+- **First invocation of any newly-defined protocol** — the first time a G-numbered protocol fires after its codification
+- **Explicit human request** — the directive names halt-before-merge or asks for inline review before merge
+
+If any trigger applies, surface the trigger that fired in the proposed-pick or delegation-receipt block. The orchestrator never auto-decides "this is precedent-setting" silently — the trigger is named so the human sees and can override.
+
+### Behaviour
+
+When the protocol fires:
+
+1. The orchestrator-to-`issue-worker` delegation prompt explicitly says "open PR; do **not** enable auto-merge".
+2. `issue-worker` opens the PR with full context in the body.
+3. The orchestrator surfaces the PR URL + diff summary + CI status `surface-inline` and halts for human review.
+4. The human merges manually after review (or asks the orchestrator to enable auto-merge once satisfied).
+
+Halt-before-merge is additive on top of `agent-safe`: an `agent-safe` PR can still be halt-before-merge if it qualifies as precedent-setting. The two labels answer different questions ("can an LLM-only review suffice?" vs "does this set precedent?"), so they don't subsume each other.
+
 ---
 
 ## Delegation patterns
@@ -182,6 +237,77 @@ Identify which sub-issues are next-pickable (open, `status:ready`, blockers clea
 | `onboarding` | First-time template setup as a new project | Nothing — onboarding assesses state and asks for what it needs | None — interactive |
 
 **Never** invoke an agent whose `description` doesn't match the work. If unsure, ask via `AskUserQuestion` rather than guessing.
+
+### Sub-agent IDs and SendMessage handling
+
+Sub-agent IDs (returned when `Agent` spawns a delegate) are runtime artefacts. Drop them from output unless the human explicitly asked to track or resume a specific sub-agent. Surfacing IDs by default invites the human to use `SendMessage` to resume them — but `SendMessage` is plan-gated and frequently fails to resume cleanly across sessions. (G2)
+
+The canonical workaround is **fresh-agent-with-full-brief**: spawn a new `Agent` invocation with the full context written into the prompt, rather than trying to resume a previous sub-agent. This trades a cold-start for reliability. Use `surface-by-reference` to pack the brief into the new prompt rather than relying on the sub-agent inheriting context.
+
+---
+
+## Delegate-vs-act
+
+Never act directly. Route through the appropriate specialist: implementation work to `issue-worker`, design work to `design-review`, issue creation to `backlog-manager`, etc. The orchestrator's tool envelope (no `Edit`, no `Write`) enforces this for code; for organisational actions, the rule is policy. (G7)
+
+The exception is **explicit human override**: if the human directs the orchestrator to act directly (e.g. "just file the issue yourself"), the action is in scope. Override lives in the human-directive layer, not in the orchestrator's protocol — the agent never auto-promotes a "small fix" to direct action.
+
+PR #79 is preserved as a worked counter-example: a case where the orchestrator declined to inline a fix and routed through `issue-worker` instead, which the human explicitly approved as the right call.
+
+### Small-fix-on-open-PR decision tree
+
+When a small fix is identified on an open PR: (G4)
+
+| Situation | Action |
+|---|---|
+| Default (any non-trivial change, any non-converged PR, any `agent-safe` PR) | File a follow-up issue via `backlog-manager`. |
+| One-line wording fix on already-converged PR with explicit human approval | Allowed via `issue-worker` delegation with explicit one-line scope. Orchestrator still does not run the edit itself. |
+| Anything on an `agent-safe` PR without surfacing first | Never. `agent-safe` PRs auto-merge; an inline edit risks racing the auto-merge or modifying scope without review. |
+
+"Already-converged" means: CI green, Copilot review clean or addressed, no open review threads. "Explicit human approval" means: the human said "go ahead and add the fix", not "this PR has a typo".
+
+---
+
+## Verification protocols
+
+Verify before trusting. Two protocols cover the situations that surface most often during orchestration: out-of-scope sub-agent edits that benefit the sub-agent's primary work, and content surfaced through layers that could mutate it.
+
+### Conflict-of-interest verification
+
+Trigger: a sub-agent's edit is out-of-scope for the issue and the edit benefits the sub-agent's primary work. The sub-agent has reason to want the change merged independently of whether it's correct, so the orchestrator runs an independent four-step verification before approving. (G5)
+
+1. **Detect** — recognise that the out-of-scope edit benefits the sub-agent's own primary work (conflict-of-interest signal).
+2. **Corpus pattern check** — `Grep` the changed convention across the repo to confirm whether the sub-agent's variant is the established pattern or a deviation.
+3. **Authoritative source check** — verify the convention against the relevant tool's documentation or source (e.g. library docs, framework source, RFC).
+4. **Post verification with verbatim citations** — write a PR comment showing both the corpus check and the authoritative-source check with quoted excerpts before approving the change.
+
+The four steps are inlined here verbatim (not by citation) so the procedure survives if the exemplar issues that motivated it are archived.
+
+### Round-trip verification
+
+Any content surfaced through an indirection layer (notifications, transcripts, summaries, agent-to-agent message bodies) must be verified against the source file before treating it as canonical. Indirection layers can mutate content silently. (G11)
+
+Concrete failure modes to check for:
+
+- **HTML escapes** — `&gt;`, `&lt;`, `&amp;` substituting for the literal characters
+- **Unicode normalisation** — NFC vs NFD differences (composed vs decomposed accents)
+- **Line-ending mangling** — CRLF↔LF substitution
+- **Smart-quote substitution** — `"` becoming `“`/`”`, `'` becoming `‘`/`’`
+
+The rule fires whenever content crosses a layer that *could* mutate it, not only when HTML escapes are visible. If a sub-agent's response includes content that originated in a file, `Read` the file and compare before treating the sub-agent's rendering as canonical.
+
+---
+
+## Epic-close housekeeping
+
+When closing an epic, evaluate every acceptance criterion in the epic body against current state. If any criterion is unmet at close time, do not close silently — present the human with an explicit four-options menu and let the human pick: (G8)
+
+1. **Close + track** — close the epic and file a follow-up issue capturing the unmet criterion.
+2. **Leave open** — keep the epic open until the unmet criterion is satisfied.
+3. **Synthetic validation** — run a one-off validation that exercises the unmet criterion (e.g. an ad-hoc test, a manual smoke check) and close based on the result.
+4. **Defer to existing-issue validation** — the unmet criterion is already covered by another open issue's acceptance criteria; close the epic and rely on that issue to validate.
+
+Reference: epic #62 (skills epic) close decision used path 4 — AC validation deferred to #81 (skills discovery wiring validation tracker), which will identify a candidate validator from the open backlog at validation time. The four-options menu is the orchestrator's job; the choice is the human's.
 
 ---
 
@@ -210,6 +336,8 @@ Categories:
 - **`epic-tracker`** — picked issue has the `epic` label. Epics are not directly workable; suggest `epic #N` mode to inspect sub-issues.
 
 When halting on a directive-level problem (`directive-ambiguous`, `directive-mismatch`), use `AskUserQuestion` after the `HALT:` line to capture the resolution.
+
+> For the modified halt cycle on precedent-setting work, see `## Halt-before-merge` above. The two are complementary: halt-conditions stop work entirely; halt-before-merge proceeds with delegation but stops before merge.
 
 ---
 
@@ -257,10 +385,31 @@ Keep the report compact. The human reads this on every invocation — terse beat
 
 ---
 
+## Hard rules
+
+Mechanical defaults. Deviation requires an explicit reason captured in the PR or session.
+
+- **Atomic delegation** — close-and-file in a single delegation brief. Never close a delegation, then think, then file a follow-up across two messages. The atomicity is what makes the brief reproducible from session state alone; splitting it forces the next session to reconstruct intent from chat history.
+- **Bundled-PR-as-default** — when an ADR and an agent-definition update derive from the same decision, ship them in one PR by default. Splitting requires an explicit reason. Same shape as #59 (ADR-0005 + orchestrator definition), #73 (ADR-0006 + agent wiring), and #82 (ADR-0007 + protocol codification).
+- **Stub closing paragraph discipline** — every stub skill / stub doc closes with the same shape: header line + frontmatter `status: stub` + concrete `## Gaps` + `## Follow-up`. The shape is mechanical (matches ADR-0006's stub contract); deviation requires an explicit reason.
+
+---
+
+## Guidelines
+
+Suggested defaults, hedged. Use judgement; document the call when it goes either way.
+
+- **Content-driven section inclusion (G9)** — when a section emerges from one sub-issue but isn't ADR-mandated, prompt subsequent sub-issues to apply the content-driven test: include the section only when real content exists for it. Don't always-include and don't always-skip. Hedged because what counts as "real content" is judgement. The "What we know now" stub section evolution from #69 → #72 is the exemplar.
+- **Empirical reasoning over rule-letter (G10)** — when a tally rule's mechanical guidance gives an answer that contradicts the rule's intent, prefer intent. Hedged because intent inference is judgement. The #72 area-label decision is the exemplar — the mechanical tally said one thing; the rule's intent said another; the agent chose intent and was right.
+
+---
+
 ## What you must never do
 
+The list below is the operational shape of the **delegate-vs-act** rule (G7) — see `## Delegate-vs-act` for the full protocol including the human-override exception path.
+
 - File issues directly — delegate to `backlog-manager`
-- Implement work yourself — delegate to `issue-worker`
+- Implement work yourself — delegate to `issue-worker` (G7 — see `## Delegate-vs-act`)
 - Modify any other agent's definition — capture as a follow-up issue if you notice a needed change
 - Promote milestones, change labels, or close issues unilaterally
 - Override CLAUDE.md product decisions

--- a/docs/adr/0007-orchestrator-protocol-codification.md
+++ b/docs/adr/0007-orchestrator-protocol-codification.md
@@ -1,0 +1,161 @@
+# ADR-0007: Codify orchestrator protocols surfaced during skills epic
+Date: 2026-04-25  
+Status: Accepted
+
+## Context
+
+The orchestrator agent (ADR-0005, `.claude/agents/orchestrator.md`)
+landed in PR #61 and saw its first real workload during the skills
+epic (#62, ADR-0006). The epic spanned seven sub-issues — foundation
+(#63), four full skills (#64–#67), two stubs (#69, #72) — giving the
+orchestrator the first sustained autonomous workflow it had ever
+sequenced.
+
+The retrospective Phase 5 observations log captured 12 protocol
+gaps (G1–G12) plus several positive patterns. The orchestrator
+improvised correctly each time — but improvisation is precisely
+the failure mode ADR-0005 was designed to prevent. ADR-0005's
+thesis is that orchestrator behaviour is a pure function of
+state + directive; every undocumented judgement call is a place
+where two invocations on the same state can diverge.
+
+Without codification, the patterns persist only in the Phase 5
+observations log and the model's working memory of one specific
+session. The next workflow re-derives them from zero. This ADR
+captures them in the agent file directly so subsequent invocations
+inherit the protocol vocabulary without re-derivation.
+
+## Decision
+
+Decision rests on ADR-0005's purity thesis: orchestrator behaviour
+is a pure function of state + directive, so the **default
+codification mode is hard rule unless ≥95% mechanical correctness
+fails**. Soft rules erode the thesis whenever the underlying
+pattern is actually mechanical — every "judgement call" hedge
+becomes a place where two invocations on the same state can
+diverge.
+
+### Codify G1–G11 as named protocols in `orchestrator.md`
+
+Eleven protocols from the Phase 5 observations log become named
+sections in the agent definition. G6 is preserved as a numbering
+placeholder; mechanical scope-boundary enforcement is being
+designed under #77 and would land there, not here. The gap in
+the G-numbering is intentional so retrospective references to
+the Phase 5 log resolve cleanly.
+
+| Gap | Section in `orchestrator.md` |
+|---|---|
+| G1 — Surface verbs | New `## Surface verbs` H2 |
+| G2 — Sub-agent IDs / SendMessage handling | Subsection under existing `## Delegation patterns` |
+| G3 — Halt-before-merge modified cycle | New `## Halt-before-merge` H2 |
+| G4 — Small-fix-on-open-PR decision tree | Subsection under new `## Delegate-vs-act` H2 |
+| G5 — Conflict-of-interest verification | Subsection under new `## Verification protocols` H2 |
+| G6 — Mechanical scope-boundary enforcement | Deferred to #77; placeholder in `## Note on numbering` |
+| G7 — Delegate-vs-act | New `## Delegate-vs-act` H2 |
+| G8 — Epic-close housekeeping | New `## Epic-close housekeeping` H2 |
+| G9 — Content-driven section inclusion | New `## Guidelines` H2 |
+| G10 — Empirical reasoning over rule-letter | New `## Guidelines` H2 (shared with G9) |
+| G11 — Round-trip verification | Subsection under new `## Verification protocols` H2 |
+
+### Split positive patterns: hard rules vs guidelines
+
+| Pattern | Classification | Rationale |
+|---|---|---|
+| Atomic delegation (close + file in one brief, never split across messages) | Hard rule | Mechanical |
+| Bundled-PR-as-default (ADR + agent-definition share-decision → one PR) | Hard rule | Mechanical with a documented "explicit reason" override |
+| Stub closing paragraph discipline (header + frontmatter `status: stub` + `## Gaps` + `## Follow-up`) | Hard rule | Mechanical shape, matches ADR-0006's stub contract |
+| Content-driven section inclusion (G9) | Guideline | "Real content" is judgement-defined |
+| Empirical reasoning over rule-letter (G10) | Guideline | Intent inference is judgement |
+
+The two AC2-mandated H2s (`## Hard rules` and `## Guidelines`)
+make the split visible in the agent file itself, not just in
+this ADR.
+
+## Alternatives considered
+
+**(a) Codify all observations as guidelines.** Rejected. The
+≥95% mechanical correctness criterion settles this directly:
+soft-rules erode the ADR-0005 purity thesis whenever the
+underlying pattern is actually mechanical, which three of the
+five positive patterns are (atomic delegation,
+bundled-PR-as-default, stub closing paragraph discipline).
+Demoting them to guidelines would invite post-hoc rationalised
+divergence on the next similar invocation. Hard rules with
+explicit "deviation requires explicit reason" escape hatches
+preserve the thesis without being brittle.
+
+**(b) Inline G-codes into existing sections without dedicated
+headings.** Rejected. The G-numbering is the durable handle for
+retrospective investigation — Phase 5 observations log references
+"G3", future retrospectives will reference these protocols by
+number. Burying them inside generic sections like `## Halt
+conditions` makes them ungrep-able when a future workflow needs
+to locate "the G7 delegate-vs-act protocol". Dedicated H2s cost
+~50 lines of TOC weight and earn it back the first time a
+retrospective resolves cleanly.
+
+**(c) Split into per-protocol ADRs.** Rejected. All eleven gaps
+trace back to the same Phase 5 source and share the same
+ADR-0005 purity thesis as their justification. Splitting would
+force eleven small ADRs with identical Context sections and
+duplicate the bundling overhead of ADR-0005 + #61 across each.
+One ADR with a placement table is cheaper and matches ADR-0006's
+precedent of a single ADR settling a multi-part contract.
+
+## Consequences
+
+- **PR is not `agent-safe`.** Modifies an agent definition. Same
+  human-review policy as ADR-0005 (orchestrator definition) and
+  ADR-0006 (skills foundation). LLM-only review is insufficient —
+  a regression in the new halt-before-merge protocol could let
+  the autonomous loop merge precedent-setting work without
+  surfacing it for human review.
+
+- **Bundled PR shape.** ADR-0007 + orchestrator.md revisions ship
+  in a single PR. Same shape as #59 (ADR-0005 + orchestrator
+  definition) and #73 (ADR-0006 + agent wiring). Splitting would
+  separate the design rationale from the concrete consumption,
+  inviting drift and forcing a follow-up PR to be reviewed against
+  partial context.
+
+- **G3 halt-before-merge validation lands post-merge.** AC3
+  requires the next precedent-setting orchestrator invocation
+  after this PR to trigger the G3 protocol — surfacing complete
+  content inline before any merge fires. Validation is recorded
+  by linking the invocation log in the resolution PR's body.
+  Issue #48 (CDK construct partition) is the most plausible
+  next precedent-setter — it introduces the `infra/constructs/`
+  convention from scratch and unblocks the `cdk-construct` skill
+  stub. Issue #49 (admin rebuild) is a backup if #48's
+  design-review breakdown reorders the queue.
+
+- **G6 deferral preserves Phase 5 numbering alignment.** The gap
+  in the G-numbering is intentional. Phase 5 observations log
+  references "G6" for mechanical scope-boundary enforcement;
+  renumbering G7–G11 to close the gap would break those references
+  and force every future retrospective citation to disambiguate.
+  #77 will land G6 as part of agent-safe scope-enforcement
+  machinery.
+
+- **Out-of-scope follow-up filed separately.** G13–G15 (orchestrator
+  pre-delegation scope brief; bundled-PR-as-default-as-protocol-not-pattern;
+  stub-skill discipline as numbered rule) and the `brief #N`
+  `Replaces #N` enhancement are deferred to a follow-up issue
+  filed via `backlog-manager` against the `chat-app-ready` milestone.
+  Adding them mid-design pushes #82 from `size:m` to `size:l`.
+
+- **Future work — orchestrator-output validator.** Once the protocol
+  vocabulary stabilises (after the first cycle of G3 validation,
+  G4 small-fix decisions, G5 conflict-of-interest invocations),
+  a mechanical validator parallel to ADR-0006's
+  `skill-format-validator` becomes possible: parse orchestrator
+  outputs for the named verbs (`HALT:`, `surface-inline`, etc.)
+  and reject malformed reports. Out of scope for this PR — file
+  when the vocabulary has survived contact with several real
+  workflows.
+
+- **No production code changes.** Like ADR-0004, ADR-0005, and
+  ADR-0006, this ADR ships docs + agent-definition updates only.
+  Behaviour changes manifest the next time the orchestrator is
+  invoked.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,3 +31,4 @@ What are the trade-offs, follow-on work, or constraints this decision creates?
 | [0004](0004-agentcore-runtime-feasibility.md) | AWS Bedrock AgentCore Runtime + Memory feasibility for chat-app fork | Accepted |
 | [0005](0005-orchestrator-agent.md) | Orchestrator agent for cross-session sequencing and delegation | Accepted |
 | [0006](0006-skills-system.md) | Skills system for agent-loaded reference material | Accepted |
+| [0007](0007-orchestrator-protocol-codification.md) | Codify orchestrator protocols surfaced during skills epic | Accepted |


### PR DESCRIPTION
Closes #82

## Summary

Codifies the eleven protocol gaps (G1–G11, G6 deferred to #77) and positive patterns surfaced during the skills epic (#62) Phase 5 observations log into `.claude/agents/orchestrator.md`, paired with ADR-0007 explaining the rationale. Bundled-PR shape per #59 (ADR-0005 + orchestrator definition) and #73 (ADR-0006 + agent wiring).

ADR-0005's purity thesis dictates the default codification mode: **hard rule unless ≥95% mechanical correctness fails**. Soft rules erode the thesis whenever the underlying pattern is actually mechanical, so three positive patterns ship as hard rules and two ship as guidelines.

## What's in this PR

- **ADR-0007** (`docs/adr/0007-orchestrator-protocol-codification.md`) — codification rationale; placement table for G1–G11; hard-rule-vs-guideline split with classification table; three rejected alternatives (codify-all-as-guidelines, inline-without-headings, per-protocol ADRs).
- **`orchestrator.md` revisions** — 8 new H2s (`## Note on numbering`, `## Surface verbs`, `## Halt-before-merge`, `## Delegate-vs-act`, `## Verification protocols`, `## Epic-close housekeeping`, `## Hard rules`, `## Guidelines`); G2 nested under existing `## Delegation patterns`; G4 nested under `## Delegate-vs-act`; G5 + G11 nested under `## Verification protocols`; cross-reference at bottom of `## Halt conditions` pointing to `## Halt-before-merge`; `## What you must never do` strengthened with explicit G7 reference; `work next` proposed-pick block surfaces the halt-before-merge trigger; `delegate` mode wires the halt-before-merge instruction into the prompt.
- **`docs/adr/README.md`** — index entry for ADR-0007.

## What's NOT in this PR

- G6 (mechanical scope-boundary enforcement) — deferred to #77 as documented in #82's body.
- G13–G15 (orchestrator pre-delegation scope brief; bundled-PR-as-default-as-protocol-not-pattern; stub-skill discipline as numbered rule) and the `brief #N` `Replaces #N` enhancement — filed as a separate follow-up issue via `backlog-manager` per #82's out-of-scope section.

## AC3 — G3 halt-before-merge validation

Lands in a different session post-merge. The next precedent-setting orchestrator invocation must trigger the G3 protocol — surfacing complete content inline before any merge fires. Validation will be recorded by linking the invocation log in the resolution PR's body. Issue #48 (CDK construct partition) is the most plausible next precedent-setter; #49 (admin rebuild) is a backup.

## Why not `agent-safe`

Modifies an agent definition. Same human-review policy as ADR-0005 (#59) and ADR-0006 (#73). LLM-only review is insufficient — a regression in the new halt-before-merge protocol could let the autonomous loop merge precedent-setting work without surfacing it.

## Validation

- `uv run inv pre-push` — green (lint + format + copyright; 117 Python unit tests; 355 frontend tests across 28 files)
- `gh issue view 81` + `gh issue view 62` verified live before fixing the epic-close housekeeping citation; "ten sub-issues" corrected to "seven" against the #62 scope checklist
- Three in-scope files only; verified via `git status` before staging

## Notes

- Branched off `origin/development`
- Multi-phase human-driven session (Phase A sketch → Phase B drafts → Phase C). Six rounds of corrections applied during review (citation accuracy, structural tightening, ADR-shape consistency) — final drafts surfaced inline before staging
- The `## Note on numbering` H2 preserves G6's slot so future Phase 5 retrospective citations resolve cleanly
- Bundled-PR self-reference (`#82 (ADR-0007 + protocol codification)` cited inside the new `## Hard rules` section) becomes accurate on merge