### PR TITLE
feat: implicit allowlist for co-located test files in scope check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -594,11 +594,18 @@ This section defines the taxonomy.
   - **JS/TS** — listing `<dir>/<name>.{js,jsx,ts,tsx}` implicitly accepts
     `<dir>/<name>.test.<ext>` and `<dir>/__snapshots__/<name>.test.<ext>.snap`
     in the **same directory only**.
-  - **Python** — listing any `<basename>.py` (under `src/starter/**`,
-    `scripts/**`, or anywhere) implicitly accepts
+  - **Python** — listing any non-test `<basename>.py` (under
+    `src/starter/**`, `scripts/**`, or anywhere) implicitly accepts
     `tests/unit/test_<basename>.py` and any nested
     `tests/unit/**/test_<basename>.py` (matches the repo's pytest
     convention of a fixed test root regardless of source location).
+    Entries whose basename already starts with `test_` are skipped —
+    forward-direction only.
+
+  Glob entries in `## Files to touch` (e.g. `src/starter/api/*.py`) do
+  not generate implicit test derivations; the implicit allowlist is
+  keyed off concrete source paths so a wildcard entry can't widen
+  scope to `tests/unit/test_*.py` (effectively all unit tests).
 
   The implicit allowlist is **forward-direction only**: listing the
   source implicitly accepts the test, but listing the test does NOT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -588,6 +588,27 @@ This section defines the taxonomy.
   strays outside that section. See issue #77 for the design rationale
   and edge-case handling.
 
+  Co-located test files are implicitly accepted alongside their source
+  (issue #105) — issue authors don't need to enumerate both. Two rule
+  shapes:
+  - **JS/TS** — listing `<dir>/<name>.{js,jsx,ts,tsx}` implicitly accepts
+    `<dir>/<name>.test.<ext>` and `<dir>/__snapshots__/<name>.test.<ext>.snap`
+    in the **same directory only**.
+  - **Python** — listing any `<basename>.py` (under `src/starter/**`,
+    `scripts/**`, or anywhere) implicitly accepts
+    `tests/unit/test_<basename>.py` and any nested
+    `tests/unit/**/test_<basename>.py` (matches the repo's pytest
+    convention of a fixed test root regardless of source location).
+
+  The implicit allowlist is **forward-direction only**: listing the
+  source implicitly accepts the test, but listing the test does NOT
+  implicitly accept the source. Production code changes always require
+  explicit listing — this preserves the property that the issue body
+  documents the real production-code surface of change. Test-only
+  changes (e.g. "add unit tests for X") are still legitimate; list the
+  test file directly in `## Files to touch` and the existing parser
+  accepts it without any implicit derivation.
+
 ### Issue creation rules
 
 When filing a new issue:

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -284,12 +284,114 @@ def _matches_any(path: str, globs: list[str]) -> bool:
     return False
 
 
+# Issue #105: implicit allowlist for co-located test files.
+#
+# When a source file is listed in `## Files to touch`, the scope check should
+# also accept its co-located test file without requiring the issue author to
+# enumerate both. Two distinct rule shapes (locked in #105's design comment):
+#
+# Rule A — JS/TS same-directory `.test` infix:
+#     <dir>/<name>.<ext> in scope (ext ∈ {js,jsx,ts,tsx})
+#         → <dir>/<name>.test.<ext>                                 implicit
+#         → <dir>/__snapshots__/<name>.test.<ext>.snap              implicit
+#     Same-directory only — does NOT cross directories.
+#
+# Rule B — Python basename-keyed, fixed `tests/unit/` root:
+#     <anywhere>/<basename>.py in scope
+#         → tests/unit/test_<basename>.py                           implicit
+#         → tests/unit/<any nested>/test_<basename>.py              implicit
+#     Cross-directory by design — pytest convention puts tests in a fixed
+#     root regardless of source location (covers src/starter/** and
+#     scripts/** without enumerating either).
+#
+# Forward-direction only: listing source implicitly accepts test, but
+# listing test does NOT implicitly accept source. Production code changes
+# always require explicit listing — preserves the property that the issue
+# body documents the real production-code surface of change.
+
+_JS_TS_EXTS = ("js", "jsx", "ts", "tsx")
+# Source filename pattern for Rule A. Must NOT already be a test file —
+# `<name>.<ext>` where `<name>` does not end with `.test`.
+_JS_TS_SOURCE_RE = re.compile(r"^(?P<name>.+?)\.(?P<ext>js|jsx|ts|tsx)$")
+# Python source filename pattern for Rule B. Must NOT already be a test
+# file — `<basename>.py` where `<basename>` does not start with `test_`.
+_PY_SOURCE_RE = re.compile(r"^(?P<basename>[^/]+)\.py$")
+
+
+def _implicit_test_paths(source_path: str) -> list[str]:
+    """
+    Given a source path from `## Files to touch`, return the list of
+    co-located test paths (and snapshot paths) that should be implicitly
+    accepted alongside it.
+
+    Returns an empty list when the source path is not a recognised source
+    file (e.g. `.md`, `.yml`, or a path that already looks like a test file
+    such as `foo.test.js` or `tests/unit/test_foo.py`).
+    """
+    derived: list[str] = []
+
+    # Strip leading "./" if present; otherwise the path stays as-is.
+    path = source_path.removeprefix("./")
+
+    # Rule A — JS/TS same-directory `.test` infix. Split the path into a
+    # directory prefix (with trailing slash, or "" for bare top-level files)
+    # and a filename so we can prepend the prefix back onto derived paths.
+    if "/" in path:
+        directory, _, filename = path.rpartition("/")
+        dir_prefix = f"{directory}/"
+    else:
+        filename = path
+        dir_prefix = ""
+
+    js_match = _JS_TS_SOURCE_RE.match(filename)
+    if js_match:
+        name = js_match.group("name")
+        ext = js_match.group("ext")
+        # Skip files that are already test files (e.g. `foo.test.js` —
+        # name ends with `.test`). Forward-direction only: tests don't
+        # imply more tests.
+        if not name.endswith(".test"):
+            derived.append(f"{dir_prefix}{name}.test.{ext}")
+            derived.append(f"{dir_prefix}__snapshots__/{name}.test.{ext}.snap")
+
+    # Rule B — Python basename-keyed, fixed `tests/unit/` root.
+    if path.endswith(".py"):
+        basename = path.rpartition("/")[2].removesuffix(".py")
+        # Skip files that are already test files (basename starts with
+        # `test_`). Forward-direction only.
+        if basename and not basename.startswith("test_"):
+            # Flat: tests/unit/test_<basename>.py
+            derived.append(f"tests/unit/test_{basename}.py")
+            # Nested: any path under tests/unit/ ending in
+            # test_<basename>.py — modelled with a glob.
+            derived.append(f"tests/unit/**/test_{basename}.py")
+
+    return derived
+
+
+def _expand_implicit_tests(allowed_globs: list[str]) -> list[str]:
+    """
+    Expand `allowed_globs` with implicit co-located test paths derived from
+    each source file in scope. Purely additive — original entries are
+    preserved unchanged. Returns the expanded list.
+    """
+    expanded = list(allowed_globs)
+    for entry in allowed_globs:
+        expanded.extend(_implicit_test_paths(entry))
+    return expanded
+
+
 def check_scope(diff_files: list[str], allowed_globs: list[str]) -> list[str]:
     """
     Return the list of files in `diff_files` that do NOT match any of the
     `allowed_globs`. Universal-allowed paths are always considered in-scope.
+
+    Implicit co-located test paths are derived from each source entry in
+    `allowed_globs` (see `_implicit_test_paths`) and added to the effective
+    allowlist before matching. This is forward-direction only — source in
+    scope implies test in scope, but not vice versa.
     """
-    effective = list(allowed_globs) + UNIVERSAL_ALLOWED
+    effective = _expand_implicit_tests(list(allowed_globs)) + UNIVERSAL_ALLOWED
     return [f for f in diff_files if not _matches_any(f, effective)]
 
 

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -337,12 +337,17 @@ def _implicit_test_paths(source_path: str) -> list[str]:
         `tests/unit/test_foo.py` — forward-direction only),
       - the entry contains glob metacharacters (`*`, `?`, `[`) — globs are
         not concrete paths and would derive an over-broad implicit set
-        (e.g. `src/starter/**` would map to `tests/unit/test_**.py`).
+        (e.g. `src/starter/**/*.py` would map to `tests/unit/test_**.py`).
     """
     derived: list[str] = []
 
-    # Strip leading "./" if present; otherwise the path stays as-is.
-    path = source_path.removeprefix("./")
+    # Use the path exactly as provided. Path-prefix normalisation (e.g.
+    # stripping a leading "./") would diverge from how `check_scope` and
+    # `_matches_any` handle `allowed_globs` and `diff_files` — neither
+    # normalises — and would create asymmetric matching where the source
+    # path itself is rejected as out-of-scope while its derived test path
+    # still passes. Keep one consistent semantics.
+    path = source_path
 
     # Glob entries are not concrete paths — skip them to avoid over-broad
     # implicit derivations (a `*.py` entry would otherwise map to

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -309,29 +309,46 @@ def _matches_any(path: str, globs: list[str]) -> bool:
 # always require explicit listing — preserves the property that the issue
 # body documents the real production-code surface of change.
 
-_JS_TS_EXTS = ("js", "jsx", "ts", "tsx")
-# Source filename pattern for Rule A. Must NOT already be a test file —
-# `<name>.<ext>` where `<name>` does not end with `.test`.
-_JS_TS_SOURCE_RE = re.compile(r"^(?P<name>.+?)\.(?P<ext>js|jsx|ts|tsx)$")
-# Python source filename pattern for Rule B. Must NOT already be a test
-# file — `<basename>.py` where `<basename>` does not start with `test_`.
-_PY_SOURCE_RE = re.compile(r"^(?P<basename>[^/]+)\.py$")
+_JS_TS_EXTS: tuple[str, ...] = ("js", "jsx", "ts", "tsx")
+# Source filename pattern for Rule A. The extension alternation is built
+# from `_JS_TS_EXTS` so the tuple is the single source of truth — extending
+# the rule to a new extension is a one-line change. Must NOT already be a
+# test file — `<name>.<ext>` where `<name>` does not end with `.test`.
+_JS_TS_SOURCE_RE = re.compile(
+    rf"^(?P<name>.+?)\.(?P<ext>{'|'.join(re.escape(ext) for ext in _JS_TS_EXTS)})$"
+)
+# Glob metacharacters — when present in a `## Files to touch` entry, that
+# entry is a wildcard, not a concrete source path; skip implicit derivation
+# to avoid widening scope to `tests/unit/test_*.py` (effectively all unit
+# tests). Concrete paths are the input contract for the implicit allowlist.
+_GLOB_METACHARS = re.compile(r"[*?\[]")
 
 
 def _implicit_test_paths(source_path: str) -> list[str]:
     """
-    Given a source path from `## Files to touch`, return the list of
-    co-located test paths (and snapshot paths) that should be implicitly
+    Given a concrete source path from `## Files to touch`, return the list
+    of co-located test paths (and snapshot paths) that should be implicitly
     accepted alongside it.
 
-    Returns an empty list when the source path is not a recognised source
-    file (e.g. `.md`, `.yml`, or a path that already looks like a test file
-    such as `foo.test.js` or `tests/unit/test_foo.py`).
+    Returns an empty list when:
+      - the source path is not a recognised source file (e.g. `.md`,
+        `.yml`),
+      - the path already looks like a test file (e.g. `foo.test.js` or
+        `tests/unit/test_foo.py` — forward-direction only),
+      - the entry contains glob metacharacters (`*`, `?`, `[`) — globs are
+        not concrete paths and would derive an over-broad implicit set
+        (e.g. `src/starter/**` would map to `tests/unit/test_**.py`).
     """
     derived: list[str] = []
 
     # Strip leading "./" if present; otherwise the path stays as-is.
     path = source_path.removeprefix("./")
+
+    # Glob entries are not concrete paths — skip them to avoid over-broad
+    # implicit derivations (a `*.py` entry would otherwise map to
+    # `tests/unit/test_*.py`, effectively allowing every unit test).
+    if _GLOB_METACHARS.search(path):
+        return derived
 
     # Rule A — JS/TS same-directory `.test` infix. Split the path into a
     # directory prefix (with trailing slash, or "" for bare top-level files)

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -722,6 +722,34 @@ def test_implicit_test_helper_skips_non_source_paths():
     assert scope_check._implicit_test_paths("tests/unit/test_main.py") == []
 
 
+def test_implicit_test_helper_skips_glob_entries():
+    """Glob entries in `## Files to touch` must not derive implicit tests
+    — `src/starter/api/*.py` would otherwise map to `tests/unit/test_*.py`
+    (effectively every unit test). The implicit allowlist keys off
+    concrete paths only."""
+    assert scope_check._implicit_test_paths("src/starter/api/*.py") == []
+    assert scope_check._implicit_test_paths("ui/src/components/*.jsx") == []
+    assert scope_check._implicit_test_paths("scripts/?.py") == []
+    assert scope_check._implicit_test_paths("ui/src/[abc].js") == []
+
+
+def test_implicit_test_glob_in_files_to_touch_does_not_widen_scope():
+    """End-to-end: a glob entry in `## Files to touch` must not silently
+    widen scope to all unit tests via implicit derivation. Only the literal
+    glob is in scope; an unrelated test file that happens to match the
+    derived `tests/unit/test_*.py` pattern is rejected."""
+    body = """## Files to touch
+
+- `src/starter/api/*.py`
+
+## Next
+"""
+    diff = ["src/starter/api/users.py", "tests/unit/test_unrelated.py"]
+    v = scope_check.evaluate(body, ["agent-safe", "api"], diff)
+    assert v.level == "FAIL"
+    assert "tests/unit/test_unrelated.py" in v.out_of_scope
+
+
 def test_fix2_kept_areas_still_resolve():
     """Issue #90 Fix 2: the kept area labels (`api`, `auth`, `infra`, `ui`,
     `documentation`, `ci`) must still resolve to their globs after the

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -578,6 +578,150 @@ def test_fix2_pruned_areas_no_longer_mapped():
     assert scope_check.area_label_paths(["compliance", "priority:p2"]) is None
 
 
+# ── Issue #105: implicit allowlist for co-located test files ─────────────────
+#
+# Two distinct rule shapes (locked in #105's design comment):
+#   Rule A — JS/TS same-directory `.test` infix.
+#   Rule B — Python basename-keyed, fixed `tests/unit/` root.
+# Forward-direction only: source in scope implies test in scope, but not
+# vice versa.
+
+
+def test_implicit_test_rule_a_js_co_located_test_passes():
+    """Rule A — JS source listed → JS co-located test implicitly accepted.
+    AC4 regression for PR #104: ui/src/api.js + ui/src/api.test.js touched
+    together passes scope check without listing the test explicitly."""
+    body = """## Files to touch
+
+- `ui/src/api.js`
+
+## Next
+"""
+    diff = ["ui/src/api.js", "ui/src/api.test.js"]
+    v = scope_check.evaluate(body, ["agent-safe", "ui"], diff)
+    assert v.level == "PASS"
+    assert v.source == "files-to-touch"
+
+
+def test_implicit_test_rule_a_tsx_co_located_test_passes():
+    """Rule A — TSX source listed → TSX co-located test implicitly accepted."""
+    body = """## Files to touch
+
+- `ui/src/components/Button.tsx`
+
+## Next
+"""
+    diff = ["ui/src/components/Button.tsx", "ui/src/components/Button.test.tsx"]
+    v = scope_check.evaluate(body, ["agent-safe", "ui"], diff)
+    assert v.level == "PASS"
+
+
+def test_implicit_test_rule_b_python_nested_test_passes():
+    """Rule B — Python source listed → nested test under tests/unit/
+    implicitly accepted. tests/unit/api/test_main.py for src/starter/api/main.py."""
+    body = """## Files to touch
+
+- `src/starter/api/main.py`
+
+## Next
+"""
+    diff = ["src/starter/api/main.py", "tests/unit/api/test_main.py"]
+    v = scope_check.evaluate(body, ["agent-safe", "api"], diff)
+    assert v.level == "PASS"
+
+
+def test_implicit_test_rule_b_python_flat_test_passes():
+    """Rule B — Python source listed → flat tests/unit/test_<name>.py
+    implicitly accepted. Cross-directory: scripts/check_agent_safe_scope.py
+    → tests/unit/test_check_agent_safe_scope.py."""
+    body = """## Files to touch
+
+- `scripts/check_agent_safe_scope.py`
+
+## Next
+"""
+    diff = [
+        "scripts/check_agent_safe_scope.py",
+        "tests/unit/test_check_agent_safe_scope.py",
+    ]
+    v = scope_check.evaluate(body, ["agent-safe", "ci"], diff)
+    assert v.level == "PASS"
+
+
+def test_implicit_test_forward_direction_only_js():
+    """Negative — Rule A is forward-direction only. Listing the test alone
+    does NOT implicitly accept the source. Production code changes always
+    require explicit listing."""
+    body = """## Files to touch
+
+- `ui/src/api.test.js`
+
+## Next
+"""
+    diff = ["ui/src/api.test.js", "ui/src/api.js"]
+    v = scope_check.evaluate(body, ["agent-safe", "ui"], diff)
+    assert v.level == "FAIL"
+    assert "ui/src/api.js" in v.out_of_scope
+
+
+def test_implicit_test_forward_direction_only_python():
+    """Negative — Rule B is forward-direction only. Listing the test alone
+    does NOT implicitly accept the source. Production code changes always
+    require explicit listing."""
+    body = """## Files to touch
+
+- `tests/unit/test_main.py`
+
+## Next
+"""
+    diff = ["tests/unit/test_main.py", "src/starter/api/main.py"]
+    v = scope_check.evaluate(body, ["agent-safe", "api"], diff)
+    assert v.level == "FAIL"
+    assert "src/starter/api/main.py" in v.out_of_scope
+
+
+def test_implicit_test_rule_a_does_not_cross_directories():
+    """Negative — Rule A is same-directory only. ui/src/api.js in scope
+    does NOT implicitly accept tests/api.test.js (different directory)."""
+    body = """## Files to touch
+
+- `ui/src/api.js`
+
+## Next
+"""
+    diff = ["ui/src/api.js", "tests/api.test.js"]
+    v = scope_check.evaluate(body, ["agent-safe", "ui"], diff)
+    assert v.level == "FAIL"
+    assert "tests/api.test.js" in v.out_of_scope
+
+
+def test_implicit_test_helper_returns_expected_paths_for_js():
+    """Direct test of `_implicit_test_paths` for JS — exposes Rule A's
+    derived paths so future maintainers can see the full surface."""
+    derived = scope_check._implicit_test_paths("ui/src/api.js")
+    assert "ui/src/api.test.js" in derived
+    assert "ui/src/__snapshots__/api.test.js.snap" in derived
+
+
+def test_implicit_test_helper_returns_expected_paths_for_python():
+    """Direct test of `_implicit_test_paths` for Python — exposes Rule B's
+    derived paths so future maintainers can see the full surface."""
+    derived = scope_check._implicit_test_paths("src/starter/api/main.py")
+    assert "tests/unit/test_main.py" in derived
+    assert "tests/unit/**/test_main.py" in derived
+
+
+def test_implicit_test_helper_skips_non_source_paths():
+    """Non-source paths (markdown, yml, paths that already look like tests)
+    yield no implicit derivations."""
+    assert scope_check._implicit_test_paths("CLAUDE.md") == []
+    assert scope_check._implicit_test_paths(".github/workflows/ci.yml") == []
+    # Already a test file — JS form.
+    assert scope_check._implicit_test_paths("ui/src/api.test.js") == []
+    # Already a test file — Python form.
+    assert scope_check._implicit_test_paths("tests/unit/test_main.py") == []
+
+
 def test_fix2_kept_areas_still_resolve():
     """Issue #90 Fix 2: the kept area labels (`api`, `auth`, `infra`, `ui`,
     `documentation`, `ci`) must still resolve to their globs after the


### PR DESCRIPTION
Closes #105

## Summary

Extends `scripts/check_agent_safe_scope.py` so that when a source file is listed in `## Files to touch`, its co-located test file is implicitly accepted. Removes the friction that produced PR #104's scope FAIL on 2026-04-26 — issue authors no longer need to enumerate both halves of a source/test pair.

## Approach

Two distinct rule shapes (locked in [#105's design comment](https://github.com/warlordofmars/agentcore-starter/issues/105#issuecomment-4323559512), implemented with two parallel match paths rather than a single parameterized rule):

- **Rule A — JS/TS same-directory `.test` infix.** `<dir>/<name>.<ext>` (ext ∈ {js,jsx,ts,tsx}) listed in scope implicitly accepts `<dir>/<name>.test.<ext>` and `<dir>/__snapshots__/<name>.test.<ext>.snap`. Same-directory only — does NOT cross directories.
- **Rule B — Python basename-keyed, fixed `tests/unit/` root.** Any `<basename>.py` in scope implicitly accepts `tests/unit/test_<basename>.py` (flat) and `tests/unit/**/test_<basename>.py` (nested). Cross-directory by design — pytest convention puts tests in a fixed root regardless of source location, covering both `src/starter/**` and `scripts/**` without enumerating either.

The implicit allowlist is **forward-direction only**. Listing source implies test, but listing test does NOT imply source. Production code changes always require explicit listing — preserves the property that the issue body documents the real production-code surface of change.

Implementation is purely additive: a new `_implicit_test_paths` helper computes the derived set per source entry, and `check_scope` runs an `_expand_implicit_tests` pass over `allowed_globs` before the existing match logic. Existing scope sources (`## Files to touch` parsing, area-label fallback, universal-allowed `CHANGELOG.md`) all behave identically.

## Test coverage

10 new unit tests in `tests/unit/test_check_agent_safe_scope.py`:

- 4 happy paths — Rule A (JS, TSX) and Rule B (flat, nested).
- 3 negative cases — forward-direction enforcement (JS + Python), cross-directory rejection.
- 3 helper-function tests — direct surface of `_implicit_test_paths` for JS / Python / non-source paths.

The first happy-path test (`test_implicit_test_rule_a_js_co_located_test_passes`) is the **PR #104 regression test** required by AC4 — `ui/src/api.js` listed alongside `ui/src/api.test.js` in the diff passes scope check without amending the issue body.

Snapshot test deferred per design — no `__snapshots__/` directories exist in the repo today (verified via `find ui -name __snapshots__ -type d`); the rule accommodates them prospectively.

## Doc updates

- **CLAUDE.md** — added a paragraph under the `agent-safe` label documentation describing both rule shapes and the forward-direction-only property.
- **`.claude/agents/issue-worker.md`** — verified by grep; the only references to "Files to touch" are for skill-selection path prediction (line 78) and the W1 push allowlist (lines 342–346), neither of which describes the scope-check rule's behaviour. No edits made; the file is untouched.

## Recursive applicability

This PR modifies the scope-check tooling itself; the new rules take effect post-merge for future PRs. The PR's own scope check runs under existing rules. Three files touched (`scripts/check_agent_safe_scope.py`, `tests/unit/test_check_agent_safe_scope.py`, `CLAUDE.md`) — all explicitly listed in #105's `## Files to touch`. Verified offline via `python scripts/check_agent_safe_scope.py --issue-body-file ... --diff-files-file ...` → PASS.

## Notes

NOT `agent-safe` — modifies the scope-check tooling itself; needs human review on the recursive-applicability boundary, per #105's note. Auto-merge intentionally NOT armed.