### PR TITLE
feat: tighten check_agent_safe_scope.py edge cases (closes #90)

### DIFF
--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -136,9 +136,11 @@ def parse_files_to_touch(body: str) -> list[str] | None:
     backticks fall through to a tokenisation pass that accepts a token as a
     path if it (1) consists only of path-safe characters
     (`[\\w./@\\-+]`) AND (2) either contains `/` or ends in a file
-    extension (matching `\\.\\w+$`). The path-safe character filter rejects
-    prose fragments like `(e.g.` or `done.` that would otherwise match the
-    extension regex and produce phantom paths.
+    extension whose first character is a letter (matching
+    `\\.[A-Za-z]\\w*$`). The path-safe character filter rejects prose
+    fragments like `(e.g.` or `done.`; the letter-leading extension rule
+    rejects version-like tokens like `v1.0` or `2.10` that would otherwise
+    match `\\.\\w+$` because `\\w` includes digits.
 
     Edge case: bare top-level files with no extension (e.g. `Makefile`) are
     NOT picked up by the no-backtick fallback. The canonical workaround is
@@ -198,9 +200,12 @@ def parse_files_to_touch(body: str) -> list[str] | None:
             if not re.fullmatch(r"[\w./@\-+]+", token):
                 continue
             # A token looks like a path if it contains `/` OR ends in a file
-            # extension. Tokens with no extension and no `/` (e.g. `Makefile`)
-            # are dropped — wrap them in backticks for explicit acceptance.
-            looks_like_path = "/" in token or bool(re.search(r"\.\w+$", token))
+            # extension whose first character is a letter (so version-like
+            # tokens such as `v1.0` are NOT treated as paths — those would
+            # match `\.\w+$` because `\w` includes digits). Tokens with no
+            # extension and no `/` (e.g. `Makefile`) are dropped — wrap them
+            # in backticks for explicit acceptance.
+            looks_like_path = "/" in token or bool(re.search(r"\.[A-Za-z]\w*$", token))
             if looks_like_path:
                 paths.append(token)
 

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -136,11 +136,12 @@ def parse_files_to_touch(body: str) -> list[str] | None:
     backticks fall through to a tokenisation pass that accepts a token as a
     path if it (1) consists only of path-safe characters
     (`[\\w./@\\-+]`) AND (2) either contains `/` or ends in a file
-    extension whose first character is a letter (matching
-    `\\.[A-Za-z]\\w*$`). The path-safe character filter rejects prose
-    fragments like `(e.g.` or `done.`; the letter-leading extension rule
-    rejects version-like tokens like `v1.0` or `2.10` that would otherwise
-    match `\\.\\w+$` because `\\w` includes digits.
+    extension matching `\\.[A-Za-z]\\w+$` — first char of extension must be
+    a letter, total extension length must be >= 2 chars. The path-safe
+    character filter rejects prose fragments like `(e.g.` or `done.`; the
+    letter-leading rule rejects version-like tokens like `v1.0` (`\\w`
+    includes digits); the >=2-char rule rejects single-letter remnants like
+    `e.g` (rstripped from `e.g.`).
 
     Edge case: bare top-level files with no extension (e.g. `Makefile`) are
     NOT picked up by the no-backtick fallback. The canonical workaround is
@@ -200,12 +201,17 @@ def parse_files_to_touch(body: str) -> list[str] | None:
             if not re.fullmatch(r"[\w./@\-+]+", token):
                 continue
             # A token looks like a path if it contains `/` OR ends in a file
-            # extension whose first character is a letter (so version-like
-            # tokens such as `v1.0` are NOT treated as paths — those would
-            # match `\.\w+$` because `\w` includes digits). Tokens with no
-            # extension and no `/` (e.g. `Makefile`) are dropped — wrap them
-            # in backticks for explicit acceptance.
-            looks_like_path = "/" in token or bool(re.search(r"\.[A-Za-z]\w*$", token))
+            # extension whose first character is a letter and whose total
+            # length is >= 2 characters. The letter-leading rule rejects
+            # version-like tokens such as `v1.0` (`\w` includes digits); the
+            # >=2-char rule rejects tokens like `e.g` (rstripped from
+            # `e.g.`) that would otherwise be misclassified as paths.
+            # Tokens with no extension and no `/` (e.g. `Makefile`) are
+            # dropped — wrap them in backticks for explicit acceptance.
+            # Trade-off: single-letter real extensions (`.c`, `.r`) are also
+            # rejected by the no-backtick fallback; backticks remain the
+            # canonical workaround. None exist in this repo today.
+            looks_like_path = "/" in token or bool(re.search(r"\.[A-Za-z]\w+$", token))
             if looks_like_path:
                 paths.append(token)
 

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -134,8 +134,11 @@ def parse_files_to_touch(body: str) -> list[str] | None:
     Bullets containing backtick-quoted tokens are preferred — backticks are
     the unambiguous, canonical form for path markers. Bullets without
     backticks fall through to a tokenisation pass that accepts a token as a
-    path if it either contains `/` or ends in a file extension (matching
-    `\\.\\w+$`).
+    path if it (1) consists only of path-safe characters
+    (`[\\w./@\\-+]`) AND (2) either contains `/` or ends in a file
+    extension (matching `\\.\\w+$`). The path-safe character filter rejects
+    prose fragments like `(e.g.` or `done.` that would otherwise match the
+    extension regex and produce phantom paths.
 
     Edge case: bare top-level files with no extension (e.g. `Makefile`) are
     NOT picked up by the no-backtick fallback. The canonical workaround is
@@ -181,10 +184,18 @@ def parse_files_to_touch(body: str) -> list[str] | None:
         # Tokenise the bullet on whitespace + common conjunctions/punctuation
         # so a bullet like `- Edit: src/a.py and src/b.py` produces two paths,
         # not one mashed-together string. Each token is then accepted only if
-        # it looks like a path (has a `/` or ends in a file extension).
+        # it looks like a path (has a `/` or ends in a file extension) AND
+        # consists of path-safe characters only — that filter rejects prose
+        # fragments like `(e.g.` or `done.` that would otherwise match the
+        # extension regex and produce phantom paths the diff can't satisfy.
         for raw_token in re.split(r"[\s,]+|\band\b", cleaned):
             token = raw_token.strip().rstrip(",.;")
             if not token:
+                continue
+            # Path-safe character filter: only word chars, dot, slash, hyphen,
+            # plus, at-sign, underscore (already in \w). Anything else (parens,
+            # quotes, colons, brackets) marks the token as prose, not a path.
+            if not re.fullmatch(r"[\w./@\-+]+", token):
                 continue
             # A token looks like a path if it contains `/` OR ends in a file
             # extension. Tokens with no extension and no `/` (e.g. `Makefile`)

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -52,42 +52,34 @@ from typing import Literal
 # ── Area-label → path-glob map ────────────────────────────────────────────────
 #
 # Per issue #77 refinements §"Area-label fallback specifics", only bounded
-# areas map cleanly to path globs. Meta-areas (dx, security, compliance,
-# marketing, growth, seo, design, ops, reliability, performance,
-# observability, ux, a11y) span the codebase and cannot be path-mapped —
-# their presence triggers a WARN fall-through, not a FAIL.
+# areas map cleanly to path globs. Meta-areas span the codebase and cannot be
+# path-mapped — their presence triggers a WARN fall-through, not a FAIL.
 #
-# These maps are forward-looking, NOT derived from the live label set.
-# Some entries (e.g. `mcp`, `sdk` in BOUNDED_AREA_GLOBS; most of META_AREAS)
-# are not yet live labels but are pre-mapped so a future label addition
-# doesn't silently fall through to WARN. Defensive — see follow-up issue
-# for ground-truthing the maps against the live taxonomy.
+# Both maps are ground-truthed to the live label set (issue #90). When a new
+# area label lands, refresh from the live taxonomy and extend whichever map
+# applies. Canonical refresh procedure:
+#
+#     gh api /repos/warlordofmars/agentcore-starter/labels --paginate \
+#         --jq '.[].name'
+#
+# Filter out priority:*, size:*, status:*, type labels (`bug`, `enhancement`,
+# `chore`), special labels (`agent-safe`, `epic`), and auto-injected GitHub
+# labels (`dependencies`, `python`, `javascript`, `github_actions`).
 
 BOUNDED_AREA_GLOBS: dict[str, list[str]] = {
     "api": ["src/starter/api/**", "tests/unit/test_api*.py", "tests/unit/test_agents_api.py"],
     "auth": ["src/starter/auth/**", "tests/unit/test_auth_*.py", "tests/e2e/test_auth_*.py"],
-    "mcp": ["src/starter/mcp/**", "tests/unit/test_mcp_*.py"],
     "infra": ["infra/**"],
     "ui": ["ui/**"],
     "documentation": ["docs/**", "docs-site/**", "README.md", "CHANGELOG.md"],
     "ci": [".github/workflows/**", "scripts/**"],
-    "sdk": ["sdk/**"],
 }
 
 META_AREAS: set[str] = {
     "dx",
     "security",
-    "compliance",
-    "marketing",
-    "growth",
-    "seo",
-    "design",
-    "ops",
     "reliability",
-    "performance",
     "observability",
-    "ux",
-    "a11y",
 }
 
 
@@ -139,6 +131,17 @@ def parse_files_to_touch(body: str) -> list[str] | None:
     Extract the list of allowed paths/globs from an issue body's
     "Files to touch" section.
 
+    Bullets containing backtick-quoted tokens are preferred — backticks are
+    the unambiguous, canonical form for path markers. Bullets without
+    backticks fall through to a tokenisation pass that accepts a token as a
+    path if it either contains `/` or ends in a file extension (matching
+    `\\.\\w+$`).
+
+    Edge case: bare top-level files with no extension (e.g. `Makefile`) are
+    NOT picked up by the no-backtick fallback. The canonical workaround is
+    to wrap the token in backticks (e.g. `` `Makefile` ``); these are rare
+    enough in practice that requiring backticks is a small cost.
+
     Returns:
         - A list of path strings (may be empty) if the heading is present.
         - None if no `## Files to touch` / `### Files to touch` heading is
@@ -178,16 +181,15 @@ def parse_files_to_touch(body: str) -> list[str] | None:
         # Tokenise the bullet on whitespace + common conjunctions/punctuation
         # so a bullet like `- Edit: src/a.py and src/b.py` produces two paths,
         # not one mashed-together string. Each token is then accepted only if
-        # it looks like a path (has a `/`) or matches a known top-level file.
+        # it looks like a path (has a `/` or ends in a file extension).
         for raw_token in re.split(r"[\s,]+|\band\b", cleaned):
             token = raw_token.strip().rstrip(",.;")
             if not token:
                 continue
-            looks_like_path = "/" in token or token in {
-                "CLAUDE.md",
-                "README.md",
-                "CHANGELOG.md",
-            }
+            # A token looks like a path if it contains `/` OR ends in a file
+            # extension. Tokens with no extension and no `/` (e.g. `Makefile`)
+            # are dropped — wrap them in backticks for explicit acceptance.
+            looks_like_path = "/" in token or bool(re.search(r"\.\w+$", token))
             if looks_like_path:
                 paths.append(token)
 

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -424,3 +424,94 @@ def test_universal_allowed_changelog_passes_in_files_to_touch_mode():
 """
     v = scope_check.evaluate(body, [], ["src/starter/foo.py", "CHANGELOG.md"])
     assert v.level == "PASS"
+
+
+# ── Issue #90 edge-case regression tests ──────────────────────────────────────
+
+
+def test_fix1_bare_top_level_file_with_extension_is_accepted():
+    """Issue #90 Fix 1: a bare token (no slash, no backticks) with a file
+    extension is accepted as a path. Previously only a hard-coded allowlist
+    of top-level files (CLAUDE.md, README.md, CHANGELOG.md) passed; new
+    top-level files like `tasks.py` or `pyproject.toml` were silently
+    dropped, causing false FAILs for legitimate diffs."""
+    body = """## Files to touch
+
+- Edit: tasks.py
+- New: pyproject.toml
+
+## Next
+"""
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed is not None
+    assert "tasks.py" in parsed
+    assert "pyproject.toml" in parsed
+
+
+def test_fix1_bare_top_level_file_without_extension_is_rejected():
+    """Issue #90 Fix 1 documented edge case: tokens without `/` and without
+    a file extension (e.g. `Makefile`) still drop. Backticks are the
+    canonical workaround; this test pins the documented behaviour so the
+    docstring stays honest."""
+    body = """## Files to touch
+
+- Edit: Makefile
+
+## Next
+"""
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed is not None
+    assert "Makefile" not in parsed
+    # Backticks remain the canonical workaround for extension-less files.
+    body_with_backticks = """## Files to touch
+
+- Edit: `Makefile`
+
+## Next
+"""
+    parsed_bt = scope_check.parse_files_to_touch(body_with_backticks)
+    assert parsed_bt == ["Makefile"]
+
+
+def test_fix2_pruned_areas_no_longer_mapped():
+    """Issue #90 Fix 2: ground-truth taxonomy. Pruned BOUNDED_AREA_GLOBS
+    keys (`mcp`, `sdk`) and pruned META_AREAS members (`compliance`,
+    `marketing`, etc.) must no longer resolve. An issue carrying only a
+    pruned label falls through to WARN, exposing it to issue-creation-time
+    enforcement instead of being silently swept under a dead mapping."""
+    # Pruned bounded areas
+    assert "mcp" not in scope_check.BOUNDED_AREA_GLOBS
+    assert "sdk" not in scope_check.BOUNDED_AREA_GLOBS
+    # Pruned meta areas
+    for pruned in (
+        "compliance",
+        "marketing",
+        "growth",
+        "seo",
+        "design",
+        "ops",
+        "performance",
+        "ux",
+        "a11y",
+    ):
+        assert pruned not in scope_check.META_AREAS, f"{pruned!r} should be pruned"
+    # An issue with only a pruned area label falls through to None (WARN).
+    assert scope_check.area_label_paths(["mcp", "priority:p2"]) is None
+    assert scope_check.area_label_paths(["compliance", "priority:p2"]) is None
+
+
+def test_fix2_kept_areas_still_resolve():
+    """Issue #90 Fix 2: the kept area labels (`api`, `auth`, `infra`, `ui`,
+    `documentation`, `ci`) must still resolve to their globs after the
+    prune. Live meta-areas (`dx`, `security`, `reliability`,
+    `observability`) must still trigger the meta-area WARN fall-through."""
+    # Bounded areas still map.
+    for area in ("api", "auth", "infra", "ui", "documentation", "ci"):
+        assert area in scope_check.BOUNDED_AREA_GLOBS, f"{area!r} should still map"
+    api_globs = scope_check.area_label_paths(["api", "priority:p2"])
+    assert api_globs is not None
+    assert any(g.startswith("src/starter/api/") for g in api_globs)
+    # Live meta-areas still WARN-fall-through.
+    for meta in ("dx", "security", "reliability", "observability"):
+        assert meta in scope_check.META_AREAS, f"{meta!r} should still be a meta-area"
+        assert scope_check.area_label_paths([meta, "priority:p2"]) is None

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -448,6 +448,34 @@ def test_fix1_bare_top_level_file_with_extension_is_accepted():
     assert "pyproject.toml" in parsed
 
 
+def test_fix1_prose_fragments_with_dots_are_not_treated_as_paths():
+    """Issue #90 Fix 1 hardening: tokens with non-path characters (parens,
+    quotes, etc.) must NOT pass the heuristic, even if they end in
+    `\\.\\w+`. Without the path-safe character filter, fragments like
+    `(e.g.` or `v1.0)` would be accepted as phantom paths, then force a
+    false FAIL because no diff file matches them. Realistic example:
+        - Edit: src/foo.py (e.g. for handling auth)"""
+    body = """## Files to touch
+
+- Edit: src/foo.py (e.g. for handling auth)
+- Edit: src/bar.py and similar files (v1.0)
+
+## Next
+"""
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed is not None
+    # Real paths still picked up.
+    assert "src/foo.py" in parsed
+    assert "src/bar.py" in parsed
+    # Prose fragments must NOT appear.
+    for token in parsed:
+        assert "(" not in token, f"prose fragment {token!r} leaked through"
+        assert ")" not in token, f"prose fragment {token!r} leaked through"
+    # Specific common abbreviations that previously slipped through.
+    assert not any("e.g" in t for t in parsed)
+    assert not any(t.startswith("v1.") for t in parsed)
+
+
 def test_fix1_bare_top_level_file_without_extension_is_rejected():
     """Issue #90 Fix 1 documented edge case: tokens without `/` and without
     a file extension (e.g. `Makefile`) still drop. Backticks are the

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -476,6 +476,32 @@ def test_fix1_prose_fragments_with_dots_are_not_treated_as_paths():
     assert not any(t.startswith("v1.") for t in parsed)
 
 
+def test_fix1_version_like_tokens_are_not_treated_as_paths():
+    """Issue #90 Fix 1 hardening (Copilot iter 2): tokens like `v1.0`,
+    `v1.2`, or `2.10` would pass the path-safe character filter (only word
+    chars + dot) AND match `\\.\\w+$` because `\\w` includes digits. The
+    extension regex is tightened to require the first extension character
+    to be a letter (`\\.[A-Za-z]\\w*$`), rejecting version-like tokens.
+
+    Real paths (`tasks.py`, `pyproject.toml`, `package-lock.json`) still
+    pass — every realistic file extension starts with a letter."""
+    body = """## Files to touch
+
+- Edit: src/foo.py for v1.0 release
+- New: pyproject.toml bumped to 2.10
+
+## Next
+"""
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed is not None
+    # Real paths picked up.
+    assert "src/foo.py" in parsed
+    assert "pyproject.toml" in parsed
+    # Version-like tokens must NOT be classified as paths.
+    assert "v1.0" not in parsed
+    assert "2.10" not in parsed
+
+
 def test_fix1_bare_top_level_file_without_extension_is_rejected():
     """Issue #90 Fix 1 documented edge case: tokens without `/` and without
     a file extension (e.g. `Makefile`) still drop. Backticks are the

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -480,8 +480,9 @@ def test_fix1_version_like_tokens_are_not_treated_as_paths():
     """Issue #90 Fix 1 hardening (Copilot iter 2): tokens like `v1.0`,
     `v1.2`, or `2.10` would pass the path-safe character filter (only word
     chars + dot) AND match `\\.\\w+$` because `\\w` includes digits. The
-    extension regex is tightened to require the first extension character
-    to be a letter (`\\.[A-Za-z]\\w*$`), rejecting version-like tokens.
+    extension regex is tightened to `\\.[A-Za-z]\\w+$` — the first char
+    after the dot must be a letter and the extension total length must be
+    >=2 chars — rejecting version-like tokens.
 
     Real paths (`tasks.py`, `pyproject.toml`, `package-lock.json`) still
     pass — every realistic file extension starts with a letter."""

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -502,6 +502,29 @@ def test_fix1_version_like_tokens_are_not_treated_as_paths():
     assert "2.10" not in parsed
 
 
+def test_fix1_unparenthesised_abbreviations_are_not_treated_as_paths():
+    """Issue #90 Fix 1 hardening (Copilot iter 3): tokens like `e.g.` in
+    prose without parens get rstripped to `e.g`, which would pass both the
+    path-safe filter AND the letter-leading extension regex (`.g` starts
+    with `g`). The extension rule is tightened to require >=2 chars after
+    the dot, rejecting `.g` while still accepting `.py`, `.md`, `.js`."""
+    body = """## Files to touch
+
+- Edit: src/foo.py e.g. for handling auth
+- Edit: src/bar.py i.e. the main entry point
+
+## Next
+"""
+    parsed = scope_check.parse_files_to_touch(body)
+    assert parsed is not None
+    # Real paths picked up.
+    assert "src/foo.py" in parsed
+    assert "src/bar.py" in parsed
+    # Abbreviations must NOT be classified as paths.
+    assert "e.g" not in parsed
+    assert "i.e" not in parsed
+
+
 def test_fix1_bare_top_level_file_without_extension_is_rejected():
     """Issue #90 Fix 1 documented edge case: tokens without `/` and without
     a file extension (e.g. `Makefile`) still drop. Backticks are the


### PR DESCRIPTION
Closes #90

## Summary

Two mechanical fixes to `scripts/check_agent_safe_scope.py`, per the design locked on the issue 2026-04-26:

- **Fix 1 — bare top-level path acceptance**: relax the no-backtick path heuristic from a hard-coded allowlist (`CLAUDE.md`, `README.md`, `CHANGELOG.md`) to "contains `/` OR ends in a file extension". Bare tokens like `tasks.py`, `pyproject.toml`, `uv.lock` now parse as paths without needing backticks. Edge case: tokens with no `/` and no extension (e.g. `Makefile`) still drop — the canonical workaround (backticks) is now documented in the parser docstring.
- **Fix 2 — ground-truth taxonomy maps**: prune `BOUNDED_AREA_GLOBS` (drop `mcp`, `sdk`) and `META_AREAS` (drop `compliance`, `marketing`, `growth`, `seo`, `design`, `ops`, `performance`, `ux`, `a11y`) so both maps reflect the live label set. Rewrite the top-comment to drop the "forward-looking" note and document the canonical refresh procedure (`gh api /repos/.../labels --paginate --jq '.[].name'`).

Two new test cases per fix exercise both branches of the new disjunction (Fix 1) and confirm pruned keys no longer map while kept keys still resolve (Fix 2). All 41 tests pass; pre-push gate green.

## Approach

- Followed the design comment verbatim — option (b) for Fix 1, full prune for Fix 2.
- Acceptance criterion 5 from the issue body (parser-warning test for ambiguous tokens) is moot under option (b) and was deliberately not implemented; the design comment overrides the AC.
- Local Copilot review surfaced one finding: `CLAUDE.md` §Area lines 558-560 still lists the pruned labels (`mcp`, `sdk`, `ux`, `a11y`, `compliance`, `design`, `performance`, `marketing`, `seo`, `growth`, `ops`). This is a **deliberate, documented divergence** — the existing test `test_area_label_paths_bounded_area_documentation` already notes "CLAUDE.md taxonomy is forward-looking; the live label set is the ground truth", and the design comment scopes this PR to the script + its tests only. CLAUDE.md taxonomy reconciliation is a separate concern (file a follow-up if desired).