### PR TITLE
fix: remove STARTER_BYPASS_GOOGLE_AUTH from deployed Lambdas

### DIFF
--- a/infra/stacks/starter_stack.py
+++ b/infra/stacks/starter_stack.py
@@ -287,11 +287,6 @@ class AgentCoreStarterStack(cdk.Stack):
             "BEDROCK_MODEL_ID": "anthropic.claude-sonnet-4-6",
         }
 
-        # In non-prod environments, bypass Google OAuth so automated e2e tests
-        # can complete the PKCE flow without a real Google account.
-        if not is_prod:
-            common_env["STARTER_BYPASS_GOOGLE_AUTH"] = "1"
-
         # Tag every resource with the deployed version for operational visibility.
         cdk.Tags.of(self).add("version", app_version)
 


### PR DESCRIPTION
Closes #18

## Summary

Removes the `if not is_prod:` block in `infra/stacks/starter_stack.py`
that injected `STARTER_BYPASS_GOOGLE_AUTH=1` on every non-prod Lambda.
With this gone, the `?test_email=` admin-mint shortcut is no longer
available on any deployed environment (dev, staging, jc, etc.).

## Approach

Strict CDK delete per the issue's standing directive — no runtime
guard, no shared bypass token, no alternative design. The runtime
consumer in `src/starter/auth/mgmt_auth.py` is unchanged: when the
env var is absent, `_BYPASS` evaluates to `False` and the code falls
through to the normal Google OAuth flow.

The bypass remains usable for `inv dev` (local) because `tasks.py`
sets `STARTER_BYPASS_GOOGLE_AUTH=1` in the local process environment
(line 355), not via CDK.

## Validation gates (per issue AC)

- `grep -rn STARTER_BYPASS_GOOGLE_AUTH infra/` → zero hits
- `grep -rn STARTER_BYPASS_GOOGLE_AUTH src/` → still finds runtime
  check in `auth/mgmt_auth.py:39, 96`
- `grep -rn STARTER_BYPASS_GOOGLE_AUTH tasks.py` → still set for `inv dev`
- `inv pre-push` clean (lint, typecheck, unit, frontend — 269 tests pass)
- `inv synth` clean
- `cdk synth -c env=dev | grep -c STARTER_BYPASS_GOOGLE_AUTH` → 0

## Notes

- **NOT `agent-safe`** — modifies CDK and the auth surface. Halting
  for human review + merge per the agent protocol; auto-merge not
  armed.
- Post-merge deploy validation (deploy to `jc`, hit
  `?test_email=` against the deployed URL, expect 401/403) is
  the human reviewer's call — local synth confirms the Lambda env
  no longer carries the bypass var.
- `tests/e2e/conftest.py` already handles the bypass-disabled case
  via `pytest.skip` when the deployed `/auth/login?test_email=` call
  returns a 3xx Google redirect — no changes needed there.