### PR TITLE
chore: rewrite src/starter/README.md as accurate module index

### DIFF
--- a/src/starter/README.md
+++ b/src/starter/README.md
@@ -1,83 +1,29 @@
-# starter (Python package)
+# `starter` package
 
-The `starter` package contains the OAuth 2.1 authorization server, management API, storage layer, and data models.
+Module index for `src/starter/`. The OAuth 2.1 discovery endpoints,
+management API, and agent wrappers live here.
 
-## Package layout
+For project-wide architecture, conventions, and the data model,
+see the top-level [`CLAUDE.md`](../../CLAUDE.md) and
+[`README.md`](../../README.md).
 
-```
+## Layout
+
+```text
 src/starter/
-├── storage.py      # DynamoDB read/write (StarterStorage class)
-├── models.py       # Pydantic models + DynamoDB serialization
+├── logging_config.py    # Structured JSON logging setup
+├── metrics.py           # CloudWatch EMF metrics helpers
 ├── auth/
-│   ├── oauth.py    # OAuth 2.1 router (authorize/token/revoke/DCR/discovery)
-│   ├── dcr.py      # Dynamic Client Registration logic (RFC 7591)
-│   └── tokens.py   # JWT issuance, decoding, and Bearer token validation
+│   ├── oauth.py         # OAuth 2.1 discovery endpoints (RFC 8414 + RFC 9728); authorize/token/revoke not yet implemented
+│   ├── tokens.py        # JWT issuance and validation (OAuth 2.1 + management sessions)
+│   ├── google.py        # Google OAuth integration (management UI login)
+│   └── mgmt_auth.py     # Management UI auth routes (/auth/login, /auth/callback)
+├── agents/
+│   ├── bedrock.py       # Converse + converse_stream (raw Bedrock)
+│   └── inline_agent.py  # invoke + invoke_stream (Bedrock inline agent)
 └── api/
-    ├── main.py     # FastAPI app wiring (CORS, routers, Lambda handler)
-    ├── _auth.py    # require_token FastAPI dependency
-    ├── users.py    # GET/POST/PATCH/DELETE /api/users
-    ├── clients.py  # GET/POST/DELETE /api/clients
-    └── stats.py    # GET /api/stats, GET /api/activity
-```
-
-## Storage (`storage.py`)
-
-`StarterStorage` is a thin wrapper around a DynamoDB `Table` resource. The constructor reads configuration from environment variables at call time (not module-import time) to support test isolation:
-
-```python
-StarterStorage(
-    table_name=None,   # → STARTER_TABLE_NAME env var or "agentcore-starter-dev"
-    region=None,       # → AWS_REGION env var or "us-east-1"
-    endpoint_url=None, # → DYNAMODB_ENDPOINT env var (for local testing)
-)
-```
-
-### DynamoDB single-table design
-
-| Entity | PK | SK | GSIs |
-|---|---|---|---|
-| OAuth client | `CLIENT#{id}` | `META` | `GSI3PK=CLIENT#{id}` (ClientIndex) |
-| Token | `TOKEN#{jti}` | `META` | — (TTL enabled) |
-| Auth code | `AUTHCODE#{code}` | `META` | — (TTL enabled) |
-| Activity log | `LOG#{date}` | `{timestamp}#{event_id}` | — |
-| User | `USER#{id}` | `META` | `GSI4PK=EMAIL#{email}` (UserEmailIndex) |
-
-## Auth (`auth/`)
-
-### `tokens.py`
-
-- `_jwt_secret()` — lazily loads the signing secret from `STARTER_JWT_SECRET` env var (tests/local) or SSM `/agentcore-starter/jwt-secret` (Lambda runtime); cached with `lru_cache`
-- `issue_jwt(token)` → signed JWT string
-- `decode_jwt(token_str)` → claims dict (raises `JWTError` if invalid/expired)
-- `validate_bearer_token(header, storage)` → `Token` model (raises `ValueError` on any failure)
-
-### `dcr.py`
-
-Validates client registration requests and creates `OAuthClient` records. Enforces:
-- Only `authorization_code` and `refresh_token` grant types
-- Valid `token_endpoint_auth_method` values
-- Auto-generates `client_secret` for confidential clients (stored hashed)
-
-### `oauth.py`
-
-Full OAuth 2.1 router. Key behaviours:
-- `GET /oauth/authorize` — validates PKCE challenge, creates `AuthorizationCode`, redirects
-- `POST /oauth/token` — verifies PKCE verifier, issues `access_token` + `refresh_token`
-- `POST /oauth/revoke` — marks token as revoked in DynamoDB
-- Authorization codes are stored as SHA-256 hashes; the plain code only travels in the redirect URL
-
-## Running locally
-
-```bash
-# Management API (HTTP)
-uv run uvicorn starter.api.main:app --port 8001 --reload
-```
-
-For local API development, set `STARTER_JWT_SECRET` to a fixed value so tokens survive process restarts:
-
-```bash
-STARTER_JWT_SECRET=dev-secret \
-STARTER_TABLE_NAME=agentcore-starter-dev \
-DYNAMODB_ENDPOINT=http://localhost:8000 \
-uv run uvicorn starter.api.main:app --port 8001 --reload
+    ├── main.py          # FastAPI app wiring (CORS, middleware, routers, /health)
+    ├── _auth.py         # require_mgmt_user / require_admin FastAPI dependencies
+    ├── agents.py        # Agent scaffold endpoints
+    └── csp.py           # CSP violation reporting endpoint
 ```

--- a/src/starter/README.md
+++ b/src/starter/README.md
@@ -14,7 +14,7 @@ src/starter/
 ├── logging_config.py    # Structured JSON logging setup
 ├── metrics.py           # CloudWatch EMF metrics helpers
 ├── auth/
-│   ├── oauth.py         # OAuth 2.1 discovery endpoints (RFC 8414 + RFC 9728); authorize/token/revoke not yet implemented
+│   ├── oauth.py         # OAuth 2.1 discovery endpoints (RFC 8414 + RFC 9728); authorize/token/revoke/register not yet implemented
 │   ├── tokens.py        # JWT issuance and validation (OAuth 2.1 + management sessions)
 │   ├── google.py        # Google OAuth integration (management UI login)
 │   └── mgmt_auth.py     # Management UI auth routes (/auth/login, /auth/callback)


### PR DESCRIPTION
Closes #28

## Summary

The previous `src/starter/README.md` documented six files that don't
exist in the codebase (`storage.py`, `models.py`, `auth/dcr.py`,
`api/users.py`, `api/clients.py`, `api/stats.py`) plus a full `dcr.py`
behaviour section for never-implemented logic. New contributors got a
fictional map.

## Approach

Took **Option A** (recommended in issue body): rewrote as a thin
~30-line module index mirroring the top-level `CLAUDE.md` "Structure"
block, scoped to `src/starter/`. Every file mentioned now exists.
Running-locally and DynamoDB single-table content was deferred to the
top-level `README.md` / `CLAUDE.md` to avoid duplication drift.

Chose Option A over Option B (delete) because a per-package module
index is genuinely useful when navigating from inside `src/starter/`
without bouncing back to the project root.

Per Copilot review feedback before push, descriptions were further
tightened to match current reality:
- `auth/oauth.py` only serves `/.well-known/*` discovery endpoints
  today (authorize/token/revoke not yet implemented)
- `api/main.py` has no Lambda handler — pure FastAPI app wiring
- `api/_auth.py` exports `require_mgmt_user` / `require_admin`, not
  `require_token`

## Test plan

- [x] `uv run inv pre-push` passes (lint + typecheck + 161 unit tests
      + 355 frontend tests)
- [x] Every file referenced in the new README exists on disk