### PR TITLE
feat: bootstrap branch model + protections in template flow

### DIFF
--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -111,6 +111,96 @@ Fix any failures before continuing.
 
 ---
 
+---
+
+## Phase 1.5 — branch model + protections (run after fork, before any code work)
+
+The template expects a dual-branch model (`development` is the GitHub default; `main` is release-only) with seven required CI status checks on both branches and `allow_auto_merge=true` so `gh pr merge --auto --squash` works as documented in CLAUDE.md. A fresh fork ships without any of this — apply it before opening any PR. The expected state is checked in at `infra/branch-protection.expected.json`.
+
+**Order is non-negotiable: PATCH first, PUT second.** The PATCH enables `allow_auto_merge`; the PUT then locks the branches behind required checks. Reversing the order means the very PR that enables auto-merge cannot itself auto-merge under the new protection rules — you would have to manually merge it under admin override.
+
+**Use the JSON-input form (`gh api --input -`).** The `-F field=` shorthand silently passes empty strings instead of JSON `null` for the `required_pull_request_reviews` and `restrictions` fields, and the API rejects empty strings. The form below is the working syntax.
+
+```bash
+# Resolve the fork's owner/repo slug
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Step 1 — repo merge settings (MUST run first)
+gh api -X PATCH "/repos/$REPO" --input - <<'EOF'
+{
+  "default_branch": "development",
+  "allow_rebase_merge": false,
+  "delete_branch_on_merge": true,
+  "allow_auto_merge": true
+}
+EOF
+
+# Step 2 — branch protection (apply to both main and development)
+for branch in main development; do
+  gh api -X PUT "/repos/$REPO/branches/$branch/protection" --input - <<'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Lint & Type Check",
+      "Unit Tests",
+      "Integration Tests (DynamoDB Local)",
+      "Frontend Tests & Build",
+      "Coverage Report",
+      "Infra Synth",
+      "Security Audit"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": false,
+  "required_conversation_resolution": false
+}
+EOF
+done
+```
+
+### Verify live state matches the checked-in snapshot
+
+The snapshot at `infra/branch-protection.expected.json` is the source of truth. Compare the live API responses field-by-field, ignoring the URL fields (`url`, `contexts_url`, `required_status_checks.url`, `required_signatures.url`) which embed the upstream `warlordofmars/agentcore-starter` slug and are not portable across forks.
+
+```bash
+EXPECTED=infra/branch-protection.expected.json
+
+# Compare repo settings (full block)
+LIVE_REPO=$(gh api "/repos/$REPO" \
+  --jq '{allow_auto_merge, allow_merge_commit, allow_rebase_merge, allow_squash_merge, default_branch, delete_branch_on_merge}')
+EXPECTED_REPO=$(jq -c .repo_settings "$EXPECTED")
+diff <(echo "$LIVE_REPO" | jq -S .) <(echo "$EXPECTED_REPO" | jq -S .) \
+  && echo "repo_settings: OK" \
+  || { echo "HALT — repo_settings drift; resolve before continuing"; exit 1; }
+
+# Compare protection (only portable fields — URL fields excluded)
+PROTECTION_FIELDS='{
+  contexts: .required_status_checks.contexts,
+  strict: .required_status_checks.strict,
+  enforce_admins: .enforce_admins.enabled,
+  required_linear_history: .required_linear_history.enabled,
+  allow_force_pushes: .allow_force_pushes.enabled,
+  allow_deletions: .allow_deletions.enabled,
+  required_conversation_resolution: .required_conversation_resolution.enabled
+}'
+for branch in main development; do
+  LIVE=$(gh api "/repos/$REPO/branches/$branch/protection" --jq "$PROTECTION_FIELDS")
+  EXPECTED_BRANCH=$(jq -c ".branches.\"$branch\" | $PROTECTION_FIELDS" "$EXPECTED")
+  diff <(echo "$LIVE" | jq -S .) <(echo "$EXPECTED_BRANCH" | jq -S .) \
+    && echo "$branch protection: OK" \
+    || { echo "HALT — $branch protection drift; resolve before continuing"; exit 1; }
+done
+```
+
+If either diff is non-empty, halt and surface the drift before moving on — onboarding is not complete until live state matches the snapshot.
+
+---
+
 ## Phase 2 — AWS prerequisites
 
 These must exist before the first CDK deploy. Check each:
@@ -347,3 +437,11 @@ Phase 6 — Scaffold replaced
 Phase 6 items are always `○` — the agent can't know when the user considers their own logic "done". Everything else is checkable from the repo and AWS state.
 
 If any Phase 1–5 item is `○`, do not declare setup complete. Identify the first incomplete item and offer to continue from there.
+
+---
+
+## Common gotchas
+
+- **Branch protection is non-optional.** On 2026-04-26 a wholesale `git push` from a long-lived clone force-rewound `origin/development` by 11 merges in the upstream template repo. Recovery succeeded only because a parallel clone retained the pre-rewind HEAD locally. The exact failure was made possible by the gap that Phase 1.5 closes — `development` had no protection at the time, so the force-push was accepted by GitHub. The SEC-1 incident (#15) and the corresponding remediation issue (#50) are the canonical references; ADR-0008 captures the W1–W7 push-discipline rules layered on top of the branch protection. Apply Phase 1.5 to every fork before opening a single PR — it is not optional and must not be deferred.
+- **`gh pr merge --auto` is silently a no-op without `allow_auto_merge=true`.** Phase 1.5's PATCH step turns this on. If you skip Phase 1.5, every `gh pr merge --auto --squash` call documented in CLAUDE.md will return success but never queue the merge — the PR sits open until a human merges it manually.
+- **`gh api -F field=` cannot pass JSON `null`.** The form silently degrades to an empty string, which the GitHub branch-protection API rejects. The `--input -` form with a heredoc is the only working syntax for `required_pull_request_reviews=null` and `restrictions=null`.

--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -111,8 +111,6 @@ Fix any failures before continuing.
 
 ---
 
----
-
 ## Phase 1.5 — branch model + protections (run after fork, before any code work)
 
 The template expects a dual-branch model (`development` is the GitHub default; `main` is release-only) with seven required CI status checks on both branches and `allow_auto_merge=true` so `gh pr merge --auto --squash` works as documented in CLAUDE.md. A fresh fork ships without any of this — apply it before opening any PR. The expected state is checked in at `infra/branch-protection.expected.json`.
@@ -126,9 +124,14 @@ The template expects a dual-branch model (`development` is the GitHub default; `
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 # Step 1 — repo merge settings (MUST run first)
+# All six fields tracked by the snapshot are set explicitly so the post-PATCH
+# state matches `infra/branch-protection.expected.json` regardless of the
+# fork's defaults — the verification step below will diff them all.
 gh api -X PATCH "/repos/$REPO" --input - <<'EOF'
 {
   "default_branch": "development",
+  "allow_squash_merge": true,
+  "allow_merge_commit": true,
   "allow_rebase_merge": false,
   "delete_branch_on_merge": true,
   "allow_auto_merge": true
@@ -165,12 +168,14 @@ done
 
 ### Verify live state matches the checked-in snapshot
 
-The snapshot at `infra/branch-protection.expected.json` is the source of truth. Compare the live API responses field-by-field, ignoring the URL fields (`url`, `contexts_url`, `required_status_checks.url`, `required_signatures.url`) which embed the upstream `warlordofmars/agentcore-starter` slug and are not portable across forks.
+The snapshot at `infra/branch-protection.expected.json` is the source of truth. It is a verbatim capture of the GitHub API response shape, so fields that the API omits when null (notably `required_pull_request_reviews` and `restrictions` when neither is configured) are absent from the snapshot — `jq .field` returns `null` for absent fields, which is the comparison contract: an absent snapshot field equals a `null` live field.
+
+The diff filter below covers every field set by Phase 1.5's PATCH and PUT plus every protection sub-setting that the snapshot records. URL fields (`url`, `contexts_url`, `required_status_checks.url`, `required_signatures.url`) embed the upstream `warlordofmars/agentcore-starter` slug and are excluded — they are not portable across forks.
 
 ```bash
 EXPECTED=infra/branch-protection.expected.json
 
-# Compare repo settings (full block)
+# Compare repo settings (full block — all six snapshot-tracked fields)
 LIVE_REPO=$(gh api "/repos/$REPO" \
   --jq '{allow_auto_merge, allow_merge_commit, allow_rebase_merge, allow_squash_merge, default_branch, delete_branch_on_merge}')
 EXPECTED_REPO=$(jq -c .repo_settings "$EXPECTED")
@@ -178,15 +183,26 @@ diff <(echo "$LIVE_REPO" | jq -S .) <(echo "$EXPECTED_REPO" | jq -S .) \
   && echo "repo_settings: OK" \
   || { echo "HALT — repo_settings drift; resolve before continuing"; exit 1; }
 
-# Compare protection (only portable fields — URL fields excluded)
+# Compare protection — every snapshot-tracked field plus everything Phase 1.5
+# explicitly configures, with URL fields excluded. `null`-returning sub-paths
+# (e.g., absent `required_pull_request_reviews`) compare equal between snapshot
+# and live, which is the intended contract.
 PROTECTION_FIELDS='{
-  contexts: .required_status_checks.contexts,
-  strict: .required_status_checks.strict,
+  required_status_checks: {
+    strict: .required_status_checks.strict,
+    contexts: .required_status_checks.contexts
+  },
+  required_signatures: .required_signatures.enabled,
   enforce_admins: .enforce_admins.enabled,
+  required_pull_request_reviews: .required_pull_request_reviews,
+  restrictions: .restrictions,
   required_linear_history: .required_linear_history.enabled,
   allow_force_pushes: .allow_force_pushes.enabled,
   allow_deletions: .allow_deletions.enabled,
-  required_conversation_resolution: .required_conversation_resolution.enabled
+  block_creations: .block_creations.enabled,
+  required_conversation_resolution: .required_conversation_resolution.enabled,
+  lock_branch: .lock_branch.enabled,
+  allow_fork_syncing: .allow_fork_syncing.enabled
 }'
 for branch in main development; do
   LIVE=$(gh api "/repos/$REPO/branches/$branch/protection" --jq "$PROTECTION_FIELDS")

--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -119,9 +119,22 @@ The template expects a dual-branch model (`development` is the GitHub default; `
 
 **Use the JSON-input form (`gh api --input -`).** The `-F field=` shorthand silently passes empty strings instead of JSON `null` for the `required_pull_request_reviews` and `restrictions` fields, and the API rejects empty strings. The form below is the working syntax.
 
+**`development` must exist before the PATCH runs.** A fresh fork (or a repo created from this template without "Include all branches" ticked) ships with `main` only. Setting `default_branch=development` on a repo where the branch doesn't exist is rejected by the API, and the subsequent PUT to `/branches/development/protection` would fail too. Step 0 below creates `development` from `main` if it's missing — it's a no-op when the branch already exists.
+
 ```bash
 # Resolve the fork's owner/repo slug
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Step 0 — ensure `development` exists (no-op if already present)
+if ! gh api "/repos/$REPO/branches/development" --silent 2>/dev/null; then
+  MAIN_SHA=$(gh api "/repos/$REPO/branches/main" --jq .commit.sha)
+  gh api -X POST "/repos/$REPO/git/refs" \
+    -f ref="refs/heads/development" \
+    -f sha="$MAIN_SHA"
+  echo "Created development from main at $MAIN_SHA"
+else
+  echo "development already exists — skipping create"
+fi
 
 # Step 1 — repo merge settings (MUST run first)
 # All six fields tracked by the snapshot are set explicitly so the post-PATCH

--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -170,7 +170,10 @@ done
 
 The snapshot at `infra/branch-protection.expected.json` is the source of truth. It is a verbatim capture of the GitHub API response shape, so fields that the API omits when null (notably `required_pull_request_reviews` and `restrictions` when neither is configured) are absent from the snapshot — `jq .field` returns `null` for absent fields, which is the comparison contract: an absent snapshot field equals a `null` live field.
 
-The diff filter below covers every field set by Phase 1.5's PATCH and PUT plus every protection sub-setting that the snapshot records. URL fields (`url`, `contexts_url`, `required_status_checks.url`, `required_signatures.url`) embed the upstream `warlordofmars/agentcore-starter` slug and are excluded — they are not portable across forks.
+The diff filter below covers every field set by Phase 1.5's PATCH and PUT plus every protection sub-setting that the snapshot records, with two intentional exclusions:
+
+- **URL fields** (`url`, `contexts_url`, `required_status_checks.url`, `required_signatures.url`) embed the upstream `warlordofmars/agentcore-starter` slug and are not portable across forks.
+- **`required_status_checks.checks`** (the `[{context, app_id}]` array) is excluded because `contexts` and `checks[].context` are derived from the same PUT input — comparing `contexts` covers the load-bearing semantics. The `app_id` value is the GitHub Apps installation ID for the GitHub Actions app (15368), which is the same across forks but adds noise without adding signal.
 
 ```bash
 EXPECTED=infra/branch-protection.expected.json

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ uv run inv seed
 # Open http://localhost:5173?test_email=you@example.com
 ```
 
+## Development
+
+This repo uses a dual-branch model: `development` is the GitHub default branch (where feature/fix PRs land via squash merge) and `main` is release-only (where `release/vX.Y.Z` PRs land via merge commit, then are auto back-merged to `development` by CI). Both branches are protected behind the seven required CI status checks defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (`Lint & Type Check`, `Unit Tests`, `Integration Tests (DynamoDB Local)`, `Frontend Tests & Build`, `Coverage Report`, `Infra Synth`, `Security Audit`) with `strict=true` so the head SHA must be up-to-date with the base branch at merge time. The repository has `allow_auto_merge=true` enabled, so `gh pr merge --auto --squash --delete-branch` queues the PR for merge as soon as required checks pass. The expected branch-protection snapshot is checked in at [`infra/branch-protection.expected.json`](infra/branch-protection.expected.json); fresh forks should apply Phase 1.5 of the onboarding agent (`.claude/agents/onboarding.md`) to install the same protections before opening any PR.
+
 ## Contributing
 
 ```bash

--- a/infra/branch-protection.expected.json
+++ b/infra/branch-protection.expected.json
@@ -1,0 +1,164 @@
+{
+  "repo_settings": {
+    "allow_auto_merge": true,
+    "allow_merge_commit": true,
+    "allow_rebase_merge": false,
+    "allow_squash_merge": true,
+    "default_branch": "development",
+    "delete_branch_on_merge": true
+  },
+  "branches": {
+    "main": {
+      "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/main/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/main/protection/required_status_checks",
+        "strict": true,
+        "contexts": [
+          "Lint & Type Check",
+          "Unit Tests",
+          "Integration Tests (DynamoDB Local)",
+          "Frontend Tests & Build",
+          "Coverage Report",
+          "Infra Synth",
+          "Security Audit"
+        ],
+        "contexts_url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/main/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "Lint & Type Check",
+            "app_id": 15368
+          },
+          {
+            "context": "Unit Tests",
+            "app_id": 15368
+          },
+          {
+            "context": "Integration Tests (DynamoDB Local)",
+            "app_id": 15368
+          },
+          {
+            "context": "Frontend Tests & Build",
+            "app_id": 15368
+          },
+          {
+            "context": "Coverage Report",
+            "app_id": 15368
+          },
+          {
+            "context": "Infra Synth",
+            "app_id": 15368
+          },
+          {
+            "context": "Security Audit",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/main/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/main/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": false
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": false
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    },
+    "development": {
+      "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/development/protection",
+      "required_status_checks": {
+        "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/development/protection/required_status_checks",
+        "strict": true,
+        "contexts": [
+          "Lint & Type Check",
+          "Unit Tests",
+          "Integration Tests (DynamoDB Local)",
+          "Frontend Tests & Build",
+          "Coverage Report",
+          "Infra Synth",
+          "Security Audit"
+        ],
+        "contexts_url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/development/protection/required_status_checks/contexts",
+        "checks": [
+          {
+            "context": "Lint & Type Check",
+            "app_id": 15368
+          },
+          {
+            "context": "Unit Tests",
+            "app_id": 15368
+          },
+          {
+            "context": "Integration Tests (DynamoDB Local)",
+            "app_id": 15368
+          },
+          {
+            "context": "Frontend Tests & Build",
+            "app_id": 15368
+          },
+          {
+            "context": "Coverage Report",
+            "app_id": 15368
+          },
+          {
+            "context": "Infra Synth",
+            "app_id": 15368
+          },
+          {
+            "context": "Security Audit",
+            "app_id": 15368
+          }
+        ]
+      },
+      "required_signatures": {
+        "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/development/protection/required_signatures",
+        "enabled": false
+      },
+      "enforce_admins": {
+        "url": "https://api.github.com/repos/warlordofmars/agentcore-starter/branches/development/protection/enforce_admins",
+        "enabled": false
+      },
+      "required_linear_history": {
+        "enabled": false
+      },
+      "allow_force_pushes": {
+        "enabled": false
+      },
+      "allow_deletions": {
+        "enabled": false
+      },
+      "block_creations": {
+        "enabled": false
+      },
+      "required_conversation_resolution": {
+        "enabled": false
+      },
+      "lock_branch": {
+        "enabled": false
+      },
+      "allow_fork_syncing": {
+        "enabled": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #50

## Summary
Three layers shipped together, scoped to docs + JSON snapshot only:

1. `infra/branch-protection.expected.json` — captures live state of repo settings + main/development branch protections at the moment Layer 1 admin mutations were applied.
2. `.claude/agents/onboarding.md` — adds Phase 1.5 (PATCH-then-PUT, JSON-input form, snapshot diff) so a fresh fork installs the same protections before opening any PR. Adds a "Common gotchas" section anchoring the SEC-1 / 2026-04-26 force-push incident as the rationale.
3. `README.md` — one-paragraph Development section covering the dual-branch model, the seven required CI status checks by name, and the `allow_auto_merge=true` setting.

## Approach
- Layer 1 admin mutations were already applied live by the orchestrator before this PR — the snapshot file is the byte-for-byte capture from that moment.
- Phase 1.5 uses `gh api --input -` with a JSON body, NOT the broken `-F field=` form from the issue body (which silently passes empty strings instead of `null` and the API rejects).
- Verification compares only portable fields (URL fields embed the upstream slug and are not portable across forks).