### PR TITLE
ci: re-evaluate agent-safe scope check when linked issue labels change

### DIFF
--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -140,13 +140,16 @@ jobs:
                 echo "PR #$PR_NUM scope check re-dispatched successfully."
               else
                 # Keep the workflow-command annotation single-line and
-                # free of untrusted content. `gh` error output can contain
-                # newlines or `::` sequences that would break the
-                # annotation or enable workflow-command injection — emit
-                # the dispatch output on a separate plain-echo line.
+                # free of untrusted content. GitHub Actions parses `::`
+                # workflow commands from any log line, not just
+                # annotation lines, so embedding raw `gh` error output
+                # (which may contain `::` sequences or newlines) would
+                # both break the annotation and enable workflow-command
+                # injection. Indent each output line by two spaces so any
+                # leading `::` cannot be parsed as a workflow command.
                 echo "::warning::PR #$PR_NUM (head: $HEAD_REF) scope check dispatch failed; skipping."
-                echo "Dispatch output:"
-                printf '%s\n' "$DISPATCH_OUTPUT"
+                echo "Dispatch output (sanitised — leading whitespace prevents workflow-command parsing):"
+                printf '%s\n' "$DISPATCH_OUTPUT" | sed 's/\r$//; s/^/  /'
               fi
             else
               echo "PR #$PR_NUM mentions $ISSUE_NUMBER but no closing-keyword link — skipping."

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -78,7 +78,6 @@ jobs:
           # like `#1234`.
           REGEX="(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#${ISSUE_NUMBER}([^0-9]|$)"
 
-          MATCHED=0
           # `jq -c` emits one compact JSON object per line for the bash loop.
           echo "$CANDIDATES" | jq -c '.[]' | while IFS= read -r pr; do
             PR_NUM=$(echo "$pr" | jq -r '.number')
@@ -90,10 +89,13 @@ jobs:
               # Re-dispatch against the PR's head ref so the resulting check
               # status updates the right commit. Cross-workflow dispatch
               # within the same repo works with the default GITHUB_TOKEN.
+              # Same-repo PRs only — the agent-safe path does not accept
+              # fork contributions today; if that changes, switch the ref
+              # to the PR's base branch and have the dispatched workflow
+              # post its check status on the head SHA explicitly.
               gh workflow run agent-safe-scope.yml \
                 --ref "$HEAD_REF" \
                 -f pr_number="$PR_NUM"
-              MATCHED=$((MATCHED + 1))
             else
               echo "PR #$PR_NUM mentions $ISSUE_NUMBER but no closing-keyword link — skipping."
             fi

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -1,7 +1,7 @@
 name: agent-safe scope check (issue retrigger)
 
 # Re-evaluate the agent-safe scope check on open PRs when their linked
-# issue's labels or body change (issue #88).
+# issue's labels change (issue #88).
 #
 # The primary `agent-safe-scope.yml` workflow only fires on `pull_request`
 # events, so a label edit on the linked **issue** (e.g. stripping `api`
@@ -19,7 +19,11 @@ name: agent-safe scope check (issue retrigger)
 
 on:
   issues:
-    types: [labeled, unlabeled, edited]
+    # Per #88's scoped AC, retrigger only on label changes. The `edited`
+    # trigger (body/title edits) is called out as a separate follow-up in
+    # #88's "Out of scope" section — file a new issue if body-driven
+    # retrigger is needed.
+    types: [labeled, unlabeled]
 
 permissions:
   issues: read
@@ -101,10 +105,19 @@ jobs:
             HEAD_REF=$(echo "$pr" | jq -r '.headRefName')
             BODY=$(echo "$pr" | jq -r '.body')
 
+            # Normalise CR/LF to spaces so `Closes:\n#88`-style references
+            # (keyword and number on different lines) are treated the same
+            # as on a single line. `grep` is line-mode by default and
+            # cannot otherwise match across newlines, but the scope-check
+            # script (`scripts/check_agent_safe_scope.py`) uses Python
+            # `re` with `\s+` which does — keep the two link-detection
+            # paths consistent.
+            NORMALISED_BODY=$(printf '%s' "$BODY" | tr '\r\n' '  ')
+
             # `printf '%s'` instead of `echo` so PR bodies starting with
             # `-n` / `-e` (or containing escape sequences echo would
             # interpret) are passed verbatim to grep.
-            if printf '%s' "$BODY" | grep -qiE "$REGEX"; then
+            if printf '%s' "$NORMALISED_BODY" | grep -qiE "$REGEX"; then
               echo "PR #$PR_NUM (head: $HEAD_REF) links issue #$ISSUE_NUMBER — re-dispatching scope check."
               # Re-dispatch against the PR's head ref so the resulting check
               # status updates the right commit. Cross-workflow dispatch

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Find open PRs linked to this issue and re-dispatch scope check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # `gh` does not auto-read `GITHUB_REPOSITORY`; without `GH_REPO`
+          # (or `--repo` / a checked-out repo) every `gh` call below fails
+          # with "no repository context found". This step does not check
+          # the repo out, so `GH_REPO` is required.
+          # See https://github.com/cli/cli/issues/3556.
+          GH_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
@@ -44,16 +50,22 @@ jobs:
 
           # `gh pr list --search` uses GitHub's PR search index — same source
           # backlinks use, cheaper than walking the issue Timeline API.
-          # `<N> in:body is:open is:pr` returns candidate open PRs whose
-          # body mentions the bare issue number; the closing-keyword regex
-          # below then filters to PRs that actually link the issue (not
-          # just mention it in passing). `--limit 1000` is a generous
-          # ceiling well above this repo's normal PR backlog so the regex
-          # filter sees effectively all candidates rather than silently
-          # truncating after the default page size.
+          # `<N> in:title,body is:open is:pr` returns candidate open PRs
+          # whose title or body mentions the bare issue number; the
+          # closing-keyword regex below then filters to PRs that actually
+          # link the issue (not just mention it in passing). Searching
+          # title+body matches `scripts/check_agent_safe_scope.py`, which
+          # detects closing keywords in both title and body — keeping the
+          # two link-detection paths consistent. `--limit 1000` is a
+          # generous ceiling well above this repo's normal PR backlog so
+          # the regex filter sees effectively all candidates rather than
+          # silently truncating after the default page size.
+          # `jq` folds title into body so the downstream regex evaluates
+          # title+body together without needing two separate match passes.
           CANDIDATES=$(gh pr list \
-            --search "$ISSUE_NUMBER in:body is:open is:pr" \
-            --json number,headRefName,body \
+            --search "$ISSUE_NUMBER in:title,body is:open is:pr" \
+            --json number,headRefName,title,body \
+            --jq 'map(.body = ((.title // "") + "\n" + (.body // "")))' \
             --limit 1000)
 
           # No-match is a no-op (common case — most issue label edits don't
@@ -70,15 +82,18 @@ jobs:
           # Match GitHub's three recognised closing keywords (Closes, Fixes,
           # Resolves) case-insensitively, with an optional `:` between the
           # keyword and the `#` (matches GitHub's own closing-keyword
-          # parser, which accepts `Closes: #123`). Per the issue #88 design
-          # decision this is the authoritative regex for retrigger
-          # discovery; `scripts/check_agent_safe_scope.py` uses a slightly
-          # narrower variant (no colon) which is fine — the script only
-          # needs to find the link going the other direction (PR -> issue)
-          # and the project convention is bare `Closes #N`. The trailing
+          # parser, which accepts `Closes: #123`). The leading
+          # `(^|[^[:alnum:]_])` requires a word boundary before the keyword
+          # so longer words like `discloses #88` do not produce false
+          # positives. Per the issue #88 design decision this is the
+          # authoritative regex for retrigger discovery;
+          # `scripts/check_agent_safe_scope.py` uses a slightly narrower
+          # variant (no colon) which is fine — the script only needs to
+          # find the link going the other direction (PR -> issue) and the
+          # project convention is bare `Closes #N`. The trailing
           # `([^0-9]|$)` prevents `#123` from matching a longer number
           # like `#1234`.
-          REGEX="(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#${ISSUE_NUMBER}([^0-9]|$)"
+          REGEX="(^|[^[:alnum:]_])(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#${ISSUE_NUMBER}([^0-9]|$)"
 
           # `jq -c` emits one compact JSON object per line for the bash loop.
           echo "$CANDIDATES" | jq -c '.[]' | while IFS= read -r pr; do

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -45,14 +45,17 @@ jobs:
 
           # `gh pr list --search` uses GitHub's PR search index — same source
           # backlinks use, cheaper than walking the issue Timeline API.
-          # `<N> in:body is:open is:pr` returns every open PR whose body
-          # mentions the bare issue number; the closing-keyword regex below
-          # then filters to PRs that actually link the issue (not just
-          # mention it in passing).
+          # `<N> in:body is:open is:pr` returns candidate open PRs whose
+          # body mentions the bare issue number; the closing-keyword regex
+          # below then filters to PRs that actually link the issue (not
+          # just mention it in passing). `--limit 1000` is a generous
+          # ceiling well above this repo's normal PR backlog so the regex
+          # filter sees effectively all candidates rather than silently
+          # truncating after the default page size.
           CANDIDATES=$(gh pr list \
             --search "$ISSUE_NUMBER in:body is:open is:pr" \
             --json number,headRefName,body \
-            --limit 50)
+            --limit 1000)
 
           # No-match is a no-op (common case — most issue label edits don't
           # have a live PR attached). Exit cleanly so the workflow run

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -139,7 +139,14 @@ jobs:
                 -f pr_number="$PR_NUM" 2>&1); then
                 echo "PR #$PR_NUM scope check re-dispatched successfully."
               else
-                echo "::warning::PR #$PR_NUM (head: $HEAD_REF) scope check dispatch failed; skipping. ${DISPATCH_OUTPUT}"
+                # Keep the workflow-command annotation single-line and
+                # free of untrusted content. `gh` error output can contain
+                # newlines or `::` sequences that would break the
+                # annotation or enable workflow-command injection — emit
+                # the dispatch output on a separate plain-echo line.
+                echo "::warning::PR #$PR_NUM (head: $HEAD_REF) scope check dispatch failed; skipping."
+                echo "Dispatch output:"
+                printf '%s\n' "$DISPATCH_OUTPUT"
               fi
             else
               echo "PR #$PR_NUM mentions $ISSUE_NUMBER but no closing-keyword link — skipping."

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -1,0 +1,102 @@
+name: agent-safe scope check (issue retrigger)
+
+# Re-evaluate the agent-safe scope check on open PRs when their linked
+# issue's labels or body change (issue #88).
+#
+# The primary `agent-safe-scope.yml` workflow only fires on `pull_request`
+# events, so a label edit on the linked **issue** (e.g. stripping `area:api`
+# from the scope) leaves the PR's last evaluation stale until the next push.
+# This workflow closes that gap: it discovers open PRs whose body references
+# the changed issue via a `Closes #<N>` / `Fixes #<N>` / `Resolves #<N>`
+# marker (case-insensitive, optional `:` and `#`) and re-dispatches the
+# scope-check workflow against each match's head ref. Branch protection
+# then sees a fresh result on the same head SHA without needing a new
+# commit on the PR branch.
+#
+# Design rationale: see issue #88 §"Design decisions" comment for the
+# tradeoff analysis (workflow re-dispatch vs. status-check refresh) and the
+# choice of `gh pr list --search` for PR discovery.
+
+on:
+  issues:
+    types: [labeled, unlabeled, edited]
+
+permissions:
+  issues: read
+  pull-requests: read
+  # Required to call `gh workflow run` against `agent-safe-scope.yml` —
+  # cross-workflow dispatch needs `actions: write` even within the same repo.
+  actions: write
+
+jobs:
+  retrigger-scope-check:
+    name: Re-dispatch scope check on linked PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find open PRs linked to this issue and re-dispatch scope check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          echo "Issue #$ISSUE_NUMBER changed; searching for linked open PRs."
+
+          # `gh pr list --search` uses GitHub's PR search index — same source
+          # backlinks use, cheaper than walking the issue Timeline API.
+          # `<N> in:body is:open is:pr` returns every open PR whose body
+          # mentions the bare issue number; the closing-keyword regex below
+          # then filters to PRs that actually link the issue (not just
+          # mention it in passing).
+          CANDIDATES=$(gh pr list \
+            --search "$ISSUE_NUMBER in:body is:open is:pr" \
+            --json number,headRefName,body \
+            --limit 50)
+
+          # No-match is a no-op (common case — most issue label edits don't
+          # have a live PR attached). Exit cleanly so the workflow run
+          # surfaces a green check.
+          COUNT=$(echo "$CANDIDATES" | jq 'length')
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::notice::No open PRs reference issue #$ISSUE_NUMBER — nothing to re-dispatch."
+            exit 0
+          fi
+
+          echo "Search returned $COUNT candidate PR(s); filtering by closing-keyword regex."
+
+          # Match GitHub's three recognised closing keywords (Closes, Fixes,
+          # Resolves) case-insensitively, with an optional `:` between the
+          # keyword and the `#` (matches GitHub's own closing-keyword
+          # parser, which accepts `Closes: #123`). Per the issue #88 design
+          # decision this is the authoritative regex for retrigger
+          # discovery; `scripts/check_agent_safe_scope.py` uses a slightly
+          # narrower variant (no colon) which is fine — the script only
+          # needs to find the link going the other direction (PR -> issue)
+          # and the project convention is bare `Closes #N`. The trailing
+          # `([^0-9]|$)` prevents `#123` from matching a longer number
+          # like `#1234`.
+          REGEX="(closes|fixes|resolves)[[:space:]]*:?[[:space:]]*#${ISSUE_NUMBER}([^0-9]|$)"
+
+          MATCHED=0
+          # `jq -c` emits one compact JSON object per line for the bash loop.
+          echo "$CANDIDATES" | jq -c '.[]' | while IFS= read -r pr; do
+            PR_NUM=$(echo "$pr" | jq -r '.number')
+            HEAD_REF=$(echo "$pr" | jq -r '.headRefName')
+            BODY=$(echo "$pr" | jq -r '.body')
+
+            if echo "$BODY" | grep -qiE "$REGEX"; then
+              echo "PR #$PR_NUM (head: $HEAD_REF) links issue #$ISSUE_NUMBER — re-dispatching scope check."
+              # Re-dispatch against the PR's head ref so the resulting check
+              # status updates the right commit. Cross-workflow dispatch
+              # within the same repo works with the default GITHUB_TOKEN.
+              gh workflow run agent-safe-scope.yml \
+                --ref "$HEAD_REF" \
+                -f pr_number="$PR_NUM"
+              MATCHED=$((MATCHED + 1))
+            else
+              echo "PR #$PR_NUM mentions $ISSUE_NUMBER but no closing-keyword link — skipping."
+            fi
+          done
+
+          echo "::notice::Issue #$ISSUE_NUMBER retrigger sweep complete."

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -4,14 +4,14 @@ name: agent-safe scope check (issue retrigger)
 # issue's labels or body change (issue #88).
 #
 # The primary `agent-safe-scope.yml` workflow only fires on `pull_request`
-# events, so a label edit on the linked **issue** (e.g. stripping `area:api`
+# events, so a label edit on the linked **issue** (e.g. stripping `api`
 # from the scope) leaves the PR's last evaluation stale until the next push.
 # This workflow closes that gap: it discovers open PRs whose body references
 # the changed issue via a `Closes #<N>` / `Fixes #<N>` / `Resolves #<N>`
-# marker (case-insensitive, optional `:` and `#`) and re-dispatches the
-# scope-check workflow against each match's head ref. Branch protection
-# then sees a fresh result on the same head SHA without needing a new
-# commit on the PR branch.
+# marker (case-insensitive, optional `:` between the keyword and the `#`)
+# and re-dispatches the scope-check workflow against each match's head ref.
+# Branch protection then sees a fresh result on the same head SHA without
+# needing a new commit on the PR branch.
 #
 # Design rationale: see issue #88 §"Design decisions" comment for the
 # tradeoff analysis (workflow re-dispatch vs. status-check refresh) and the
@@ -36,7 +36,6 @@ jobs:
       - name: Find open PRs linked to this issue and re-dispatch scope check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail

--- a/.github/workflows/agent-safe-scope-issue-retrigger.yml
+++ b/.github/workflows/agent-safe-scope-issue-retrigger.yml
@@ -86,7 +86,10 @@ jobs:
             HEAD_REF=$(echo "$pr" | jq -r '.headRefName')
             BODY=$(echo "$pr" | jq -r '.body')
 
-            if echo "$BODY" | grep -qiE "$REGEX"; then
+            # `printf '%s'` instead of `echo` so PR bodies starting with
+            # `-n` / `-e` (or containing escape sequences echo would
+            # interpret) are passed verbatim to grep.
+            if printf '%s' "$BODY" | grep -qiE "$REGEX"; then
               echo "PR #$PR_NUM (head: $HEAD_REF) links issue #$ISSUE_NUMBER — re-dispatching scope check."
               # Re-dispatch against the PR's head ref so the resulting check
               # status updates the right commit. Cross-workflow dispatch
@@ -95,9 +98,21 @@ jobs:
               # fork contributions today; if that changes, switch the ref
               # to the PR's base branch and have the dispatched workflow
               # post its check status on the head SHA explicitly.
-              gh workflow run agent-safe-scope.yml \
+              #
+              # Dispatch can fail when the PR's head branch predates the
+              # `workflow_dispatch` trigger being added to
+              # `agent-safe-scope.yml` (older PRs that haven't merged or
+              # rebased the base branch since). Catch the per-PR failure
+              # and emit a warning so one stale branch doesn't fail the
+              # whole sweep — the scope evaluation will simply remain
+              # stale on that PR until it next pushes a commit.
+              if DISPATCH_OUTPUT=$(gh workflow run agent-safe-scope.yml \
                 --ref "$HEAD_REF" \
-                -f pr_number="$PR_NUM"
+                -f pr_number="$PR_NUM" 2>&1); then
+                echo "PR #$PR_NUM scope check re-dispatched successfully."
+              else
+                echo "::warning::PR #$PR_NUM (head: $HEAD_REF) scope check dispatch failed; skipping. ${DISPATCH_OUTPUT}"
+              fi
             else
               echo "PR #$PR_NUM mentions $ISSUE_NUMBER but no closing-keyword link — skipping."
             fi

--- a/.github/workflows/agent-safe-scope.yml
+++ b/.github/workflows/agent-safe-scope.yml
@@ -31,11 +31,13 @@ name: agent-safe scope check
 on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, edited]
-  # Issue label / body changes can invalidate a previously-passing scope
+  # Issue label changes can invalidate a previously-passing scope
   # evaluation without any new commits hitting the PR's head branch
   # (issue #88). The companion workflow `agent-safe-scope-issue-retrigger.yml`
-  # discovers PRs linked to a changed issue and re-dispatches this workflow
-  # against each PR's head ref so branch protection sees a fresh result.
+  # discovers PRs linked to an issue whose labels changed and re-dispatches
+  # this workflow against each PR's head ref so branch protection sees a
+  # fresh result. (Issue body/title edits are out of scope for #88; file a
+  # follow-up if body-driven retrigger is needed.)
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/agent-safe-scope.yml
+++ b/.github/workflows/agent-safe-scope.yml
@@ -31,6 +31,17 @@ name: agent-safe scope check
 on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, edited]
+  # Issue label / body changes can invalidate a previously-passing scope
+  # evaluation without any new commits hitting the PR's head branch
+  # (issue #88). The companion workflow `agent-safe-scope-issue-retrigger.yml`
+  # discovers PRs linked to a changed issue and re-dispatches this workflow
+  # against each PR's head ref so branch protection sees a fresh result.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to re-evaluate (required when dispatched manually or by the issue-retrigger workflow)."
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -51,7 +62,10 @@ jobs:
       - name: Run scope check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Resolve PR_NUMBER from whichever trigger fired. `pull_request`
+          # supplies `event.pull_request.number`; `workflow_dispatch` supplies
+          # `event.inputs.pr_number`. Exactly one is non-empty per run.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         run: |
           set -euo pipefail
           # Use uv run so the script picks up the project's Python version


### PR DESCRIPTION
Closes #88

## Summary

Adds a new GitHub Actions workflow that watches `issues: [labeled, unlabeled]` events and re-dispatches the existing `agent-safe-scope.yml` workflow against any open PRs linked to the changed issue via a `Closes`/`Fixes`/`Resolves #N` title or body marker. This closes the gap where issue label edits mid-PR left the PR's last scope evaluation stale until the next push.

## Approach

Per the locked design comment on #88 (2026-04-26):

- **Workflow re-dispatch** chosen over status-check refresh: simpler, reuses the existing scope-check workflow as the single source of truth, Actions-minutes cost is negligible for an edge-case path.
- **PR discovery via `gh pr list --search`**: same source backlinks use, cheaper than walking the issue Timeline API. Searches `in:title,body` and folds title into body via `--jq` so the closing-keyword regex evaluates both — matches `scripts/check_agent_safe_scope.py`, which also detects links from title or body. Regex matches GitHub's three closing keywords (`Closes`/`Fixes`/`Resolves`) case-insensitively, with optional `:` between the keyword and `#`, and a leading word-boundary group so longer words like `discloses #88` don't false-positive.
- **Trigger narrowed to `[labeled, unlabeled]`** per #88's "Out of scope" section — body/title edits are an explicit follow-up; file a separate issue if body-driven retrigger is needed.
- **`agent-safe-scope.yml` gains a `workflow_dispatch` trigger** with a `pr_number` input. The existing `pull_request` trigger stays. Both paths converge on the same job using `${{ github.event.pull_request.number || github.event.inputs.pr_number }}`.
- **Permissions** on the new workflow: `issues: read`, `pull-requests: read`, `actions: write` (the last is required for cross-workflow dispatch even within the same repo). Uses default `secrets.GITHUB_TOKEN`; no PAT required.
- **`GH_REPO` env var required** — `gh` does not auto-read `GITHUB_REPOSITORY`; without `GH_REPO` (or `--repo` / a checked-out repo) every `gh` call fails with "no repository context found". See https://github.com/cli/cli/issues/3556.
- **CR/LF normalised before grep** so `Closes:\n#88`-style references match consistently with the scope-check script's `\s+` regex (Python `re` matches across newlines; `grep` is line-mode by default).
- **Per-PR dispatch errors are warnings, not failures** — older PR branches whose copy of `agent-safe-scope.yml` predates the `workflow_dispatch` trigger will fail to dispatch; emit a `::warning::` so one stale branch doesn't fail the entire sweep.
- **No-match is a no-op**: if no open PRs reference the issue, the workflow exits cleanly without error.
- **Same head-ref invariant**: re-dispatched job runs against the PR's current head SHA, so the check status updates the right commit and branch protection sees a fresh result without needing a new push.

## Files changed

- `.github/workflows/agent-safe-scope.yml` — adds `workflow_dispatch` trigger with `pr_number` input; `PR_NUMBER` env var resolves from either trigger source.
- `.github/workflows/agent-safe-scope-issue-retrigger.yml` — new file. Watches issue label events, discovers linked open PRs, re-dispatches the scope check.

## Implementation notes

- Copilot pre-push review flagged that the new workflow's regex (which permits `Closes: #N` with optional colon, per the locked design spec) is more permissive than the existing `scripts/check_agent_safe_scope.py` regex (no colon). The new comment in the workflow now explicitly notes this divergence is intentional: the retrigger uses the broader GitHub-spec regex for discovery; the script uses the narrower project-convention regex (bare `Closes #N`) for resolution. Tightening the script's regex to match is out of scope for #88.

## E2e validation

**Deferred to a follow-up.** The acceptance criterion calls for an end-to-end test (open an agent-safe PR linked to a sandbox issue, change labels, observe the re-run), but executing it requires (a) an agent-safe PR currently open against `development` and (b) a sandbox issue we can flip labels on. Neither is available in this cycle. The mechanical wiring is straightforward enough that I judged it acceptable to land the workflow change and verify behaviourally on the next real agent-safe PR. Recommend the human reviewer note this on the PR before merge.

## Test plan

- [ ] CI passes on the PR branch
- [ ] After merge: on the next `agent-safe`-labelled issue with an open PR, edit a label on the issue and confirm the scope check re-runs against the PR's head SHA without a new commit