### PR TITLE
fix: restore e2e-dev CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,6 +606,7 @@ jobs:
     needs: deploy-dev
     if: github.event_name == 'push' && github.ref == 'refs/heads/development'
     runs-on: ubuntu-latest
+    environment: development
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -618,86 +619,22 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Install Playwright
-        run: uv run playwright install chromium --with-deps
-
-      - name: Run auth + MCP e2e tests
-        env:
-          STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
-          STARTER_MCP_URL: ${{ needs.deploy-dev.outputs.mcp_url }}
-          STARTER_ADMIN_EMAIL: ${{ vars.STARTER_ADMIN_EMAIL }}
-        run: uv run pytest tests/e2e/test_auth_e2e.py tests/e2e/test_mcp_e2e.py -v
-
-      - name: Run admin metrics e2e tests
-        env:
-          STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
-          STARTER_ADMIN_EMAIL: ${{ vars.STARTER_ADMIN_EMAIL }}
-        run: uv run pytest tests/e2e/test_admin_e2e.py -v
-
-      - name: Run UI e2e tests (Playwright)
-        env:
-          STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
-          STARTER_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
-        run: uv run pytest tests/e2e/test_ui_e2e.py -v
-
-      - name: Run docs e2e tests (Playwright)
-        env:
-          STARTER_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
-        run: uv run pytest tests/e2e/test_docs_e2e.py -v
-
-      - name: Run Dashboard e2e tests (Playwright)
-        env:
-          STARTER_UI_URL: ${{ needs.deploy-dev.outputs.ui_url }}
-          STARTER_ADMIN_EMAIL: ${{ vars.STARTER_ADMIN_EMAIL }}
-        run: uv run pytest tests/e2e/test_dashboard_e2e.py -v
-
-      - name: Issue synthetic token via PKCE bypass
-        id: synth-token
+      # The six per-suite e2e test files (test_auth_e2e.py, test_mcp_e2e.py,
+      # test_admin_e2e.py, test_ui_e2e.py, test_docs_e2e.py,
+      # test_dashboard_e2e.py) were removed during the #47-era scaffolding
+      # strip-down. Until proper e2e suites are reauthored against the
+      # current API/UI surface (tracked separately), this job runs a
+      # single smoke check against the deployed dev API — green smoke
+      # proves the Lambda is up and the Function URL is reachable from
+      # the runner, validating the full deploy → reachability chain.
+      # Mirrors the e2e-prod "Smoke test prod API" precedent below.
+      - name: Smoke test dev API
         env:
           STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
         run: |
-          TOKEN=$(uv run python - <<'PYEOF'
-          import base64, hashlib, os, secrets
-          import httpx
-
-          api = os.environ["STARTER_API_URL"].rstrip("/")
-          verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
-          challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
-
-          with httpx.Client(base_url=api, follow_redirects=False, timeout=30.0) as http:
-              reg = http.post("/oauth/register", json={
-                  "client_name": "Synthetic Traffic", "redirect_uris": ["http://localhost/cb"],
-              })
-              reg.raise_for_status()
-              client_id = reg.json()["client_id"]
-
-              auth = http.get("/oauth/authorize", params={
-                  "response_type": "code", "client_id": client_id,
-                  "redirect_uri": "http://localhost/cb",
-                  "code_challenge": challenge, "code_challenge_method": "S256",
-              })
-              location = auth.headers.get("location", "")
-              if "accounts.google.com" in location:
-                  raise RuntimeError("Google OAuth redirect — STARTER_BYPASS_GOOGLE_AUTH not enabled on dev")
-              code = location.split("code=")[1].split("&")[0]
-
-              token_resp = http.post("/oauth/token", data={
-                  "grant_type": "authorization_code", "code": code,
-                  "redirect_uri": "http://localhost/cb", "client_id": client_id,
-                  "code_verifier": verifier,
-              })
-              token_resp.raise_for_status()
-              print(token_resp.json()["access_token"], end="")
-          PYEOF
-          )
-          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
-
-      - name: Run synthetic traffic (dev)
-        env:
-          STARTER_API_URL: ${{ needs.deploy-dev.outputs.ui_url }}
-          STARTER_MCP_URL: ${{ needs.deploy-dev.outputs.ui_url }}
-          STARTER_BEARER_TOKEN: ${{ steps.synth-token.outputs.token }}
-        run: uv run python scripts/synthetic_traffic.py
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$STARTER_API_URL/health")
+          echo "Health check status: $STATUS"
+          [ "$STATUS" = "200" ] || (echo "Dev health check failed!" && exit 1)
 
       - name: Notify Slack — e2e failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,8 @@ agentcore-starter/
 │   ├── unit/                  # Pure logic, no AWS deps
 │   ├── integration/           # Tests against DynamoDB Local
 │   └── e2e/                   # Playwright tests against deployed env
-│       ├── test_auth_e2e.py
-│       └── test_ui_e2e.py     # Admin UI (Playwright)
+│       ├── __init__.py
+│       └── conftest.py        # Shared fixtures (e.g. live_admin_token)
 ├── scripts/
 │   └── check_copyright.py     # Copyright header linter
 ├── .github/
@@ -171,7 +171,8 @@ agentcore-starter/
 - Infra synth + Trivy IaC scan (CloudFormation SARIF → GitHub Security tab)
 - Trivy dependency audit (SARIF → GitHub Security tab)
 - SonarCloud scan
-- On push to `development`: deploy to dev + run all e2e tests
+- On push to `development`: deploy to dev + smoke-test the dev API
+  (the per-suite e2e tests are pending reauthor — see `tests/e2e/`)
 - On push to `main`: release + deploy to prod + back-merge to development
 
 Other workflows:
@@ -434,12 +435,18 @@ Must be re-run after every `inv dev` restart (DynamoDB Local is ephemeral).
 
 ### Running UI e2e tests locally
 
+> **Note:** `tests/e2e/` currently contains only `__init__.py` and
+> `conftest.py` — the per-suite test modules are pending reauthor.
+> The commands below will collect zero tests until those suites land
+> (`pytest` exit 5 — "no tests ran"). Documented here so the wiring
+> stays correct for when the suites are restored.
+
 ```bash
 # Auto-detects the Vite port — no env vars to set manually
 uv run inv e2e-local
 
 # Run a specific test file
-uv run inv e2e-local --tests tests/e2e/test_ui_e2e.py
+uv run inv e2e-local --tests tests/e2e/<file>.py
 
 # Repeat N times to check for flakiness
 uv run inv e2e-local --n 5
@@ -458,8 +465,9 @@ Key local e2e gotchas:
   `CORS_ORIGINS=http://localhost:<port>` when starting the stack.
 - `inv seed` (or `inv dev --seed`) must succeed before running e2e tests —
   if auth bypass returns 500, the table is likely missing.
-- `test_docs_e2e.py` is excluded automatically — those tests require a
-  deployed VitePress build; run them against the deployed stack with `inv e2e`.
+- Any `test_docs_e2e.py` suite (when restored) is excluded automatically —
+  those tests require a deployed VitePress build; run them against the
+  deployed stack with `inv e2e`.
 
 ### When to run local e2e tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -12,10 +12,17 @@ tests/
 │   ├── test_api.py
 │   └── test_oauth.py
 └── e2e/               # Against the deployed AWS stack
-    ├── conftest.py        # live_token fixture (DCR + PKCE)
-    ├── test_auth_e2e.py
-    └── test_ui_e2e.py     # Playwright
+    ├── __init__.py
+    └── conftest.py        # Shared fixtures (e.g. live_admin_token)
 ```
+
+> **Note:** The per-suite e2e files (`test_auth_e2e.py`, `test_mcp_e2e.py`,
+> `test_admin_e2e.py`, `test_ui_e2e.py`, `test_docs_e2e.py`,
+> `test_dashboard_e2e.py`) were removed during the #47-era scaffolding
+> strip-down and have not yet been reauthored against the current API/UI
+> surface. The CI `e2e-dev` job currently runs a single curl smoke check
+> against the deployed dev API's `/health` endpoint instead. Reauthoring
+> proper e2e suites is tracked separately.
 
 ## Unit tests
 
@@ -72,7 +79,8 @@ Run against the **deployed AWS stack**. Require valid Lambda Function URLs and a
 | Variable | Required by | Description |
 |---|---|---|
 | `STARTER_API_URL` | all e2e | API Lambda Function URL |
-| `STARTER_UI_URL` | `test_ui_e2e.py` | CloudFront UI URL |
+| `STARTER_UI_URL` | UI Playwright suites (when restored) | CloudFront UI URL |
+| `STARTER_ADMIN_EMAIL` | admin/dashboard suites (when restored) | Admin email used by the bypass login |
 
 All can be found in the CloudFormation stack outputs:
 
@@ -84,26 +92,25 @@ aws cloudformation describe-stacks --stack-name AgentCoreStarterStack-dev \
 ### Run e2e tests
 
 ```bash
-# Auth tests
-uv run pytest tests/e2e/test_auth_e2e.py -v
-
-# UI tests (Playwright — requires Chromium)
+# UI / Playwright suites (when restored — requires Chromium)
 uv run playwright install chromium --with-deps
-uv run pytest tests/e2e/test_ui_e2e.py -v
 
-# All e2e
+# All e2e (currently only conftest fixtures; no test files yet)
 uv run pytest tests/e2e -v
 ```
 
 ### Token management
 
-E2E tests **self-issue tokens** via the `live_token` fixture in `conftest.py`. It performs a full DCR + PKCE flow against `STARTER_API_URL` at session start — no pre-issued token needed.
+The shared `live_admin_token` fixture in `conftest.py` issues a management
+JWT via the Google auth bypass (`/auth/login?test_email=`). It skips when
+`STARTER_API_URL` or `STARTER_ADMIN_EMAIL` is unset, and when the bypass
+is not enabled on the target environment.
 
 ### Skip behaviour
 
-Tests skip gracefully when the required env vars are not set:
-- `test_auth_e2e.py` — skips if `STARTER_API_URL` unset
-- `test_ui_e2e.py` — skips if `STARTER_UI_URL` unset
+Tests skip gracefully when the required env vars are not set — each suite
+declares its own dependencies on `STARTER_API_URL`, `STARTER_UI_URL`, or
+`STARTER_ADMIN_EMAIL` as appropriate.
 
 ## CI pipeline
 


### PR DESCRIPTION
Closes #97

## Summary

Two mechanical defects were preventing any green dev pipeline run after the `deploy-dev` job. Both fixed in one diff per the locked design on the issue.

- **Defect 1 (Option C)**: The `e2e-dev` job referenced six per-suite e2e test files (`test_auth_e2e.py`, `test_mcp_e2e.py`, `test_admin_e2e.py`, `test_ui_e2e.py`, `test_docs_e2e.py`, `test_dashboard_e2e.py`) that were removed during the #47-era scaffolding strip-down. `pytest` exited 4 ("file or directory not found"). All six pytest invocations, plus the synthetic-token PKCE bypass step and the synthetic-traffic step that depend on those tests' setup, are replaced with a single curl smoke check against `/health` on the deployed dev API — mirroring the existing `e2e-prod` "Smoke test prod API" precedent.
- **Defect 2 (mechanical)**: The `e2e-dev` job lacked `environment: development`, so `${{ vars.STARTER_ADMIN_EMAIL }}` resolved against repo-level vars only (empty) instead of the env-scoped variable. Added the one-line declaration parallel to `deploy-dev`. The env scope is retained even though the smoke step itself doesn't need `STARTER_ADMIN_EMAIL` — costs nothing and is required for any future e2e additions.

`CLAUDE.md` and `tests/README.md` reconciled to actual post-PR `tests/e2e/` contents (`__init__.py`, `conftest.py`).

## Approach

- **Smoke step shape mirrors e2e-prod** (`ci.yml` ~line 808). Same step name pattern, same env-var wiring against `needs.deploy-dev.outputs.api_url`, same curl + status-code check against `/health`. Orchestrator confirmed `/health` returns 200 unauthenticated on the dev API.
- **`live_admin_token` fixture in `tests/e2e/conftest.py` left in place.** It's an orphan now (no test file consumes it), but proper cleanup is out of scope for this PR. Surface as a follow-up: when the per-suite e2e tests are reauthored, either wire them up to use the fixture or delete it.
- **`tests/README.md` is updated as a related cross-reference.** It documented the same now-missing files in its `tests/e2e/` listing and example commands. Kept changes scoped to the missing-test-files concern.
- **Local Copilot review (`copilot -p /review`)** flagged a "subshell `exit 1` won't propagate" concern on the `[ "$STATUS" = "200" ] || (echo ... && exit 1)` pattern. False positive — the subshell's exit code is the return value of the `||` clause, which is the script's final command, which GitHub Actions checks. Same pattern is already in production at `e2e-prod`; the orchestrator brief explicitly required mirroring that precedent.
- **CLAUDE.md line 174 ("run all e2e tests" on push to development)** also updated to reflect the new "smoke-test the dev API" reality.

## AC4 — post-merge validation

The fourth acceptance criterion ("a push to `development` produces a green deploy-dev → green e2e-dev → green pipeline … record the run URL in the resolution PR body") cannot be satisfied before merge. The smoke step is gated by `if: github.event_name == 'push' && github.ref == 'refs/heads/development'`, so it does not run on the feature branch. Lint and YAML parse are validated; full smoke validation happens on the next push to `development` after merge.

**AC4 satisfied post-merge (2026-04-26):** https://github.com/warlordofmars/agentcore-starter/actions/runs/24966508817 — `Deploy (dev)` ✓ → `E2E Tests (dev)` ✓ (`Smoke test dev API` step ran cleanly in 9s).

## Verification

- 3 files touched (`.github/workflows/ci.yml`, `CLAUDE.md`, `tests/README.md`).
- Net diff: 49 insertions, 97 deletions — net negative as expected for an Option-C cleanup.
- `uv run inv pre-push` green (lint + typecheck + 355 frontend tests pass).
- `python -c "yaml.safe_load(open('.github/workflows/ci.yml'))"` parses cleanly.
- `e2e-dev` job confirmed to declare `environment: development` post-edit.
