### PR TITLE
docs: add 2026-04-26 strategy session retro

### DIFF
--- a/docs/retros/2026-04-26-strategy-session-retro.md
+++ b/docs/retros/2026-04-26-strategy-session-retro.md
@@ -1,0 +1,362 @@
+# Combined retro — 2026-04-26 strategy session
+
+**Date:** 2026-04-26
+**Duration:** ~7 hours (mid-session compaction in this conversation; multiple Claude Code sessions in parallel)
+**Outcome:** Two PRs merged (#85 orchestrator codification, #83 scope-boundary enforcement). One force-push incident, fully recovered. Two follow-up issues filed. Two more identified but not yet filed.
+
+This retro covers three threads:
+
+- **Part A** — Strategy-partner role: project-instructions evolution
+- **Part B** — Force-push incident: root cause, recovery, prevention
+- **Part C** — PR #85 / #83 execution: phase-shape effectiveness, review-layer division of labor
+
+Synthesis at the end pulls cross-cutting observations and lists action items by urgency.
+
+---
+
+## Part A — Strategy-partner retro
+
+### A1. New observations from this session
+
+These extend the strategy-partner observation log (SP1–SP10 from earlier sessions):
+
+**SP11 — Diff-size sanity check is not in the project instructions but should be.**
+The Phase C self-report on PR #85 said "three in-scope files modified, no others." The actual PR had 38 files. The agent's self-report wasn't a check against GitHub state — it was the agent's understanding of its own work. The strategy partner caught the discrepancy by querying `gh pr view --json changedFiles,additions,deletions` after the fact. The catch was reactive, not proactive. Should be promoted to a project-instructions rule: *whenever an agent reports a PR was opened, independently query the PR's file count and net additions before accepting the report.*
+
+**SP12 — First-diagnosis confidence needs explicit alternatives.**
+When PR #85 first showed 38 files, my immediate diagnosis was "stale local development branch in the agent's clone, didn't fetch before branching." That was wrong; actual cause was upstream rewind. The `forced-update` line in the reflog was visible from the first diagnostic but I read it as "evidence of stale state" rather than "evidence of upstream rewind." The lesson: when evidence points at multiple possible causes, the strategy partner should *explicitly enumerate alternatives* before leading with one. Single-hypothesis diagnosis leaves room for the wrong-but-plausible answer to anchor the investigation.
+
+**SP13 — Surface ambiguity recurs even when codifying it.**
+When the orchestrator session produced ADR-0007 + orchestrator.md drafts in Phase B, its first report described the diffs but pasted the actual content into tool blocks invisible to the strategy partner. The G1 protocol the agent was *literally drafting in that same session* was specifically designed to prevent this. The agent re-surfaced cleanly on the second prompt, but the recurrence suggests `surface-inline` needs a stronger mechanical handle than verbal definition — perhaps a worked counter-example in G1 itself ("if your report references a tool block, you have NOT surfaced inline").
+
+**SP14 — Multi-clone topology is a known unknown.**
+The session 2 forensic exposed that the user has multiple local clones with different baseline states (`-spike` vs canonical). My mental model assumed single-clone working environments, which led to early misattribution of the force-push. Project instructions should mention asking the user about clone topology when forensic data spans multiple clones, not assume one clone.
+
+**SP15 — Defensive layers are non-overlapping (confirmed once more).**
+Multiple errors caught this session by different mechanisms: (a) human noticed Phase B report only had a summary, not actual content; (b) project-instructions issue-number-discipline rule made strategy partner reflexively run `gh issue view` on cited numbers; (c) the verification habit cascaded into checking the corrected text too, catching a second error in the fix; (d) Copilot review on #83 caught the fail-open hole that the strategy partner missed. Each layer caught a different error. No single rule is sufficient. Defense-in-depth is the design principle, not the fallback.
+
+**SP16 — Conversation-length drift surfaced once but didn't bite.**
+This session is genuinely long enough that I missed at least one subtle thing (mistakenly diagnosing `main` as rewound when it was just naturally behind). I should have run a verification check on `main`'s expected state before claiming damage. Project-instructions rule on escalating to fresh sessions exists but didn't fire because progress was being made. Worth making the trigger more sensitive: *if a confident-sounding claim about repo state is being made under context pressure, verify before asserting*.
+
+**SP17 — Issue-number discipline rule landed correctly and earned its place.**
+The most consequential save of the session: when the orchestrator's draft cited `#71/#80/#82` as the AC3 validators for path-4 close on epic #62 (correct citation: `#81` alone), the project-instructions rule made me reflexively run `gh issue view`. Without it, the wrong citations would have shipped into a load-bearing agent file. This is a concrete win attributable to the project instructions, not to base reasoning.
+
+### A2. Project instruction edits proposed
+
+These are concrete edits to fold in. Diffs are illustrative, not literal — depending on current project instructions structure.
+
+**Edit 1 — Add diff-size sanity check rule.**
+
+Add to *What you don't do*:
+
+> Do not accept agent self-reports about PR scope without independent verification. When an agent reports a PR was opened or modified, query `gh pr view --json changedFiles,additions,deletions` before accepting the report. Cross-check the file count against expected scope before approving any merge.
+
+**Edit 2 — Strengthen first-diagnosis discipline.**
+
+Add to *Working protocols* under *Push-back protocol* or as new section *Diagnostic protocol*:
+
+> When evidence points at multiple possible causes, explicitly enumerate the alternatives before recommending one. Single-hypothesis diagnosis anchors the investigation; the right answer often hides as the second-most-plausible reading. If a forensic signal could fit two interpretations, surface both with the evidence that would distinguish them.
+
+**Edit 3 — Surface verbs gloss in own behavior.**
+
+Add to *Tone* or *Working protocols*:
+
+> When asking an agent to surface content, the strategy partner uses surface verbs explicitly: "surface inline," "surface by reference," "surface as summary." When an agent's report references content not visible (tool blocks, files not pasted), re-prompt with explicit `surface-inline` instruction before accepting the report.
+
+**Edit 4 — Multi-clone awareness.**
+
+Add to *About John* or as a new behavioral note:
+
+> When forensic data appears to span multiple sources or contains conflicting evidence, ask the user about clone/session topology before assuming a single working environment. Multiple local clones, multiple Claude Code sessions, and stale baselines are common and shape diagnostic interpretation.
+
+**Edit 5 — Conversation-length drift sensitivity.**
+
+Refine *When to escalate to a fresh session*:
+
+> When a confident-sounding claim about current repo state is about to be made under context pressure, verify against the live tools before asserting. The threshold for proposing a fresh session is not absolute conversation length — it's the ratio of confident assertions to verifiable claims. If recent assertions are increasingly memory-derived, surface that fact and offer a handoff brief.
+
+### A3. New rules to consider
+
+Less prescriptive than A2, more directional. Worth thinking about for the next project-instructions revision pass:
+
+- **Pre-flight `gh issue list` for new-issue proposals already exists.** Performed correctly this session.
+- **`gh issue view` before citing numbers already exists.** Earned its place this session.
+- **Add: `gh pr view` with diff stats before approving merge.** Promote from convention to rule.
+- **Add: `gh api repos/{owner}/{repo}/branches/{branch}` to verify branch state before claiming a branch is rewound or not.** This would have caught the `main`-not-actually-rewound mistake faster.
+- **Consider: proactive forensic order.** When investigating an unexpected diff size, the order should be (1) compare base SHA to current target SHA, (2) check branch protection state, (3) check reflog for force-update signals, (4) ask about clone topology. The first three are queryable via tools; the fourth is conversational.
+
+---
+
+## Part B — Force-push incident retro
+
+### B1. Root cause analysis
+
+**The mechanism, with high confidence:**
+
+The 4a issue-worker session running in `/Users/john/Projects/agentcore-starter-spike` issued a `git push` command (most likely `git push --all --force` or a `git push --force` with `push.default = matching` in effect) at 23:07:07 EDT on 2026-04-25. This pushed every local branch with a remote counterpart. The clone's local `development` ref was at `943923a` (the SEC-1 fix from earlier that day, never updated through any of the subsequent merges); origin's `development` was at `14ea24e` (after PR #80 merge). The wholesale push rewound origin/development backwards by 11 merges.
+
+**Why it succeeded:**
+
+- Branch protection on `development` was *not yet applied* — no `allow_force_pushes=false` setting.
+- `--force-with-lease` (if used) would have been satisfied: the lease default uses the local clone's remote-tracking ref, which had been updated to `14ea24e` via fetch at 22:58:19. So `--force-with-lease=development` would have seen origin actually at `14ea24e` (matching) and accepted the push.
+- The agent's understanding of "halt-before-merge" was narrowly scoped to `gh pr merge --auto`, not to git operations on shared refs.
+
+**Why the agent did the wholesale push:**
+
+Most likely accidental, not deliberate. The 4-second gap between rebase finish (23:07:03) and push (23:07:07) suggests intent was to push the rebased validation test branch only. The agent's session 2 forensic explicitly couldn't recall the command (post-`/clear`) but reconstructed the most plausible mechanism from reflog analysis. Two evidence points support the accidental-collateral hypothesis:
+
+1. The chore branch (60d4751) was pushed cleanly at 23:25:45 with no collateral, suggesting the session was capable of single-ref pushes when issuing them deliberately.
+2. Local development was never modified in this clone (no commit, reset, or merge on it). Pushing it was pointless from any rational standpoint, only explicable as accidental side-effect of a multi-ref push command.
+
+### B2. Why the diagnosis took the path it did
+
+**First diagnosis was wrong.** When PR #85 first showed 38 files, the strategy partner's read was "stale local branch in this clone, didn't fetch before branching." The `forced-update` line in the cleared session's reflog was visible from the first diagnostic but read as "evidence of stale state" rather than "evidence of upstream rewind."
+
+**Second diagnostic shifted the story.** The second session's reflog showed the same `forced-update` line. Two independent reflogs reporting the same forced-update line, but neither showed an outgoing push from the same clone, made the picture clearer: something *outside* both clones rewound origin.
+
+**The `-spike` clone diagnostic confirmed the source.** Its reflog showed `943923a refs/remotes/origin/development@{2026-04-25 23:07:07 -0400}: update by push` — an outgoing push from that clone, target development. That's the smoking gun.
+
+**Total diagnostic time:** ~30-45 minutes from first surfacing the 38-file diff to confirming the `-spike` clone as source. Not unreasonable but could have been faster if the strategy partner had jumped to the multi-clone hypothesis earlier.
+
+**What helped:**
+
+- `git reflog show --all --date=iso` was the single most valuable command. The phrase `fetch origin: forced-update` distinguishes "this clone observed a rewind" from "this clone caused one."
+- `git branch -a -v` showing `development [ahead 11]` proved the clean clone had a recovery anchor.
+- The `-spike` clone's separate reflog with the outgoing push at the matching timestamp was independent confirmation.
+
+**What slowed things down:**
+
+- Bash history checks were fruitless. Claude Code's Bash tool runs in a non-interactive shell that doesn't write to interactive `$HISTFILE`. In future incidents, skip bash history; go straight to reflog.
+- Multi-clone topology was a missing piece of context. Earlier orientation would have surfaced this faster.
+- GitHub PR `baseRefOid` cache delays. After restore, PRs #83 and #85 still showed bloated diffs against the rewound base SHA. Resolved via `gh pr edit --base main` and back to `--base development` to force recompute.
+
+### B3. Recovery procedure assessment
+
+**The procedure that worked:**
+
+```
+git push origin development:development --force-with-lease=development:943923a
+```
+
+The `--force-with-lease=<branch>:<expected-sha>` form (with explicit SHA) was less intuitive than the bare `--force-with-lease` but the explicitness was exactly right. Pinning to `943923a` ensured the push could only succeed if origin was in the rewound state we'd diagnosed, not some intermediate state if a third writer had jumped in. **Lease check held; restore succeeded first try.**
+
+**Why it worked from this clone specifically:**
+
+The cleared-orchestrator session's clone had local `development` at `14ea24e` (the pre-rewind HEAD). It was the only place a branch ref still pointed to that SHA. Without it, recovery would have required cherry-picking through orphaned merge commit SHAs from the GitHub side, much more involved.
+
+**Worth keeping as a pattern:** *destructive recovery operations should always include lease/precondition checks against the diagnosed state, so they fail safely if reality has shifted between diagnosis and action.*
+
+### B4. Defensive layers analysis
+
+The incident exposed which layers were and weren't load-bearing.
+
+**Layers that existed but didn't help:**
+
+- *Verbal halt-before-merge.* Held for `gh pr merge --auto` but didn't extend to `git push --all`. The verbal rule covered what it explicitly said; everything else was open.
+- *Branch protection on development.* Did not exist at incident time. `#50` in bootstrap epic tracked the gap as "known unknown"; this incident materialized it as actual data loss.
+- *Conversation/agent ID surfacing.* Wouldn't have helped — the issue was concurrency between sessions, not single-session bad behavior.
+
+**Layers that mitigated impact:**
+
+- *Multi-clone redundancy (accidentally).* The cleared-orchestrator session's clone retained `14ea24e` on local `development`. Without that backup, recovery would have been much harder. This is a property of having multiple clones, not a deliberate safeguard.
+- *Read-only diagnostic protocol.* The strategy partner's instinct to gather data before taking action prevented additional damage. The HALT-IMMEDIATELY-and-investigate sequence was the right shape.
+- *`--force-with-lease` with explicit SHA.* The recovery push was safe even under ongoing uncertainty.
+
+**Layers added during recovery:**
+
+- Branch protection on `development` with `allow_force_pushes=false`, `allow_deletions=false`, `required_conversation_resolution=true`. Active before PR #85 was merged. The exact failure mode that caused the incident is now mechanically rejected at the GitHub API layer.
+
+**Layer still needed:**
+
+- Branch protection on `main`. Same shape, not yet applied.
+- Tightened `issue-worker.md` push discipline (see B5).
+- Pre-push check for `push.default = matching`.
+
+### B5. Issues to file (formal action items)
+
+Two issues identified earlier this session as "to file" but ended up not being filed (drafts existed in a backlog-manager invocation that was never approved). Both should be filed in a fresh session.
+
+**Issue 1: Bump #50 priority + cite 2026-04-26 incident as materialized risk**
+
+Brief: Issue #50 (branch protection on `development`) was a known gap in the bootstrap epic. The 2026-04-26 incident materialized this gap as actual data loss. Recovery succeeded via cross-clone restore. Branch protection has now been manually applied to `development`; #50 should be bumped to `priority:p0`, body updated with a `## Materialized risk` section citing the incident, and a one-line note that protection is now applied (verifiable via `gh api /repos/warlordofmars/agentcore-starter/branches/development/protection`). Status flips to ready-for-close pending verification.
+
+**Issue 2: Tighten `issue-worker.md` to forbid wholesale pushes**
+
+Title shape: *"Tighten issue-worker.md push discipline (forbid wholesale pushes, require explicit refspecs)"*
+
+Labels: enhancement, priority:p0, size:s, status:design-needed, dx, documentation. Milestone: chat-app-ready.
+
+Body covers:
+- Context: 2026-04-26 force-push incident; bash history not recoverable so the rule must forbid the *category* of dangerous operations, not specific commands.
+- Mechanical rules to add:
+    - Allowlist of valid push targets (current feature branch only).
+    - Prohibition on `git push --all`, `git push --mirror`, and any push without an explicit `<branch>:<branch>` refspec.
+    - Prohibition on bare `git push` (the default-upstream behavior is too easy to misfire on a stale branch).
+    - Required pre-fetch before any branch operation; verify local branch is fast-forwarded to origin.
+    - Pre-push verification: `git config --get push.default` must be `simple` or `current` (refuse to push if `matching`).
+    - Pre-push verification: local branches *not currently checked out* must not be drifted from origin (stale-clone signal); halt and surface if so.
+- Acceptance criteria:
+    - All five rules expressed as mechanical pattern-matches against command strings or git config values, not behavioral hedges.
+    - CLAUDE.md PR workflow section cross-references the new rules.
+    - After merge, the next agent-safe issue-worker run validates no false-positive halts under the new constraints.
+- Notes: NOT agent-safe (modifies an agent definition). Same human-review policy as #59 / #82. Branch protection on `development` is the load-bearing mechanical defense; this issue adds a second layer at the agent level. Both layers needed because branch protection only catches what reaches the protected branch — agent-level rules catch dangerous categories before they reach origin at all.
+
+**Additional issues identified but lower priority:**
+
+**Issue 3 (P2/P3): Tighten `check_agent_safe_scope.py` edge cases**
+
+Title: *"Tighten check_agent_safe_scope.py edge cases (bare top-level paths + taxonomy ground-truthing)"*
+
+Covers:
+- Finding 2 from PR #83 review: bare-path tokenization in `parse_files_to_touch()` drops top-level files without slashes (e.g. `pyproject.toml`, `tasks.py`). Fix: extend the allowed top-level set, or relax the `looks_like_path` heuristic, or document that bare top-level paths must be backticked.
+- Finding 3 (partial): `BOUNDED_AREA_GLOBS` and `META_AREAS` are forward-looking, not derived from live label state. The forward-looking comment was added in commit `b51f28b`; ground-truthing the maps against live labels is the deferred work.
+
+Labels: enhancement, priority:p3, size:s, status:design-needed, dx, documentation.
+
+**Issue 4 (P1): Branch protection on `main`**
+
+Title: *"Apply branch protection to main (parity with development)"*
+
+Body: `main` is the release branch. Currently has no branch protection. After the 2026-04-26 incident, `development` got `allow_force_pushes=false`, `allow_deletions=false`, `required_conversation_resolution=true`. `main` should get the same treatment — release branches should be at least as protected as development.
+
+Trivial implementation: same `gh api -X PUT` call with `main` substituted for `development`. Single command, no design-review needed. Could be agent-safe if scoped tight; or just done manually.
+
+Labels: chore, priority:p1, size:xs, status:ready, dx.
+
+**Issue 5: Standardize on a single canonical clone, or document clone-hygiene rules**
+
+The `-spike` clone was originally created for issue #17 (AgentCore Runtime spike) and kept around past its purpose. Stale baseline plus reuse for unrelated work made it a force-rewind weapon. Worth either:
+
+- Decommissioning purpose-specific clones after their original work merges (procedural rule).
+- Adding a session-start hook in `issue-worker.md` that refuses to operate if the clone's local branches are >N commits behind their origin counterparts (mechanical).
+- Standardizing on a single canonical clone per repo (organizational).
+
+Labels: enhancement, priority:p2, size:m, status:design-needed, dx, documentation. Milestone: chat-app-ready.
+
+---
+
+## Part C — PR #85 / #83 execution retro
+
+### C1. Phase-shape effectiveness for #85
+
+The three-phase shape (Phase A sketch → Phase B drafts → Phase C PR open, all human-gated) was the right design. Four observations:
+
+**Phase A halt prevented Phase B disaster.** The Phase A review caught three structural issues (16-H2 explosion, AC3 candidate creating circular dependency, ADR-shape break with unjustified Findings section) that would have shipped into the agent file if Phase B had drafted from the unrevised sketch. Phase A's value comes from being *cheap to revise* — pure prose, no diffs, no commits. The phase-shape reliability holds.
+
+**Phase B caught issue-number errors.** During Phase B review, the agent's draft cited `#71/#80/#82` as the AC3 validators for path-4 close on epic #62 (correct citation: `#81` alone). Source of the error: `#81`'s own body (filed in a previous session) incorrectly claimed `#20` is `agent-safe`; the orchestrator faithfully copied that error into the agent file. Compounding error: three other issues mis-numbered. Without verification at *every* reference point, the wrong citations would have shipped into a load-bearing agent file.
+
+**Phase C surface-format gap.** The Phase C self-report on PR #85 said "three in-scope files modified" — but the actual PR had 38 files (force-push damage). The agent's self-report wasn't a check against GitHub state. The gap got caught reactively. Adding "diff stats vs expected scope" as a mandatory line in halt-before-merge surface output would close this.
+
+**No phase felt unnecessary in retrospect.** Even Phase C, which would normally be the cheapest halt, was where the catastrophic state surfaced. The protocol earned all three.
+
+### C2. Issue-worker autonomous cycle effectiveness for #83
+
+Mostly clean execution with one critical incident. The bounded mechanical work (script + workflow + tests) was well-suited to the issue-worker shape. The session ran ~40 minutes unattended, produced 5 in-scope files, validation PR, all 33 unit tests passing.
+
+**What went well:**
+
+- Real validation PR (#84) opened-and-closed end-to-end, demonstrating the FAIL fires before auto-merge.
+- Test matrix from issue #77 refinements (cases a–f) all implemented.
+- Universal-allowed-paths exception (CHANGELOG.md) correctly handled.
+- Clean separation: shared parser, both code-reviewer and CI workflow consume it.
+
+**What didn't go well (other than the force-push):**
+
+- Two real bugs Copilot caught that shipped into the initial implementation:
+    - Empty Files-to-touch section returned WARN (fail-open).
+    - `area:*` prefix matching was implemented but the live taxonomy uses bare names (`api`, not `area:api`). *This was actually fixed in `60d4751` before Copilot's second review, making the second-round Copilot finding a false positive against current HEAD — but the first-round implementation had the bug.*
+- One bug surfaced during thread-resolution verification that wasn't in any review: `BOUNDED_AREA_GLOBS` keyed `documentation` issues under the `docs` key. Live label is `documentation`. Issues falling through to WARN, defeating the gate. Fixed in `5331d73`.
+
+### C3. Recursive validation evidence
+
+PR #83's CI run included the `Scope check (agent-safe PRs)` job — running against its own diff. The new mechanism validated itself before merging. This is a non-trivial property to land. The check correctly:
+
+- Identified PR #83 as not-agent-safe (its linked issue #77 doesn't carry `agent-safe`).
+- Returned `PASS (skipped)` — no scope evaluation required.
+- Exit 0, CI green.
+
+If PR #83 had been agent-safe, the check would have evaluated against #77's body. Worth noting for completeness: the gate's first real load-bearing test will be on the next agent-safe PR with a real Files-to-touch section that strays.
+
+### C4. Surface-inline ambiguity recurrence at meta-level
+
+When the orchestrator session produced ADR-0007 + orchestrator.md drafts in Phase B, its first report described the diffs but pasted the actual content into tool blocks invisible to the strategy partner. The G1 protocol the agent was *literally drafting in that same session* was specifically designed to prevent this failure mode.
+
+The agent re-surfaced cleanly on the second prompt, but the recurrence suggests `surface-inline` needs a stronger mechanical handle than verbal definition. Worth folding into the next orchestrator-revision pass: a worked counter-example in G1 itself ("if your report references a tool block, you have NOT surfaced inline").
+
+### C5. Copilot vs strategy-partner review division of labor
+
+Two complementary review layers. Different signals, different noise profiles.
+
+**Copilot review on #83 was 8/9 noise.** Of 9 threads:
+- 6 were stale (pre-rebase content)
+- 1 was a false positive (already-fixed)
+- 1 was actually-actionable (Thread #2, fail-open hole)
+- 1 was deferrable to a follow-up (Thread #3, retrigger)
+
+Net: 1 actionable signal out of 9. **Copilot's bar for thread filing is low**, but it found the fail-open hole that the strategy partner missed.
+
+**Strategy-partner review on Phase B drafts caught structural issues.** 16-H2 explosion, AC3 candidate circular dependency, ADR-shape break, multiple issue-number errors, contradictory table wording, G9/G10 H2 ambiguity. Different category of finding — structure and consistency — that Copilot wasn't surfacing because Copilot operates on diffs, not structural fit.
+
+**Conclusion:** *neither layer is a substitute for the other.* Copilot reviews catch local code bugs; strategy-partner reviews catch structural and consistency issues. Both needed for high-stakes PRs. Worth being explicit in protocol design about the distinct roles.
+
+### C6. Additive-scope-during-fix-commit handling
+
+When the agent surfaced the `documentation` label mismatch as an additional finding during thread-resolution verification, the right response was bundling-with-explicit-acknowledgment (Option 1.5), not strict scope discipline (Option 2 — defer to follow-up).
+
+**Why bundling was right here:**
+
+- Same shape of bug as the original Thread #1 (script keys vs live taxonomy).
+- Small enough fix that filing a separate issue + opening a separate PR + reviewing + merging would be more overhead than the fix itself.
+- The "stop and surface before scope-expanding" pattern from #77's escape-hatch policy already happened — the agent halted and flagged the discovery before applying.
+- Acknowledging in commit message + PR comment kept the audit trail honest.
+
+**Pattern worth codifying:** *additive scope expansions during fix commits are acceptable IF the agent halts and surfaces the discovery first AND the additive change is documented in commit message + PR comment.* This is a more permissive reading than strict scope discipline but matches #77's escape-hatch intent.
+
+---
+
+## Synthesis
+
+### Cross-cutting observations
+
+1. **Mechanical defenses beat verbal hedges, every time.** Branch protection on `development` would have prevented the force-push incident regardless of any agent's behavior. The verbal `halt-before-merge` instruction held for what it covered (`gh pr merge --auto`) but didn't extend to the unfenced surface (`git push`). Where both verbal and mechanical defenses are available for the same risk, the mechanical one is load-bearing.
+
+2. **Defensive layers should be non-overlapping.** Multiple errors were caught this session by mechanisms that operated on different signals — Copilot's diff review, strategy partner's structural review, project-instructions reflex rules, the human's pattern recognition on file counts. Each layer caught a different error. No single rule is sufficient. Defense-in-depth is the design principle, not the fallback.
+
+3. **Issue numbers from memory are unreliable; live verification is cheap.** The single most consequential save of the session was the project-instructions rule "always run `gh issue view` before citing." Without it, wrong issue numbers would have shipped into a load-bearing agent file. The cost is one tool call; the benefit is preventing entire papercut compounding chains.
+
+4. **Multi-session/multi-clone topology shapes everything.** The force-push incident was fundamentally a concurrency problem between sessions with no mutual awareness. The recovery was possible because of accidental redundancy (multiple clones). Future protocol design needs to account for this rather than assume single-clone, single-session execution.
+
+5. **The phase-shape protocol earns its cost.** The three-phase halt-before-merge protocol on PR #85 caught three substantive structural issues at Phase A (cheapest halt) and several issue-number errors at Phase B (still cheap). Without these halts, the work would have shipped into the agent file with errors. The phases that "felt unnecessary" turned out not to be.
+
+### Action items by urgency
+
+**P0 — File or apply this week:**
+
+1. **File issue: bump #50 priority + cite 2026-04-26 incident.** Verify branch protection now applied. Status flips to ready-for-close.
+2. **File issue: tighten `issue-worker.md` push discipline.** Body draft in Part B above.
+3. **Apply branch protection on `main`.** Single `gh api -X PUT` command, same JSON as `development`.
+
+**P1 — File this week:**
+
+4. **File issue: tighten `check_agent_safe_scope.py` edge cases** (bare top-level paths + taxonomy ground-truthing).
+
+**P2 — File next week or as part of broader retro:**
+
+5. **File issue: clone-hygiene rules** (decommission per-spike clones, or pre-push staleness check).
+6. **Update project instructions** with edits A2.1–A2.5.
+
+**P3 — Folded into next orchestrator-revision pass:**
+
+7. **G16+ candidates from this session:** add a worked counter-example to G1 about tool blocks vs `surface-inline`; add diff-size sanity check to halt-before-merge surface format; consider explicit cross-session concurrency rule.
+
+### What this session validated
+
+- The orchestrator codification (PR #85) is now live. G1–G11 protocols active.
+- The mechanical scope-boundary check (PR #83) is now live. G6's deferred slot is closed.
+- Branch protection on `development` is now active. The exact failure mode that almost wiped 11 merges is mechanically rejected at the GitHub layer.
+- The phased halt-before-merge protocol fired correctly on its inaugural use (#85's own merge) and again on its second invocation (#83's merge).
+- Multi-session strategic coordination (orchestrator session + 4a issue-worker session + 4b human-driven session + parallel backlog-manager invocations) can produce coherent work — even when one of the sessions causes a force-push incident — provided the strategy-partner role surfaces and resolves issues before they compound.
+
+---
+
+*Retro produced from forensic data across three Claude Code sessions plus the strategy-partner conversation. Inputs: cleared-orchestrator session forensic, `-spike` 4a session forensic, merge-cycle session forensic. Synthesis by strategy partner.*

--- a/docs/retros/README.md
+++ b/docs/retros/README.md
@@ -1,0 +1,9 @@
+# Retros
+
+Post-session retrospectives for major work pushes. Each retro captures observations, decisions, and follow-up items in a format suitable for long-arc reference.
+
+## Index
+
+| Date | Title | Summary |
+|---|---|---|
+| 2026-04-26 | [Strategy session retro](2026-04-26-strategy-session.md) | Force-push incident recovery + PR #85/#83 merges + 18 strategy-partner observations across three threads |

--- a/docs/retros/README.md
+++ b/docs/retros/README.md
@@ -6,4 +6,4 @@ Post-session retrospectives for major work pushes. Each retro captures observati
 
 | Date | Title | Summary |
 |---|---|---|
-| 2026-04-26 | [Strategy session retro](2026-04-26-strategy-session.md) | Force-push incident recovery + PR #85/#83 merges + 18 strategy-partner observations across three threads |
+| 2026-04-26 | [Strategy session retro](2026-04-26-strategy-session-retro.md) | Force-push incident recovery + PR #85/#83 merges + 18 strategy-partner observations across three threads |


### PR DESCRIPTION
Captures the strategy-partner session that landed PRs #85 and #83, diagnosed and recovered from a force-push incident on origin/development, and surfaced 18 strategy-partner observations across three threads (strategy-partner role evolution, force-push incident, PR execution).

Action items folded into #50 (priority bump + materialized-risk citation),

## Summary

<!-- What does this PR do? Why? -->

## Changes

<!-- Bullet list of notable changes -->

## Test plan

- [ ] `uv run inv pre-push` passes locally
- [ ] New behaviour covered by tests
- [ ] Coverage remains at 100%

## Checklist

- [ ] PR title is descriptive
- [ ] Closes #<!-- issue number -->
- [ ] Docs updated if behaviour changed
- [ ] No secrets or credentials committed
