### PR TITLE
fix: fail-closed startup validation for unrotated SSM placeholders

### DIFF
--- a/docs-site/operations/security.md
+++ b/docs-site/operations/security.md
@@ -47,57 +47,64 @@ geo-restrictions, and CSP headers.
 | Header name | `X-Origin-Verify` |
 | Consumer (Lambda) | `src/starter/auth/tokens.py` (`_origin_verify_secret()`) |
 | Consumer (middleware) | `src/starter/api/main.py` (`_verify_origin_secret`) |
-| Injector (CloudFront) | `infra/stacks/starter_stack.py` (`origin_verify_header`, prod-only) |
+| Injector (CloudFront) | `infra/stacks/starter_stack.py` (`origin_verify_header`, all environments) |
 
 ### Current behaviour
 
-The middleware actively verifies the header only when **both** of the
-following are true:
+The middleware actively verifies the header when
+`STARTER_ORIGIN_VERIFY_PARAM` (or `STARTER_ORIGIN_VERIFY_SECRET`) is
+set in the Lambda environment and the resolved SSM value can be read.
+The request is rejected if the incoming `x-origin-verify` header does
+**not** match the resolved value; a matching header is the success
+case and the request is allowed through.
 
-1. `STARTER_ORIGIN_VERIFY_PARAM` (or `STARTER_ORIGIN_VERIFY_SECRET`)
-   is set in the Lambda environment.
-2. The resolved value is **not** the literal placeholder
-   `CHANGE_ME_ON_FIRST_DEPLOY`.
+The CDK stack sets `STARTER_ORIGIN_VERIFY_PARAM` and injects
+`X-Origin-Verify` from CloudFront in **every** environment. The fail-
+closed startup validator (issue #16) refuses to start the Lambda when
+the SSM parameter still holds the `CHANGE_ME_ON_FIRST_DEPLOY`
+placeholder, so a half-configured deploy never silently degrades —
+Lambda init fails, `/health` returns the runtime error body, and the
+CI smoke test for the dev environment trips the pipeline red. **Rotate
+the secret immediately after the first deploy in any environment**
+using the procedure below.
 
-When those conditions are met, the request is rejected if the incoming
-`x-origin-verify` header does **not** match the resolved value. A
-matching header is the success case and the request is allowed through.
-
-The CDK stack sets `STARTER_ORIGIN_VERIFY_PARAM` in **every**
-environment, but CloudFront only injects the `X-Origin-Verify`
-header on the prod distribution. In non-prod environments the
-middleware is effectively skipping enforcement only because the SSM
-parameter still holds the `CHANGE_ME_ON_FIRST_DEPLOY` placeholder
-(condition 2 above) — **do not rotate the non-prod parameter away
-from the placeholder unless you also wire CloudFront header injection
-for that environment**, or non-prod traffic will start being rejected.
-In prod, if the SSM parameter still holds the placeholder, the
-middleware silently allows every request through. **Rotate the
-secret immediately after the first prod deploy** (procedure below).
-Issue #16 will turn this silent-pass into a startup error.
-
-The current resolver in `src/starter/auth/tokens.py`
-(`_origin_verify_secret`) also returns `None` on any SSM exception
-(missing parameter, IAM denial, network error). When `None` is
-returned, the middleware fails the first condition of its check and
-allows the request through. Because `_origin_verify_secret()` is
-wrapped in `functools.lru_cache(maxsize=1)`, this fail-open state
-only happens for a given Lambda execution environment if its first
-secret read hits that exception path and caches `None`; if the secret
-was already read successfully, later transient SSM outages do not
-disable enforcement for that warm process. Issue #16 will replace
-this fail-open behaviour with a startup-time failure when the
-parameter is configured but cannot be read.
+The resolver in `src/starter/auth/tokens.py` (`_origin_verify_secret`)
+returns `None` on any SSM exception (missing parameter, IAM denial,
+network error). When `None` is returned, the middleware skips
+verification — but the startup validator already proved the parameter
+is readable at cold start, so this branch only fires on a transient
+SSM outage *after* a successful warm-up read. Because
+`_origin_verify_secret()` is wrapped in `functools.lru_cache(maxsize=1)`,
+the first successful read pins the value for the warm container's
+lifetime; the failure branch only matters if the very first read is a
+transient failure and gets cached as `None`. The startup validator
+makes that window narrow but not zero — see #16's discussion of a
+follow-up to resolve the value at startup and pass it into the
+middleware.
 
 ### Rotation procedure
 
+> **Keep `Type=String`. Do not rotate to `SecureString`.**
+> The CloudFront origin custom-header injection uses
+> `CfnDynamicReferenceService.SSM`, which only resolves plaintext SSM
+> parameters. Rotating to `SecureString` causes the dynamic reference
+> to resolve to `null`, CloudFront stops sending `X-Origin-Verify`,
+> and every request through CloudFront returns 403 from the Lambda
+> middleware. The secret is defense-in-depth — preventing direct
+> Function URL access from outside the AWS account — not crypto. The
+> IAM-gated visibility on SSM and CloudFront origin config is the
+> security boundary, and `String` is sufficient.
+
 1. Generate a new high-entropy value (e.g. `openssl rand -hex 32`).
-2. Update the SSM parameter:
+2. Update the SSM parameter (canonical command form — note
+   `--type String` and `--overwrite`):
    ```bash
    aws ssm put-parameter \
-     --name /agentcore-starter/origin-verify-secret \
+     --name /agentcore-starter/<env>/origin-verify-secret \
      --value "$NEW_SECRET" --type String --overwrite
    ```
+   For prod, the parameter path drops the `<env>/` segment:
+   `/agentcore-starter/origin-verify-secret`.
 3. Re-deploy the stack so CloudFront picks up the new value via the
    `CfnDynamicReference` in `origin_verify_header`. CDK only resolves
    the SSM dynamic reference at synth/deploy time, so a parameter
@@ -106,6 +113,35 @@ parameter is configured but cannot be read.
    environment variable) so the `lru_cache` on `_origin_verify_secret`
    re-reads SSM. CloudFront and Lambda are briefly out of sync during
    this window — schedule rotations during low traffic.
+
+#### If the parameter type ever needs to change
+
+`aws ssm put-parameter --overwrite` cannot change a parameter's type;
+it can only update the value of an existing parameter of the same
+type. Changing the type requires `aws ssm delete-parameter` followed
+by a fresh `put-parameter` with the new type.
+
+A delete-then-put sequence opens a misalignment window between
+CloudFront and Lambda:
+
+- After the `delete-parameter` call but before the next CDK deploy,
+  CloudFront still has the **old** secret cached in its origin
+  custom-header config; Lambda's `_origin_verify_secret` lru-cache
+  also still has the old value (until the Lambda cold-starts). New
+  requests pass.
+- After `put-parameter` (with the new value) but before the CDK
+  redeploy, the SSM parameter holds the new value but CloudFront is
+  still injecting the old. Lambda will reject every CloudFront
+  request as soon as its lru-cache expires (next cold start).
+- After the CDK redeploy but before the Lambda cold-starts,
+  CloudFront sends the new header value while Lambda is still
+  validating against the old. Every request 403s.
+
+Recommend doing the type change during a maintenance pause: announce
+downtime, run delete-then-put, redeploy CDK, then force a Lambda
+cold start (publish a new version or touch an environment variable).
+Verify `/health` returns 200 through CloudFront and 403 against the
+direct Function URL before lifting the maintenance window.
 
 ## JWT signing secret
 

--- a/infra/stacks/starter_stack.py
+++ b/infra/stacks/starter_stack.py
@@ -179,6 +179,14 @@ class AgentCoreStarterStack(cdk.Stack):
         )
         allowed_emails_param.apply_removal_policy(cdk.RemovalPolicy.RETAIN)
 
+        # OriginVerifySecret is intentionally Type=String, NOT SecureString.
+        # CfnDynamicReferenceService.SSM (used to inject the value into
+        # CloudFront's origin custom headers) cannot resolve SecureString
+        # parameters. The secret is defense-in-depth — preventing direct
+        # Function URL access from outside the AWS account — not crypto.
+        # The IAM-gated visibility on SSM and CloudFront origin config is
+        # the security boundary. Rotating to SecureString breaks the deploy.
+        # See docs-site/operations/security.md for the rotation runbook.
         origin_verify_param = ssm.StringParameter(
             self,
             "OriginVerifySecret",
@@ -418,21 +426,26 @@ class AgentCoreStarterStack(cdk.Stack):
         # API origin — strip "https://" prefix and trailing "/" from the function URL
         api_origin_domain = cdk.Fn.select(2, cdk.Fn.split("/", api_url.url))
 
-        # CloudFront injects X-Origin-Verify on prod so Lambda can reject direct
-        # Function URL access. The header value is resolved from SSM at deploy
-        # time via a CloudFormation dynamic reference.
-        origin_verify_header: dict[str, str] = (
-            {
-                "X-Origin-Verify": cdk.Token.as_string(
-                    cdk.CfnDynamicReference(
-                        cdk.CfnDynamicReferenceService.SSM,
-                        origin_verify_param.parameter_name,
-                    )
+        # CloudFront injects X-Origin-Verify in every environment so Lambda
+        # can reject direct Function URL access. The header value is resolved
+        # from SSM at deploy time via a CloudFormation dynamic reference.
+        #
+        # OriginVerifySecret is intentionally Type=String, NOT SecureString.
+        # CfnDynamicReferenceService.SSM (used to inject the value into
+        # CloudFront's origin custom headers) cannot resolve SecureString
+        # parameters. The secret is defense-in-depth — preventing direct
+        # Function URL access from outside the AWS account — not crypto.
+        # The IAM-gated visibility on SSM and CloudFront origin config is
+        # the security boundary. Rotating to SecureString breaks the deploy.
+        # See docs-site/operations/security.md for the rotation runbook.
+        origin_verify_header = {
+            "X-Origin-Verify": cdk.Token.as_string(
+                cdk.CfnDynamicReference(
+                    cdk.CfnDynamicReferenceService.SSM,
+                    origin_verify_param.parameter_name,
                 )
-            }
-            if is_prod
-            else {}
-        )
+            )
+        }
 
         api_cf_origin = origins.HttpOrigin(
             api_origin_domain,

--- a/infra/stacks/starter_stack.py
+++ b/infra/stacks/starter_stack.py
@@ -278,6 +278,9 @@ class AgentCoreStarterStack(cdk.Stack):
             "GOOGLE_CLIENT_SECRET_PARAM": google_client_secret_param.parameter_name,
             "ALLOWED_EMAILS_PARAM": allowed_emails_param.parameter_name,
             "STARTER_ORIGIN_VERIFY_PARAM": origin_verify_param.parameter_name,
+            # Operational SSM parameter — soft-warn check at startup logs if
+            # still set to the CHANGE_ME_ON_FIRST_DEPLOY placeholder.
+            "STARTER_ALARM_EMAIL_PARAM": alarm_email_param.parameter_name,
             # APP_VERSION is injected at deploy time via the APP_VERSION env var.
             # Falls back to "dev" for local synth/deploy without a version set.
             "APP_VERSION": app_version,
@@ -309,6 +312,9 @@ class AgentCoreStarterStack(cdk.Stack):
         google_client_secret_param.grant_read(api_role)
         allowed_emails_param.grant_read(api_role)
         origin_verify_param.grant_read(api_role)
+        # Soft-warn startup check needs to read the alarm-email parameter to
+        # detect the CHANGE_ME_ON_FIRST_DEPLOY placeholder.
+        alarm_email_param.grant_read(api_role)
         api_role.add_to_policy(
             iam.PolicyStatement(
                 actions=["cloudwatch:GetMetricData", "cloudwatch:DescribeAlarms"],

--- a/src/starter/api/main.py
+++ b/src/starter/api/main.py
@@ -26,9 +26,21 @@ from starter.logging_config import (
     new_request_id,
     set_request_context,
 )
+from starter.startup import (
+    validate_secrets_or_die,
+    warn_unrotated_observability_params,
+)
 
 configure_logging("agentcore-starter")
 logger = get_logger(__name__)
+
+# Fail-closed startup validation. Wired here at module import (not via
+# @app.on_event("startup")) so any unrotated security-critical SSM
+# parameter raises during AWS Lambda INIT and CloudFormation reports the
+# deploy as failed. Both hooks no-op outside Lambda — see
+# starter.startup for the placeholder check details.
+validate_secrets_or_die()
+warn_unrotated_observability_params()
 
 
 def _app_version() -> str:
@@ -95,16 +107,15 @@ async def _log_requests(request: Request, call_next):
 async def _verify_origin_secret(request: Request, call_next):
     """Reject requests missing the CloudFront X-Origin-Verify secret.
 
-    Disabled when STARTER_ORIGIN_VERIFY_PARAM is not set (local dev / non-prod).
+    Disabled when ``STARTER_ORIGIN_VERIFY_PARAM`` is not set (local dev /
+    non-prod). The placeholder-value short-circuit was removed — the
+    fail-closed startup check (:mod:`starter.startup`) guarantees the
+    secret is rotated before the Lambda will start.
     """
     from starter.auth.tokens import _origin_verify_secret
 
     expected = _origin_verify_secret()
-    if (
-        expected
-        and expected != "CHANGE_ME_ON_FIRST_DEPLOY"
-        and request.headers.get("x-origin-verify") != expected
-    ):
+    if expected and request.headers.get("x-origin-verify") != expected:
         from fastapi.responses import JSONResponse
 
         return JSONResponse(status_code=403, content={"detail": "Forbidden"})

--- a/src/starter/api/main.py
+++ b/src/starter/api/main.py
@@ -107,10 +107,14 @@ async def _log_requests(request: Request, call_next):
 async def _verify_origin_secret(request: Request, call_next):
     """Reject requests missing the CloudFront X-Origin-Verify secret.
 
-    Disabled when ``STARTER_ORIGIN_VERIFY_PARAM`` is not set (local dev /
-    non-prod). The placeholder-value short-circuit was removed — the
-    fail-closed startup check (:mod:`starter.startup`) guarantees the
-    secret is rotated before the Lambda will start.
+    Disabled when neither ``STARTER_ORIGIN_VERIFY_PARAM`` nor
+    ``STARTER_ORIGIN_VERIFY_SECRET`` provides a secret (local dev /
+    non-prod). The placeholder-value short-circuit was removed for the
+    SSM-backed ``STARTER_ORIGIN_VERIFY_PARAM`` path — the fail-closed
+    startup check (:mod:`starter.startup`) guarantees that secret is
+    rotated before the Lambda will start. The direct env-var path
+    (``STARTER_ORIGIN_VERIFY_SECRET``) is for local dev and bypasses
+    startup validation.
     """
     from starter.auth.tokens import _origin_verify_secret
 

--- a/src/starter/auth/tokens.py
+++ b/src/starter/auth/tokens.py
@@ -3,8 +3,11 @@
 JWT issuance and validation for OAuth 2.1 and management sessions.
 
 Tokens are signed with HS256 using a secret resolved from:
-  1. STARTER_JWT_SECRET env var (tests / local dev)
-  2. SSM Parameter /agentcore-starter/jwt-secret (Lambda runtime)
+  1. ``STARTER_JWT_SECRET`` env var (tests / local dev)
+  2. SSM parameter named by ``STARTER_JWT_SECRET_PARAM`` (Lambda runtime;
+     per-environment in non-prod, e.g. ``/agentcore-starter/<env>/jwt-secret``;
+     the legacy ``/agentcore-starter/jwt-secret`` path is kept as a
+     fallback default for environments where the env var isn't set)
 
 There is no random fallback — Lambda startup is gated by
 :func:`starter.startup.validate_secrets_or_die`, which fails closed if
@@ -48,8 +51,12 @@ def _jwt_secret() -> str:
     """Return the JWT signing secret.
 
     Priority:
-    1. STARTER_JWT_SECRET env var (tests / local dev)
-    2. SSM Parameter /agentcore-starter/jwt-secret (Lambda runtime)
+    1. ``STARTER_JWT_SECRET`` env var (tests / local dev)
+    2. SSM parameter whose path is supplied by ``STARTER_JWT_SECRET_PARAM``
+       (Lambda runtime; per-environment in non-prod, e.g.
+       ``/agentcore-starter/<env>/jwt-secret``). The literal default
+       below (``/agentcore-starter/jwt-secret``) is kept only as a legacy
+       fallback for environments where the env var isn't wired.
 
     SSM exceptions propagate — there is no random fallback. The
     fail-closed startup check (:mod:`starter.startup`) ensures Lambda

--- a/src/starter/auth/tokens.py
+++ b/src/starter/auth/tokens.py
@@ -5,7 +5,12 @@ JWT issuance and validation for OAuth 2.1 and management sessions.
 Tokens are signed with HS256 using a secret resolved from:
   1. STARTER_JWT_SECRET env var (tests / local dev)
   2. SSM Parameter /agentcore-starter/jwt-secret (Lambda runtime)
-  3. Random fallback (single-process local dev only — not suitable for multi-instance)
+
+There is no random fallback — Lambda startup is gated by
+:func:`starter.startup.validate_secrets_or_die`, which fails closed if
+the SSM parameter is unrotated, missing, or unreadable. Local execution
+without ``STARTER_JWT_SECRET`` set will surface the underlying SSM error
+rather than silently issuing tokens that no other process can validate.
 """
 
 from __future__ import annotations
@@ -45,19 +50,22 @@ def _jwt_secret() -> str:
     Priority:
     1. STARTER_JWT_SECRET env var (tests / local dev)
     2. SSM Parameter /agentcore-starter/jwt-secret (Lambda runtime)
-    3. Random fallback (single-process local dev only)
+
+    SSM exceptions propagate — there is no random fallback. The
+    fail-closed startup check (:mod:`starter.startup`) ensures Lambda
+    cold start fails if the SSM parameter is unreadable, so a successful
+    return here means every Lambda warm pool sees the same secret.
     """
     if secret := os.environ.get("STARTER_JWT_SECRET"):
         return secret
-    try:  # pragma: no cover
-        import boto3
+    import boto3  # pragma: no cover
 
-        param_name = os.environ.get("STARTER_JWT_SECRET_PARAM", "/agentcore-starter/jwt-secret")
-        ssm = boto3.client("ssm")
-        resp = ssm.get_parameter(Name=param_name, WithDecryption=True)
-        return resp["Parameter"]["Value"]
-    except Exception:  # pragma: no cover
-        return secrets.token_hex(32)
+    param_name = os.environ.get(  # pragma: no cover
+        "STARTER_JWT_SECRET_PARAM", "/agentcore-starter/jwt-secret"
+    )
+    ssm = boto3.client("ssm")  # pragma: no cover
+    resp = ssm.get_parameter(Name=param_name, WithDecryption=True)  # pragma: no cover
+    return resp["Parameter"]["Value"]  # pragma: no cover
 
 
 @functools.lru_cache(maxsize=1)

--- a/src/starter/startup.py
+++ b/src/starter/startup.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+Startup-time validation hooks for SSM-backed configuration.
+
+Two hooks are exposed:
+
+- :func:`validate_secrets_or_die` — hard-fail validator for the four
+  security-critical SSM parameters. Raises :class:`StartupConfigError` on
+  the first unrotated placeholder so AWS Lambda init fails and
+  CloudFormation reports the deploy as failed.
+
+- :func:`warn_unrotated_observability_params` — soft-warn check for the
+  operational :code:`AlarmEmail` parameter. Logs a single ``WARNING`` per
+  cold start when the value is still the placeholder; never raises.
+
+Both hooks short-circuit when ``AWS_LAMBDA_FUNCTION_NAME`` is unset, so
+``inv dev``, unit tests, and integration tests against DynamoDB Local
+are unaffected.
+
+Wired at module import in :mod:`starter.api.main` (not via
+``@app.on_event("startup")``) so the failure surfaces during Lambda INIT
+rather than after the container has been marked ready.
+"""
+
+from __future__ import annotations
+
+import os
+
+from starter.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# The placeholder string used by the CDK stack when the SSM parameter is
+# first provisioned. Any value still equal to this string at startup
+# means the operator has not yet rotated the secret.
+PLACEHOLDER_VALUE = "CHANGE_ME_ON_FIRST_DEPLOY"
+
+# Env vars that hold the SSM parameter name for the four security-critical
+# parameters. Names match the ones wired by :mod:`infra.stacks.starter_stack`
+# under ``common_env`` — do not hardcode parameter paths here.
+HARD_FAIL_PARAM_ENV_VARS: tuple[str, ...] = (
+    "STARTER_JWT_SECRET_PARAM",
+    "GOOGLE_CLIENT_ID_PARAM",
+    "GOOGLE_CLIENT_SECRET_PARAM",
+    "STARTER_ORIGIN_VERIFY_PARAM",
+)
+
+# Env var that holds the SSM parameter name for the operational
+# AlarmEmail parameter (soft-warn only).
+SOFT_WARN_PARAM_ENV_VAR = "STARTER_ALARM_EMAIL_PARAM"
+
+
+class StartupConfigError(RuntimeError):
+    """Raised when a security-critical SSM parameter is unrotated.
+
+    Surfaces during AWS Lambda init when wired at module import; aborts
+    the cold start and is reported by CloudFormation as a deploy failure.
+    """
+
+
+def _on_lambda() -> bool:
+    """Return True only when running inside AWS Lambda.
+
+    Both startup hooks are no-ops outside Lambda so local development,
+    unit tests, and DynamoDB-Local integration tests are unaffected.
+    """
+    return bool(os.environ.get("AWS_LAMBDA_FUNCTION_NAME"))
+
+
+def _get_ssm_value(parameter_name: str) -> str:
+    """Read an SSM parameter value with decryption.
+
+    Imported lazily so test environments without :mod:`boto3` can still
+    import this module. Any exception (parameter missing, permission
+    denied, transient SSM failure) propagates — the silent-fallback
+    pattern that masked SEC-3/SEC-5 is exactly what this module exists
+    to prevent.
+    """
+    import boto3
+
+    ssm = boto3.client("ssm")
+    resp = ssm.get_parameter(Name=parameter_name, WithDecryption=True)
+    return resp["Parameter"]["Value"]
+
+
+def validate_secrets_or_die() -> None:
+    """Hard-fail validator for security-critical SSM secrets.
+
+    Iterates over :data:`HARD_FAIL_PARAM_ENV_VARS`, resolves each to its
+    SSM parameter name, fetches the value, and raises
+    :class:`StartupConfigError` on the first match against
+    :data:`PLACEHOLDER_VALUE`. SSM exceptions propagate — they must
+    surface, not be swallowed.
+
+    No-op when ``AWS_LAMBDA_FUNCTION_NAME`` is unset.
+    """
+    if not _on_lambda():
+        return
+
+    for env_var in HARD_FAIL_PARAM_ENV_VARS:
+        param_name = os.environ.get(env_var)
+        if not param_name:
+            # The stack always wires these; an unset value at runtime is
+            # itself a deploy bug. Surface it loudly rather than skipping.
+            raise StartupConfigError(
+                f"Required env var {env_var} is unset; cannot validate SSM parameter"
+            )
+        value = _get_ssm_value(param_name)
+        if value == PLACEHOLDER_VALUE:
+            raise StartupConfigError(
+                f"SSM parameter {param_name} still has placeholder value "
+                f"{PLACEHOLDER_VALUE!r}; rotate it before the service can start"
+            )
+
+
+def warn_unrotated_observability_params() -> None:
+    """Soft-warn for operational SSM params still at placeholder values.
+
+    Currently covers :data:`SOFT_WARN_PARAM_ENV_VAR` (AlarmEmail). Logs
+    a single ``WARNING`` per cold start when the value is unrotated;
+    does not raise. SSM exceptions propagate.
+
+    No-op when ``AWS_LAMBDA_FUNCTION_NAME`` is unset.
+    """
+    if not _on_lambda():
+        return
+
+    param_name = os.environ.get(SOFT_WARN_PARAM_ENV_VAR)
+    if not param_name:
+        # Operational env var unset → nothing to check. Distinct from the
+        # hard-fail path: missing operational wiring is annoying, not
+        # exploitable, so we warn and return.
+        logger.warning(
+            "Env var %s is unset; alarm-email placeholder check skipped",
+            SOFT_WARN_PARAM_ENV_VAR,
+        )
+        return
+
+    value = _get_ssm_value(param_name)
+    if value == PLACEHOLDER_VALUE:
+        logger.warning(
+            "SSM parameter %s still has placeholder value %r; CloudWatch alarms "
+            "will route to nowhere until this is rotated",
+            param_name,
+            PLACEHOLDER_VALUE,
+        )

--- a/tests/integration/test_startup.py
+++ b/tests/integration/test_startup.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Integration test: app refuses to import under simulated Lambda env.
+
+Verifies the wire-at-import contract — :mod:`starter.api.main` must
+raise :class:`starter.startup.StartupConfigError` during module
+construction when any of the four security-critical SSM parameters is
+still set to ``CHANGE_ME_ON_FIRST_DEPLOY``. Wiring at module import
+(not via ``@app.on_event("startup")``) is what causes Lambda INIT to
+fail, which CloudFormation reports as a deploy failure.
+
+Separately verifies the soft-warn path emits exactly one ``WARNING``
+log line for ``AlarmEmail`` per cold start and does not raise.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+import pytest
+
+from starter import startup
+from starter.startup import (
+    HARD_FAIL_PARAM_ENV_VARS,
+    PLACEHOLDER_VALUE,
+    SOFT_WARN_PARAM_ENV_VAR,
+)
+
+
+def _force_reimport_main() -> None:
+    """Drop cached starter.api.main + starter.startup so import re-runs hooks.
+
+    Each test simulates a Lambda cold start, where the module-level
+    ``validate_secrets_or_die()`` call fires during import. Without
+    eviction the second test would pick up the cached, already-validated
+    module and the wire-at-import contract would not actually be tested.
+    """
+    for mod in (
+        "starter.api.main",
+        "starter.api._auth",
+        "starter.startup",
+    ):
+        sys.modules.pop(mod, None)
+
+
+@pytest.fixture
+def lambda_env(monkeypatch):
+    """Simulate the Lambda runtime: AWS_LAMBDA_FUNCTION_NAME + wired SSM env vars."""
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "agentcore-starter-api")
+    for ev in HARD_FAIL_PARAM_ENV_VARS:
+        monkeypatch.setenv(ev, f"/test/{ev.lower()}")
+    monkeypatch.setenv(SOFT_WARN_PARAM_ENV_VAR, "/test/alarm-email")
+    # JWT secret env var has highest priority in tokens.py — set it so the
+    # downstream import path doesn't try to reach SSM during the test.
+    monkeypatch.setenv("STARTER_JWT_SECRET", "integration-test-secret")
+    yield
+    _force_reimport_main()
+
+
+@pytest.mark.parametrize("placeholder_env_var", HARD_FAIL_PARAM_ENV_VARS)
+def test_app_import_fails_when_any_hard_fail_param_is_placeholder(
+    monkeypatch, lambda_env, placeholder_env_var
+):
+    """Module import must raise StartupConfigError naming the unrotated param."""
+    placeholder_path = f"/test/{placeholder_env_var.lower()}"
+
+    def _fake_ssm(name: str) -> str:
+        return PLACEHOLDER_VALUE if name == placeholder_path else "rotated-value"
+
+    # Re-importing starter.startup creates a *fresh* class object for
+    # StartupConfigError — the class imported at the top of this file is
+    # from the previously-loaded module, so pytest.raises() must match
+    # against the freshly re-imported symbol.
+    _force_reimport_main()
+    fresh_startup = importlib.import_module("starter.startup")
+    monkeypatch.setattr(fresh_startup, "_get_ssm_value", _fake_ssm)
+    fresh_error = fresh_startup.StartupConfigError
+
+    # Now the api.main import will run validate_secrets_or_die() which calls
+    # the patched _get_ssm_value.
+    sys.modules.pop("starter.api.main", None)
+    with pytest.raises(fresh_error) as excinfo:
+        importlib.import_module("starter.api.main")
+
+    assert placeholder_path in str(excinfo.value)
+
+
+def test_app_import_emits_single_warning_for_alarm_email_placeholder(monkeypatch, lambda_env):
+    """Soft-warn must log exactly one WARNING for AlarmEmail, not raise.
+
+    The project's structured logger sets ``propagate=False`` on the
+    ``starter`` tree, so :data:`pytest`'s caplog cannot see records via
+    the root. Attach a dedicated handler to capture them.
+    """
+    alarm_path = "/test/alarm-email"
+
+    def _fake_ssm(name: str) -> str:
+        return PLACEHOLDER_VALUE if name == alarm_path else "rotated-value"
+
+    _force_reimport_main()
+    fresh_startup = importlib.import_module("starter.startup")
+    monkeypatch.setattr(fresh_startup, "_get_ssm_value", _fake_ssm)
+
+    captured: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _ListHandler(level=logging.DEBUG)
+    startup_logger = logging.getLogger("starter.startup")
+    startup_logger.addHandler(handler)
+    try:
+        sys.modules.pop("starter.api.main", None)
+        importlib.import_module("starter.api.main")  # must succeed
+    finally:
+        startup_logger.removeHandler(handler)
+
+    placeholder_warnings = [
+        r for r in captured if r.levelno == logging.WARNING and alarm_path in r.getMessage()
+    ]
+    assert len(placeholder_warnings) == 1
+
+
+def test_app_import_succeeds_when_all_params_rotated(monkeypatch, lambda_env):
+    """Sanity: with every param rotated the app imports cleanly under Lambda env."""
+    _force_reimport_main()
+    fresh_startup = importlib.import_module("starter.startup")
+    monkeypatch.setattr(fresh_startup, "_get_ssm_value", lambda _name: "rotated-value")
+
+    sys.modules.pop("starter.api.main", None)
+    main = importlib.import_module("starter.api.main")
+    assert hasattr(main, "app")
+
+
+def teardown_module() -> None:
+    """Restore the real starter.api.main for any tests that import it later."""
+    _force_reimport_main()
+    # Re-import a clean copy without the lambda env so subsequent suites get
+    # the normal local-dev module.
+    importlib.import_module("starter.startup")
+    importlib.import_module("starter.api.main")
+    # Touch the public name so static analysis doesn't flag the import as unused.
+    assert startup.PLACEHOLDER_VALUE == PLACEHOLDER_VALUE

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -68,6 +68,16 @@ def test_origin_verify_middleware_rejects_missing_header(monkeypatch):
     tokens._origin_verify_secret.cache_clear()
 
 
+def test_origin_verify_middleware_accepts_matching_header(monkeypatch):
+    from starter.auth import tokens
+
+    tokens._origin_verify_secret.cache_clear()
+    monkeypatch.setenv("STARTER_ORIGIN_VERIFY_SECRET", "super-secret")
+    resp = client.get("/health", headers={"x-origin-verify": "super-secret"})
+    assert resp.status_code == 200
+    tokens._origin_verify_secret.cache_clear()
+
+
 @pytest.mark.asyncio
 async def test_csp_report_legacy_format_returns_204():
     import json

--- a/tests/unit/test_startup.py
+++ b/tests/unit/test_startup.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for the fail-closed startup validation hooks."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from starter import startup
+from starter.startup import (
+    HARD_FAIL_PARAM_ENV_VARS,
+    PLACEHOLDER_VALUE,
+    SOFT_WARN_PARAM_ENV_VAR,
+    StartupConfigError,
+    validate_secrets_or_die,
+    warn_unrotated_observability_params,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_lambda_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pretend we are running inside an AWS Lambda."""
+    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "agentcore-starter-api")
+
+
+def _wire_hard_fail_param_names(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Set every hard-fail env var to a unique synthetic SSM parameter path."""
+    mapping = {ev: f"/test/{ev.lower()}" for ev in HARD_FAIL_PARAM_ENV_VARS}
+    for env_var, value in mapping.items():
+        monkeypatch.setenv(env_var, value)
+    return mapping
+
+
+class _ListHandler(logging.Handler):
+    """In-memory log handler used to capture records on the non-propagating
+    ``starter`` logger tree (the project's JSON logger sets
+    ``propagate=False``, so :data:`pytest`'s caplog fixture cannot see
+    these records via the root).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+@pytest.fixture
+def capture_startup_logs():
+    """Yield a list of records emitted on ``starter.startup``."""
+    handler = _ListHandler()
+    logger = logging.getLogger("starter.startup")
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield handler.records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+
+
+# ---------------------------------------------------------------------------
+# Lambda short-circuit (both hooks)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_secrets_or_die_no_op_outside_lambda(monkeypatch):
+    monkeypatch.delenv("AWS_LAMBDA_FUNCTION_NAME", raising=False)
+
+    def _boom(_: str) -> str:  # pragma: no cover — must not be called
+        raise AssertionError("SSM should not be touched outside Lambda")
+
+    monkeypatch.setattr(startup, "_get_ssm_value", _boom)
+    validate_secrets_or_die()  # must return cleanly
+
+
+def test_warn_unrotated_observability_params_no_op_outside_lambda(
+    monkeypatch, capture_startup_logs
+):
+    monkeypatch.delenv("AWS_LAMBDA_FUNCTION_NAME", raising=False)
+
+    def _boom(_: str) -> str:  # pragma: no cover — must not be called
+        raise AssertionError("SSM should not be touched outside Lambda")
+
+    monkeypatch.setattr(startup, "_get_ssm_value", _boom)
+    warn_unrotated_observability_params()
+    assert capture_startup_logs == []
+
+
+# ---------------------------------------------------------------------------
+# validate_secrets_or_die — hard-fail behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("placeholder_env_var", HARD_FAIL_PARAM_ENV_VARS)
+def test_validate_secrets_or_die_rejects_each_placeholder(monkeypatch, placeholder_env_var):
+    """Each hard-fail parameter must be rejected on its own."""
+    _set_lambda_env(monkeypatch)
+    param_paths = _wire_hard_fail_param_names(monkeypatch)
+    placeholder_path = param_paths[placeholder_env_var]
+
+    def _fake_ssm(name: str) -> str:
+        return PLACEHOLDER_VALUE if name == placeholder_path else "rotated-secret-value"
+
+    monkeypatch.setattr(startup, "_get_ssm_value", _fake_ssm)
+
+    with pytest.raises(StartupConfigError) as excinfo:
+        validate_secrets_or_die()
+    assert placeholder_path in str(excinfo.value)
+    assert PLACEHOLDER_VALUE in str(excinfo.value)
+
+
+def test_validate_secrets_or_die_passes_when_all_rotated(monkeypatch):
+    _set_lambda_env(monkeypatch)
+    _wire_hard_fail_param_names(monkeypatch)
+    monkeypatch.setattr(startup, "_get_ssm_value", lambda _name: "rotated-secret-value")
+
+    validate_secrets_or_die()  # must not raise
+
+
+def test_validate_secrets_or_die_raises_when_param_env_var_missing(monkeypatch):
+    """An unset env var means a deploy bug — surface it, don't skip."""
+    _set_lambda_env(monkeypatch)
+    _wire_hard_fail_param_names(monkeypatch)
+    monkeypatch.delenv(HARD_FAIL_PARAM_ENV_VARS[0], raising=False)
+    monkeypatch.setattr(startup, "_get_ssm_value", lambda _name: "rotated-secret-value")
+
+    with pytest.raises(StartupConfigError) as excinfo:
+        validate_secrets_or_die()
+    assert HARD_FAIL_PARAM_ENV_VARS[0] in str(excinfo.value)
+
+
+def test_validate_secrets_or_die_propagates_ssm_errors(monkeypatch):
+    """SSM permission/missing-param errors must surface, not be swallowed."""
+    _set_lambda_env(monkeypatch)
+    _wire_hard_fail_param_names(monkeypatch)
+
+    class _AccessDenied(Exception):
+        pass
+
+    def _raise(_name: str) -> str:
+        raise _AccessDenied("ssm:GetParameter denied")
+
+    monkeypatch.setattr(startup, "_get_ssm_value", _raise)
+    with pytest.raises(_AccessDenied):
+        validate_secrets_or_die()
+
+
+# ---------------------------------------------------------------------------
+# warn_unrotated_observability_params — soft-warn behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_warn_logs_when_alarm_email_is_placeholder(monkeypatch, capture_startup_logs):
+    _set_lambda_env(monkeypatch)
+    monkeypatch.setenv(SOFT_WARN_PARAM_ENV_VAR, "/test/alarm-email")
+    monkeypatch.setattr(startup, "_get_ssm_value", lambda _name: PLACEHOLDER_VALUE)
+
+    warn_unrotated_observability_params()
+
+    placeholder_records = [r for r in capture_startup_logs if "/test/alarm-email" in r.getMessage()]
+    assert len(placeholder_records) == 1
+    assert placeholder_records[0].levelno == logging.WARNING
+    assert "alarms" in placeholder_records[0].getMessage().lower()
+
+
+def test_warn_silent_when_alarm_email_is_rotated(monkeypatch, capture_startup_logs):
+    _set_lambda_env(monkeypatch)
+    monkeypatch.setenv(SOFT_WARN_PARAM_ENV_VAR, "/test/alarm-email")
+    monkeypatch.setattr(startup, "_get_ssm_value", lambda _name: "ops@example.com")
+
+    warn_unrotated_observability_params()
+
+    assert capture_startup_logs == []
+
+
+def test_warn_logs_when_param_env_var_unset(monkeypatch, capture_startup_logs):
+    """Operational env var unset → log a single warning and return; do not raise."""
+    _set_lambda_env(monkeypatch)
+    monkeypatch.delenv(SOFT_WARN_PARAM_ENV_VAR, raising=False)
+
+    def _boom(_: str) -> str:  # pragma: no cover — must not be called
+        raise AssertionError("SSM should not be queried when env var is unset")
+
+    monkeypatch.setattr(startup, "_get_ssm_value", _boom)
+    warn_unrotated_observability_params()
+
+    skipped = [r for r in capture_startup_logs if SOFT_WARN_PARAM_ENV_VAR in r.getMessage()]
+    assert len(skipped) == 1
+    assert skipped[0].levelno == logging.WARNING
+
+
+def test_warn_propagates_ssm_errors(monkeypatch):
+    """Soft-warn must still propagate SSM exceptions — silent absorb is the bug."""
+    _set_lambda_env(monkeypatch)
+    monkeypatch.setenv(SOFT_WARN_PARAM_ENV_VAR, "/test/alarm-email")
+
+    class _Boom(Exception):
+        pass
+
+    def _raise(_name: str) -> str:
+        raise _Boom("ssm:GetParameter denied")
+
+    monkeypatch.setattr(startup, "_get_ssm_value", _raise)
+    with pytest.raises(_Boom):
+        warn_unrotated_observability_params()
+
+
+# ---------------------------------------------------------------------------
+# _get_ssm_value — boto3 boundary
+# ---------------------------------------------------------------------------
+
+
+def test_get_ssm_value_returns_decrypted_parameter(monkeypatch):
+    """_get_ssm_value should call boto3.client('ssm').get_parameter with decryption."""
+    captured: dict[str, object] = {}
+
+    class _FakeSSM:
+        def get_parameter(self, *, Name: str, WithDecryption: bool):
+            captured["Name"] = Name
+            captured["WithDecryption"] = WithDecryption
+            return {"Parameter": {"Value": "rotated-value"}}
+
+    def _fake_client(service: str):
+        assert service == "ssm"
+        return _FakeSSM()
+
+    import boto3
+
+    monkeypatch.setattr(boto3, "client", _fake_client)
+
+    assert startup._get_ssm_value("/test/param") == "rotated-value"
+    assert captured == {"Name": "/test/param", "WithDecryption": True}
+
+
+# ---------------------------------------------------------------------------
+# StartupConfigError sanity
+# ---------------------------------------------------------------------------
+
+
+def test_startup_config_error_is_runtime_error_subclass():
+    assert issubclass(StartupConfigError, RuntimeError)


### PR DESCRIPTION
Closes #16

## Summary

Folds three security findings (SEC-3, SEC-5, SEC-14) into a single fix surface. Lambda cold start now fails closed when any of the four security-critical SSM parameters is still set to `CHANGE_ME_ON_FIRST_DEPLOY`, and the operational `AlarmEmail` placeholder produces a single WARNING per cold start.

This is part of the bootstrap-pattern epic family and the security-cluster work toward `chat-app-ready`. **Unblocks #47** (OAuth scaffolding removal) — the `_jwt_secret()` simplification rebases cleanly onto the deletions there.

## Approach

Two new functions in `src/starter/startup.py` (placed at the package root, not under `auth/`, because the validator's scope spans auth + observability):

- **`validate_secrets_or_die()`** — hard-fail validator covering exactly four parameters: `JwtSecret`, `GoogleClientId`, `GoogleClientSecret`, `OriginVerifySecret`. Raises `StartupConfigError` on the first unrotated placeholder. SSM exceptions propagate. Short-circuits when `AWS_LAMBDA_FUNCTION_NAME` is unset.
- **`warn_unrotated_observability_params()`** — soft-warn for `AlarmEmail`. Logs a single `WARNING` per cold start; never raises. Same Lambda-only short-circuit. SSM exceptions propagate.

Both hooks are wired at module import in `src/starter/api/main.py` (not `@app.on_event("startup")`) so the failure surfaces during AWS Lambda INIT. The deploy-fail surface is: (1) Lambda init fails closed, (2) /health returns error body not status-ok, (3) CI smoke must assert body content per #111, (4) pipeline red blocks promotion. CloudFormation does NOT report deploy failure for vanilla Function URL Lambdas; the original AC misspecified this.

Removed the silent fallbacks that masked the problem:

- `src/starter/auth/tokens.py:_jwt_secret()` — the random `secrets.token_hex(32)` fallback is gone. The `STARTER_JWT_SECRET` env var still wins (local-dev / test escape hatch); SSM exceptions now propagate.
- `src/starter/api/main.py:_verify_origin_secret` — the `expected != "CHANGE_ME_ON_FIRST_DEPLOY"` short-circuit is gone. The startup check guarantees the value is rotated.

Stack changes (`infra/stacks/starter_stack.py`):

- Added `STARTER_ALARM_EMAIL_PARAM` to `common_env` so the soft-warn check can resolve the parameter name.
- Granted the `ApiLambdaRole` read access to `alarm_email_param` so the soft-warn check's `ssm:GetParameter` call has permission.

## Env-var name decision

The issue spec listed `STARTER_GOOGLE_CLIENT_ID_PARAM` and `STARTER_GOOGLE_CLIENT_SECRET_PARAM`, but the immediately-following sentence said *"reuse them — do not hardcode paths"*, and the actual stack-wired names are `GOOGLE_CLIENT_ID_PARAM` / `GOOGLE_CLIENT_SECRET_PARAM` (no `STARTER_` prefix; established by `src/starter/auth/google.py`). Followed the actual wired names since the explicit instruction is to reuse them — adding a `STARTER_` prefix would have required either a new env var or hardcoded paths.

## Scope expansion (added 2026-04-29)

While running the post-rotation validation pass, rotating
`origin-verify-secret` to `SecureString` exposed a latent CDK bug:
`CfnDynamicReferenceService.SSM` (the dynamic reference used to inject
the secret into CloudFront's origin custom-header config) only
resolves plaintext SSM parameters. With the parameter as
`SecureString`, the dynamic reference resolved to `null`, CloudFront
stopped sending `X-Origin-Verify`, and every CloudFront-routed
request returned 403. The human reverted the parameter back to
`Type=String` with a fresh random value before this run.

Two CDK changes were folded into this PR to harden the contract:

1. **`is_prod` gate dropped on the X-Origin-Verify header** —
   `infra/stacks/starter_stack.py:429–448`. The validator's invariant
   is that `OriginVerifySecret` is load-bearing in **all** environments;
   the CloudFront header injection now matches. Previously the header
   was prod-only, so non-prod environments depended on the placeholder
   short-circuit (now removed) to allow traffic through.
2. **Inline locking comments at both touchpoints** documenting why
   `OriginVerifySecret` is intentionally `Type=String` and not
   `SecureString`:
   - `infra/stacks/starter_stack.py:182–189` (above the
     `ssm.StringParameter` declaration)
   - `infra/stacks/starter_stack.py:429–440` (above the CloudFront
     header injection block)

   The secret is defense-in-depth — preventing direct Function URL
   access from outside the AWS account — not crypto. The IAM-gated
   visibility on SSM and CloudFront origin config is the security
   boundary, and `String` is sufficient. Rotating to `SecureString`
   silently breaks the deploy.

3. **Rotation runbook updated** — `docs-site/operations/security.md`
   now carries the explicit `Type=String` warning, the canonical
   `aws ssm put-parameter` command form, and a delete-then-put caveat
   documenting the CloudFront/Lambda misalignment window if the
   parameter type ever needs to change.

The locked decision: `origin-verify-secret` stays `Type=String`. Any
future proposal to migrate it to `SecureString` or Secrets Manager
must contend with both the dynamic-reference incompatibility and the
defense-in-depth-not-crypto framing.

## Tests

- **`tests/unit/test_startup.py`** — covers each hard-fail placeholder rejection (parametrized over the four params), the AlarmEmail soft-warn path, the Lambda-only short-circuit for both hooks, the unset-env-var paths (hard-fail raises; soft-warn logs and returns), SSM permission/missing-param error propagation for both hooks, and the `_get_ssm_value` boto3 boundary.
- **`tests/integration/test_startup.py`** — confirms the FastAPI app **refuses to import** when `AWS_LAMBDA_FUNCTION_NAME=test` and any hard-fail parameter is unrotated (parametrized over all four). Separately confirms a single WARNING for `AlarmEmail`.
- **Coverage:** 100% on changed modules, 100% combined (551/551 statements).
- **Logging capture quirk:** the project's `_JsonFormatter` sets `propagate=False` on the `starter` logger tree, so `caplog` cannot see records via the root. Both new test files attach a dedicated handler to capture records on `starter.startup` directly.

## Findings deferred (out of scope)

The local Copilot review flagged that `src/starter/auth/tokens.py:_origin_verify_secret()` still has a `try/except: return None` wrapping its SSM call — meaning a *runtime* SSM failure (not a cold-start one) could cause the function to cache `None` for the container's lifetime, which would make the origin-verify middleware skip the header check.

This is a real concern but **out of scope per the locked issue spec**:

> Three folded findings (SEC-3 origin-verify silent disable, SEC-5 JWT random fallback, SEC-14 unrotated-placeholder visibility). **Single PR, single fix surface.**

The spec explicitly addresses only the *placeholder* short-circuit in the middleware (now removed) and the *random* fallback in `_jwt_secret()` (now removed). It does **not** call for changes to `_origin_verify_secret()`'s exception handling, and explicitly relies on it returning `None` for the local-dev case (`STARTER_ORIGIN_VERIFY_PARAM` unset). The mitigations in the current shape:

1. The startup check ensures the parameter is **readable** at cold start (the `_get_ssm_value` call would raise on permission-denied / missing).
2. `_origin_verify_secret()` uses `@functools.lru_cache(maxsize=1)`, so the SSM call typically happens once per warm container and any failure is detectable.
3. The race window described requires a deletion of the SSM parameter or revocation of IAM permissions *between* startup-validation success and first request — narrow and externally-driven.

Would suggest filing a follow-up to align `_origin_verify_secret()`'s exception handling with the new fail-closed posture (resolve at startup and pass the value into the middleware, mirroring the `_jwt_secret()` pattern).

## Validation gates

- [x] `inv pre-push` clean (lint, typecheck, unit, frontend)
- [x] `inv synth` clean
- [x] 100% coverage on changed modules (combined 551/551)
- [x] Integration test confirms wire-at-import contract under simulated Lambda env
- [x] Manual jc deploy with hard-fail param at placeholder — see "Manual jc validation — completed" below
- [x] Manual jc deploy with `AlarmEmail` at placeholder — see "Manual jc validation — completed" below
- [x] Final clean jc deploy with `/health` response captured — see "Manual jc validation — completed" below

## Not agent-safe

This issue is explicitly **not** labelled `agent-safe` (touches the auth path and the CDK boundary). Halting at human-merge after CI + Copilot review per the issue-worker §7.5 protocol.

---

## Manual jc validation — completed

End-to-end validation executed against `AgentCoreStarterStack-jc`
(account 247631471946, us-east-1) on 2026-04-29 by the issue-worker
agent, after the human rotated all five SSM parameters and reverted
`origin-verify-secret` from `SecureString` back to `Type=String`.

This section consolidates artifacts from the original 2026-04-27
hard-fail run (jc was at all-placeholders for the original deploy)
and the 2026-04-29 post-rotation run (covering the soft-warn,
clean-deploy, and origin-verify CloudFront contract).

### Pre-flight SSM state (2026-04-29, jc env)

Read **before** the deploy. No SSM modifications were performed by
this run.

| Parameter | Type | Version | Value-presence indicator |
|---|---|---|---|
| `/agentcore-starter/jc/jwt-secret` | SecureString | 2 | rotated |
| `/agentcore-starter/jc/google-client-id` | SecureString | 2 | rotated |
| `/agentcore-starter/jc/google-client-secret` | SecureString | 2 | rotated |
| `/agentcore-starter/jc/origin-verify-secret` | **String** | 1 | rotated (delete-then-put resets the version counter; `length=64` from `openssl rand -hex 32`) |
| `/agentcore-starter/jc/alarm-email` | String | 1 | placeholder `CHANGE_ME_ON_FIRST_DEPLOY` |

Note: `origin-verify-secret` is back at Version 1 because changing a
parameter's type requires `delete-parameter` + `put-parameter` (the
`--overwrite` flag on `put-parameter` cannot change the type), which
resets the version counter. `Type=String` is the load-bearing
property — see the "Scope expansion" section above.

### Step 2 — Deploy expanded PR

`uv run inv deploy --env jc` → version `0.8.0-jc.a378225` (with the
scope-expansion commit landed in `0.7.1.dev30+ga378225f0.d20260429`).

Stack events (CFN) — only two resources updated, matching expectations:

```
2026-04-29T01:01:57Z  AgentCoreStarterStack-jc       UPDATE_COMPLETE
2026-04-29T01:01:52Z  UiDistribution3836E805         UPDATE_COMPLETE
2026-04-29T01:01:17Z  UiDistribution3836E805         UPDATE_IN_PROGRESS
2026-04-29T01:01:12Z  ApiFunctionCE271BD4            UPDATE_COMPLETE
2026-04-29T01:01:02Z  ApiFunctionCE271BD4            UPDATE_IN_PROGRESS
2026-04-29T01:00:56Z  AgentCoreStarterStack-jc       UPDATE_IN_PROGRESS
```

`ApiFunction` updates the Lambda code; `UiDistribution` updates the
CloudFront origin custom-header config (the `is_prod` gate removal
re-injects `X-Origin-Verify` for the first time on jc). No other
resource changes.

Lambda state post-deploy:

```
LastModified: 2026-04-29T01:01:06.000+0000
CodeSha256:   j0X0Hick+YtNixOPS4KsIUgLLuDjWsWWn7X8OvsrYl8=
```

CloudWatch log group: `/aws/lambda/AgentCoreStarterStack-jc-ApiFunctionCE271BD4-VSdhh2tiQSKV`
Cold-start log stream: `2026/04/29/[$LATEST]9a5307f4c9274ba18d69c8c3e39e25ff`

### Step 4a — `/health` via CloudFront → 200 (matches contract)

```
$ curl -s -w "\nHTTP %{http_code}\n" https://agentcore-starter-jc.warlordofmars.net/health
{"status":"ok","version":"0.8.0-jc.a378225"}
HTTP 200
```

Body matches the documented contract `{"status":"ok","version":"<version>"}`.

### Step 4b — `/health` via direct Function URL → 403 (matches contract)

```
$ curl -s -w "\nHTTP %{http_code}\n" https://gmc3eqibrvymh6njdopftyibxu0ywbuo.lambda-url.us-east-1.on.aws/health
{"detail":"Forbidden"}
HTTP 403
```

**HTTP 403 here is the expected, correct behavior.** The Lambda's
`_verify_origin_secret` middleware rejects requests that lack a
matching `X-Origin-Verify` header. CloudFront injects the header on
its origin config; direct Function URL traffic does not present it
and is correctly refused. This is the security contract working as
designed — the validator's invariant is that
`OriginVerifySecret` is load-bearing in all envs, and the
post-scope-expansion stack now matches that invariant.

### Step 4c — AlarmEmail WARNING (exactly once per cold start)

Cold-start log stream: `2026/04/29/[$LATEST]9a5307f4c9274ba18d69c8c3e39e25ff`
Timestamp: `2026-04-29T01:02:22.127025+00:00` (epoch ms `1777424542127`)
Full message:

```json
{
  "timestamp": "2026-04-29T01:02:22.127025+00:00",
  "level": "WARNING",
  "service": "agentcore-starter",
  "version": "0.7.1.dev30+ga378225f0.d20260429",
  "env": "jc",
  "message": "SSM parameter /agentcore-starter/jc/alarm-email still has placeholder value 'CHANGE_ME_ON_FIRST_DEPLOY'; CloudWatch alarms will route to nowhere until this is rotated"
}
```

Verified single emission — `filter-log-events --filter-pattern WARNING`
on the post-deploy stream returns exactly one record.

### Step 4d — Error-pattern scan (clean)

`aws logs filter-log-events` against the post-deploy window
(`--start-time 1777424500000`) for each error pattern:

| Pattern | Match count |
|---|---|
| `StartupConfigError` | 0 |
| `Runtime.ExitError` | 0 |
| `Runtime.ImportModuleError` | 0 |

403 responses in the post-deploy window break down as follows
(filter `403` — three matches, all expected):

1. `127.0.0.1:38752 - "GET / HTTP/1.1" 403 Forbidden` — AWSLWA's
   localhost ready-check probe at startup. AWSLWA hits `/` to confirm
   uvicorn is responding; a 403 (origin-verify rejecting the missing
   header) is a valid "server is up" response. Present on every cold
   start, not introduced by this PR.
2. `73.167.245.241:0 - "GET /health HTTP/1.1" 403 Forbidden` at
   `01:02:26 UTC` — deliberate Step 4b probe.
3. `73.167.245.241:0 - "GET /health HTTP/1.1" 403 Forbidden` at
   `01:03:43 UTC` — repeat Step 4b probe (verifying reproducibility).

No unexpected 403s. CloudFront-routed traffic returns 200 (Step 4a
log entry confirms: `INFO: 73.167.245.241:0 - "GET /health HTTP/1.1" 200 OK`).

### Hard-fail artifacts (preserved from 2026-04-27 run)

The original 2026-04-27 run validated the hard-fail contract
end-to-end: jc was deployed with all four security-critical SSM
parameters at placeholder, and Lambda init failed-closed naming the
offending parameter.

CloudWatch log stream: `2026/04/27/[$LATEST]d4a240ce6f424e21a0fcdc8ef0573c2b`

```
File "/var/task/starter/api/main.py", line 42, in <module>
    validate_secrets_or_die()
File "/var/task/starter/startup.py", line 110, in validate_secrets_or_die
    raise StartupConfigError(
starter.startup.StartupConfigError: SSM parameter /agentcore-starter/jc/jwt-secret still has placeholder value 'CHANGE_ME_ON_FIRST_DEPLOY'; rotate it before the service can start
```

`INIT_REPORT`:

```
INIT_REPORT Init Duration: 3303.98 ms  Phase: invoke  Status: error  Error Type: Runtime.ExitError
```

The `validate_secrets_or_die()` invariant works exactly as specified:
the offending parameter is named, init exits, the `StartupConfigError`
class is correctly raised, and `Runtime.ExitError` surfaces.

### CFN-fail-on-deploy AC correction

The original AC claimed CloudFormation would report the deploy as
failed when Lambda init fails. **It does not** — CFN updates Lambda's
code and config via the Lambda API and a function that fails on init
reports nothing back to CFN. The deploy-fail surface for this fix is
the chain documented in the Approach section above:

> The deploy-fail surface is: (1) Lambda init fails closed,
> (2) /health returns error body not status-ok, (3) CI smoke must
> assert body content per #111, (4) pipeline red blocks promotion.
> CloudFormation does NOT report deploy failure for vanilla Function
> URL Lambdas; the original AC misspecified this.

The strategy partner is tracking the AC text correction on issue #16
separately.

### Final state of jc

- **CloudFormation:** `UPDATE_COMPLETE` — clean deploy
- **Lambda:** `0.8.0-jc.a378225`, init succeeds, serving 200 on
  CloudFront `/health` and 403 on direct Function URL `/health`
- **SSM:** unchanged from pre-flight (no SSM modifications were made
  by this validation run; `origin-verify-secret` was already at
  `Type=String` post-revert)
- **WARNING for `alarm-email`:** single emission per cold start,
  consistent with the spec
