### PR TITLE
fix: strip trailing slash from STARTER_API_URL in ci.yml smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,7 +632,7 @@ jobs:
         env:
           STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$STARTER_API_URL/health")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STARTER_API_URL%/}/health")
           echo "Health check status: $STATUS"
           [ "$STATUS" = "200" ] || (echo "Dev health check failed!" && exit 1)
 
@@ -806,7 +806,7 @@ jobs:
         env:
           STARTER_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$STARTER_API_URL/health")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STARTER_API_URL%/}/health")
           echo "Health check status: $STATUS"
           [ "$STATUS" = "200" ] || (echo "Prod health check failed!" && exit 1)
 


### PR DESCRIPTION
Closes #113

## Summary

Lambda Function URLs always end in `/`. The dev and prod smoke-test steps in `ci.yml` were string-concatenating `$STARTER_API_URL` with `/health`, producing `//health` — which FastAPI treats as a literal path and 404s on. The bug had been latent since the smoke test was added, masked by the `Runtime.ImportModuleError` that prevented the Lambda from ever reaching FastAPI; PR #112 fixed the runtime and surfaced the path bug on the next post-merge dev pipeline run.

Replace `"$STARTER_API_URL/health"` with `"${STARTER_API_URL%/}/health"` (bash parameter expansion that strips one trailing slash if present) at both call sites — dev (line 635) and prod (line 809).

## Approach

Two-line shell-parameter-expansion fix as specified in the issue. No alternatives considered (per the locked scope: no URL-normalisation libraries, no CDK output changes, no custom-domain switch). Verified the expansion locally:

```
$ URL="https://x.lambda-url.us-east-1.on.aws/" && echo "${URL%/}/health"
https://x.lambda-url.us-east-1.on.aws/health
```

## Diff

```diff
@@ -632,7 +632,7 @@ jobs:
         env:
           STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$STARTER_API_URL/health")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STARTER_API_URL%/}/health")
           echo "Health check status: $STATUS"
           [ "$STATUS" = "200" ] || (echo "Dev health check failed!" && exit 1)
@@ -806,7 +806,7 @@ jobs:
         env:
           STARTER_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$STARTER_API_URL/health")
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STARTER_API_URL%/}/health")
           echo "Health check status: $STATUS"
           [ "$STATUS" = "200" ] || (echo "Prod health check failed!" && exit 1)
```

## Validation

- `inv pre-push` clean (lint, typecheck, 173 unit tests passed, 269 frontend tests passed across 27 files).
- Local Copilot review: no issues found.
- No `inv deploy` / `inv e2e` needed — there is no app-code or CDK change. The real validation is the post-merge dev pipeline running the fixed smoke test against the deployed Lambda.

## Notes

- **Not agent-safe** — touches `.github/workflows/`. Auto-merge will not be armed; PR halts here for human review and merge.
- Part of bootstrap-pattern epic #56 (the bug only became visible after #112 unblocked the runtime).