### PR TITLE
docs: warn that cdk deploy does not propagate SSM rotation to CloudFront

### DIFF
--- a/docs-site/operations/security.md
+++ b/docs-site/operations/security.md
@@ -201,14 +201,17 @@ middleware.
    > ```
    >
    > **Verification.** Run the verification curls **only after
-   > completing step 4 below** (the Lambda bounce that flushes the
-   > `_origin_verify_secret` lru-cache). Between `update-distribution`
-   > finishing and the Lambda bounce, CloudFront is sending the new
-   > header value while Lambda is still validating against the old
-   > cached value — every CloudFront-routed request 403s in that
-   > window, and the 403 is *expected*, not a failed CloudFront
-   > update. Wait for the distribution status to reach `Deployed`
-   > (a few minutes), perform step 4, then run:
+   > completing rotation step 4 below** (the outer rotation
+   > procedure's Lambda bounce, which flushes the
+   > `_origin_verify_secret` lru-cache — distinct from the
+   > workaround snippet's own `# 4. Push the update…` step).
+   > Between `update-distribution` finishing and the Lambda bounce,
+   > CloudFront is sending the new header value while Lambda is
+   > still validating against the old cached value — every
+   > CloudFront-routed request 403s in that window, and the 403 is
+   > *expected*, not a failed CloudFront update. Wait for the
+   > distribution status to reach `Deployed` (a few minutes),
+   > perform rotation step 4, then run:
    >
    > ```bash
    > # Direct Function URL with no header → 403 (Lambda rejects).
@@ -216,11 +219,11 @@ middleware.
    >   "https://<lambda-function-url-host>/health"
    > # Expect: 403
    >
-   > # /health via CloudFront → 200 with status:ok ONLY after step 4
-   > # has refreshed Lambda's cached SSM secret to match CloudFront's
-   > # injected header value.
+   > # /health via CloudFront → 200 with status:ok ONLY after
+   > # rotation step 4 has refreshed Lambda's cached SSM secret to
+   > # match CloudFront's injected header value.
    > curl -sS "https://agentcore-starter-<env>.<hosted-zone>/health"
-   > # Expect after step 4: {"status":"ok","version":"..."}
+   > # Expect after rotation step 4: {"status":"ok","version":"..."}
    > ```
    >
    > Both observations together confirm CloudFront is now sending

--- a/docs-site/operations/security.md
+++ b/docs-site/operations/security.md
@@ -105,10 +105,14 @@ middleware.
    ```
    For prod, the parameter path drops the `<env>/` segment:
    `/agentcore-starter/origin-verify-secret`.
-3. Re-deploy the stack so CloudFront picks up the new value via the
-   `CfnDynamicReference` in `origin_verify_header`. CDK only resolves
-   the SSM dynamic reference at synth/deploy time, so a parameter
-   update alone is not enough.
+3. Re-deploy the stack. **By itself this is not enough** — see the
+   WARNING immediately below. CDK only resolves the
+   `CfnDynamicReference` in `origin_verify_header` at synth/deploy
+   time, so a bare `aws ssm put-parameter` won't propagate the new
+   value, but the redeploy alone won't either. The WARNING below
+   explains why and gives the manual workaround required after every
+   rotation until [#116](https://github.com/warlordofmars/agentcore-starter/issues/116)
+   lands.
 
    > **WARNING — `cdk deploy` does NOT propagate the rotated SSM
    > value to CloudFront.** The CloudFront origin custom-header for
@@ -138,18 +142,33 @@ middleware.
    > a `trap` to wipe them on exit:
    >
    > ```bash
-   > # Allocate temp files and ensure they are removed even on error.
-   > DIST_CONFIG=$(mktemp)
-   > DIST_BODY=$(mktemp)
-   > DIST_BODY_PATCHED=$(mktemp)
+   > # 0. Re-export the value just written to SSM in step 2 of the
+   > #    outer rotation procedure. The patch in step 3 below splices
+   > #    NEW_SECRET into CloudFront's distribution config.
+   > export NEW_SECRET="<the-same-value-passed-to-aws-ssm-put-parameter>"
+   >
+   > # Allocate temp files (with explicit templates for portability
+   > # across GNU coreutils and BSD mktemp) and ensure they are
+   > # removed on exit — they contain the rotated secret in plaintext.
+   > DIST_CONFIG=$(mktemp "${TMPDIR:-/tmp}/dist-config.XXXXXX")
+   > DIST_BODY=$(mktemp "${TMPDIR:-/tmp}/dist-body.XXXXXX")
+   > DIST_BODY_PATCHED=$(mktemp "${TMPDIR:-/tmp}/dist-body-patched.XXXXXX")
    > trap 'rm -f "$DIST_CONFIG" "$DIST_BODY" "$DIST_BODY_PATCHED"' EXIT
    >
    > # 1. Resolve the distribution ID for this environment.
-   > #    Replace <env> with dev / jc / prod as appropriate; for prod,
-   > #    the alias is `agentcore-starter` (no env suffix).
+   > #    For dev / jc / non-prod environments, the alias is
+   > #    `agentcore-starter-<env>` — substitute the env name in the
+   > #    JMESPath below. For prod, the alias is `agentcore-starter`
+   > #    (no env suffix), so use the prod-specific filter shown in
+   > #    the second form.
+   > # Non-prod (replace <env>):
    > DIST_ID=$(aws cloudfront list-distributions \
    >   --query "DistributionList.Items[?Aliases.Items[?contains(@, 'agentcore-starter-<env>')]].Id" \
    >   --output text)
+   > # Prod equivalent (uncomment for prod, comment out the form above):
+   > # DIST_ID=$(aws cloudfront list-distributions \
+   > #   --query "DistributionList.Items[?Aliases.Items[?@ == 'agentcore-starter.<hosted-zone>']].Id" \
+   > #   --output text)
    >
    > # 2. Fetch the current distribution config + ETag. The response
    > #    has top-level keys DistributionConfig and ETag; update-distribution
@@ -161,7 +180,6 @@ middleware.
    >
    > # 3. Patch the X-Origin-Verify HeaderValue under the Lambda
    > #    Function URL origin (the origin whose CustomHeaders.Quantity > 0).
-   > #    NEW_SECRET is the value just written to SSM in step 2 above.
    > jq --arg new "$NEW_SECRET" '
    >   .Origins.Items |= map(
    >     if (.CustomHeaders.Quantity // 0) > 0 then

--- a/docs-site/operations/security.md
+++ b/docs-site/operations/security.md
@@ -200,9 +200,15 @@ middleware.
    >   --distribution-config "file://$DIST_BODY_PATCHED"
    > ```
    >
-   > **Verification.** After the `update-distribution` call returns
-   > and the distribution status reaches `Deployed` (a few minutes),
-   > confirm the new secret is in sync between CloudFront and Lambda:
+   > **Verification.** Run the verification curls **only after
+   > completing step 4 below** (the Lambda bounce that flushes the
+   > `_origin_verify_secret` lru-cache). Between `update-distribution`
+   > finishing and the Lambda bounce, CloudFront is sending the new
+   > header value while Lambda is still validating against the old
+   > cached value — every CloudFront-routed request 403s in that
+   > window, and the 403 is *expected*, not a failed CloudFront
+   > update. Wait for the distribution status to reach `Deployed`
+   > (a few minutes), perform step 4, then run:
    >
    > ```bash
    > # Direct Function URL with no header → 403 (Lambda rejects).
@@ -210,10 +216,11 @@ middleware.
    >   "https://<lambda-function-url-host>/health"
    > # Expect: 403
    >
-   > # /health via CloudFront → 200 with status:ok (CloudFront's injected
-   > # header now matches what Lambda reads from SSM).
+   > # /health via CloudFront → 200 with status:ok ONLY after step 4
+   > # has refreshed Lambda's cached SSM secret to match CloudFront's
+   > # injected header value.
    > curl -sS "https://agentcore-starter-<env>.<hosted-zone>/health"
-   > # Expect: {"status":"ok","version":"..."}
+   > # Expect after step 4: {"status":"ok","version":"..."}
    > ```
    >
    > Both observations together confirm CloudFront is now sending

--- a/docs-site/operations/security.md
+++ b/docs-site/operations/security.md
@@ -109,6 +109,98 @@ middleware.
    `CfnDynamicReference` in `origin_verify_header`. CDK only resolves
    the SSM dynamic reference at synth/deploy time, so a parameter
    update alone is not enough.
+
+   > **WARNING — `cdk deploy` does NOT propagate the rotated SSM
+   > value to CloudFront.** The CloudFront origin custom-header for
+   > `X-Origin-Verify` is wired with `CfnDynamicReferenceService.SSM`,
+   > which renders into the CloudFormation template as a fixed
+   > literal string of the form <code v-pre>{{resolve:ssm:/agentcore-starter/&lt;env&gt;/origin-verify-secret}}</code>.
+   > That template string is identical across SSM rotations, so
+   > CloudFormation sees no diff on the `UiDistribution` resource
+   > and CloudFront's stored distribution config is never updated.
+   > Tracked as [#116](https://github.com/warlordofmars/agentcore-starter/issues/116);
+   > until the architectural fix lands, follow the manual workaround
+   > below after every origin-verify rotation.
+   >
+   > **Failure mode.** The next Lambda cold start reads the new
+   > secret from SSM directly, but CloudFront keeps sending the old
+   > secret on every origin request. Result: every CloudFront-routed
+   > request returns 403 from `_verify_origin_secret`, surfacing
+   > minutes to hours after the deploy depending on cold-start
+   > timing. The deploy logs show success and there is no signal at
+   > the moment of action that anything is wrong — failure mimics
+   > success.
+   >
+   > **CLI workaround.** Splice the new secret into CloudFront's
+   > distribution config directly. Validated against the dev and jc
+   > distributions on 2026-04-29. The intermediate files contain the
+   > rotated secret in plaintext, so the snippet uses `mktemp` and
+   > a `trap` to wipe them on exit:
+   >
+   > ```bash
+   > # Allocate temp files and ensure they are removed even on error.
+   > DIST_CONFIG=$(mktemp)
+   > DIST_BODY=$(mktemp)
+   > DIST_BODY_PATCHED=$(mktemp)
+   > trap 'rm -f "$DIST_CONFIG" "$DIST_BODY" "$DIST_BODY_PATCHED"' EXIT
+   >
+   > # 1. Resolve the distribution ID for this environment.
+   > #    Replace <env> with dev / jc / prod as appropriate; for prod,
+   > #    the alias is `agentcore-starter` (no env suffix).
+   > DIST_ID=$(aws cloudfront list-distributions \
+   >   --query "DistributionList.Items[?Aliases.Items[?contains(@, 'agentcore-starter-<env>')]].Id" \
+   >   --output text)
+   >
+   > # 2. Fetch the current distribution config + ETag. The response
+   > #    has top-level keys DistributionConfig and ETag; update-distribution
+   > #    accepts only the inner DistributionConfig as its --distribution-config
+   > #    body, so split the two.
+   > aws cloudfront get-distribution-config --id "$DIST_ID" > "$DIST_CONFIG"
+   > ETAG=$(jq -r '.ETag' "$DIST_CONFIG")
+   > jq '.DistributionConfig' "$DIST_CONFIG" > "$DIST_BODY"
+   >
+   > # 3. Patch the X-Origin-Verify HeaderValue under the Lambda
+   > #    Function URL origin (the origin whose CustomHeaders.Quantity > 0).
+   > #    NEW_SECRET is the value just written to SSM in step 2 above.
+   > jq --arg new "$NEW_SECRET" '
+   >   .Origins.Items |= map(
+   >     if (.CustomHeaders.Quantity // 0) > 0 then
+   >       .CustomHeaders.Items |= map(
+   >         if .HeaderName == "X-Origin-Verify" then .HeaderValue = $new else . end
+   >       )
+   >     else . end
+   >   )
+   > ' "$DIST_BODY" > "$DIST_BODY_PATCHED"
+   >
+   > # 4. Push the update with the captured ETag.
+   > aws cloudfront update-distribution \
+   >   --id "$DIST_ID" \
+   >   --if-match "$ETAG" \
+   >   --distribution-config "file://$DIST_BODY_PATCHED"
+   > ```
+   >
+   > **Verification.** After the `update-distribution` call returns
+   > and the distribution status reaches `Deployed` (a few minutes),
+   > confirm the new secret is in sync between CloudFront and Lambda:
+   >
+   > ```bash
+   > # Direct Function URL with no header → 403 (Lambda rejects).
+   > curl -sS -o /dev/null -w "%{http_code}\n" \
+   >   "https://<lambda-function-url-host>/health"
+   > # Expect: 403
+   >
+   > # /health via CloudFront → 200 with status:ok (CloudFront's injected
+   > # header now matches what Lambda reads from SSM).
+   > curl -sS "https://agentcore-starter-<env>.<hosted-zone>/health"
+   > # Expect: {"status":"ok","version":"..."}
+   > ```
+   >
+   > Both observations together confirm CloudFront is now sending
+   > the rotated secret and Lambda accepts it. If only the second
+   > step is verified, the validation is incomplete — a stale
+   > CloudFront header that happens to match a stale Lambda cache
+   > would also pass `/health`.
+
 4. Bounce the Lambda (e.g. publish a new version or update an
    environment variable) so the `lru_cache` on `_origin_verify_secret`
    re-reads SSM. CloudFront and Lambda are briefly out of sync during

--- a/docs-site/operations/security.md
+++ b/docs-site/operations/security.md
@@ -106,12 +106,15 @@ middleware.
    For prod, the parameter path drops the `<env>/` segment:
    `/agentcore-starter/origin-verify-secret`.
 3. Re-deploy the stack. **By itself this is not enough** — see the
-   WARNING immediately below. CDK only resolves the
-   `CfnDynamicReference` in `origin_verify_header` at synth/deploy
-   time, so a bare `aws ssm put-parameter` won't propagate the new
-   value, but the redeploy alone won't either. The WARNING below
-   explains why and gives the manual workaround required after every
-   rotation until [#116](https://github.com/warlordofmars/agentcore-starter/issues/116)
+   WARNING immediately below. CDK synthesizes the
+   `CfnDynamicReference` in `origin_verify_header` into the
+   CloudFormation template, and CloudFormation resolves the resulting
+   <code v-pre>{{resolve:ssm:...}}</code> reference during stack
+   create/update. Because the template string stays byte-identical
+   across SSM rotations, a bare `aws ssm put-parameter` won't
+   propagate the new value, and the redeploy alone won't either. The
+   WARNING below explains why and gives the manual workaround required
+   after every rotation until [#116](https://github.com/warlordofmars/agentcore-starter/issues/116)
    lands.
 
    > **WARNING — `cdk deploy` does NOT propagate the rotated SSM
@@ -226,6 +229,17 @@ middleware.
 
 #### If the parameter type ever needs to change
 
+> **The same propagation gap from the WARNING in step 3 applies
+> here.** Until [#116](https://github.com/warlordofmars/agentcore-starter/issues/116)
+> lands, references to "after the CDK redeploy" in this section
+> should be read as "after the CDK redeploy **and** the manual
+> `aws cloudfront update-distribution` step from the WARNING above".
+> The bullets describe what *would* happen if redeploy alone
+> propagated the SSM value, and translate to the post-#116 steady
+> state — they are still useful for understanding the misalignment
+> windows, but the manual step has to land in the same operator
+> sequence today.
+
 `aws ssm put-parameter --overwrite` cannot change a parameter's type;
 it can only update the value of an existing parameter of the same
 type. Changing the type requires `aws ssm delete-parameter` followed
@@ -243,15 +257,18 @@ CloudFront and Lambda:
   redeploy, the SSM parameter holds the new value but CloudFront is
   still injecting the old. Lambda will reject every CloudFront
   request as soon as its lru-cache expires (next cold start).
-- After the CDK redeploy but before the Lambda cold-starts,
+- After the CDK redeploy and the manual `update-distribution` step
+  (per the WARNING above), but before the Lambda cold-starts,
   CloudFront sends the new header value while Lambda is still
   validating against the old. Every request 403s.
 
 Recommend doing the type change during a maintenance pause: announce
-downtime, run delete-then-put, redeploy CDK, then force a Lambda
-cold start (publish a new version or touch an environment variable).
-Verify `/health` returns 200 through CloudFront and 403 against the
-direct Function URL before lifting the maintenance window.
+downtime, run delete-then-put, redeploy CDK, run the manual
+`aws cloudfront update-distribution` workaround from the WARNING in
+step 3, then force a Lambda cold start (publish a new version or
+touch an environment variable). Verify `/health` returns 200 through
+CloudFront and 403 against the direct Function URL before lifting the
+maintenance window.
 
 ## JWT signing secret
 

--- a/docs-site/operations/security.md
+++ b/docs-site/operations/security.md
@@ -158,15 +158,19 @@ middleware.
    > DIST_BODY_PATCHED=$(mktemp "${TMPDIR:-/tmp}/dist-body-patched.XXXXXX")
    > trap 'rm -f "$DIST_CONFIG" "$DIST_BODY" "$DIST_BODY_PATCHED"' EXIT
    >
-   > # 1. Resolve the distribution ID for this environment.
-   > #    For dev / jc / non-prod environments, the alias is
-   > #    `agentcore-starter-<env>` — substitute the env name in the
-   > #    JMESPath below. For prod, the alias is `agentcore-starter`
-   > #    (no env suffix), so use the prod-specific filter shown in
-   > #    the second form.
-   > # Non-prod (replace <env>):
+   > # 1. Resolve the distribution ID for this environment. The
+   > #    CloudFront alternate domain name is the full FQDN — for dev /
+   > #    jc / non-prod environments,
+   > #    `agentcore-starter-<env>.<hosted-zone>`; for prod,
+   > #    `agentcore-starter.<hosted-zone>` (no env suffix). The
+   > #    JMESPath uses exact-match (`@ == ...`) on the full FQDN to
+   > #    avoid matching unrelated distributions whose alias happens to
+   > #    share the `agentcore-starter-<env>` prefix (e.g. `dev` vs
+   > #    `dev2`) — `contains(@, ...)` would silently return multiple
+   > #    IDs and break the get-distribution-config call below.
+   > # Non-prod (replace <env> and <hosted-zone>):
    > DIST_ID=$(aws cloudfront list-distributions \
-   >   --query "DistributionList.Items[?Aliases.Items[?contains(@, 'agentcore-starter-<env>')]].Id" \
+   >   --query "DistributionList.Items[?Aliases.Items[?@ == 'agentcore-starter-<env>.<hosted-zone>']].Id" \
    >   --output text)
    > # Prod equivalent (uncomment for prod, comment out the form above):
    > # DIST_ID=$(aws cloudfront list-distributions \


### PR DESCRIPTION
Closes #117

Mitigates #116 (architectural fix tracked separately).
Corrects the runbook shipped in #115.
Part of #56 (bootstrap-pattern epic).

## Summary

The rotation procedure in `docs-site/operations/security.md` (shipped
in PR #115) instructs operators to `aws ssm put-parameter --overwrite`
followed by `cdk deploy`, with the implication that the redeploy
propagates the new value to CloudFront. **It does not** — see #116 for
the architectural defect.

Following the runbook as written today silently breaks every
CloudFront-routed request at the next Lambda cold start: Lambda reads
the NEW secret from SSM directly, but CloudFront keeps sending the OLD
secret. Result: 403 on every request, surfacing minutes to hours after
the deploy with no signal at the moment of action that anything is
wrong. This is a worse failure mode than the silent-fallback that
#115 deleted, because it mimics success.

This PR adds a hot-fix WARNING block immediately after step 3 of the
origin-verify rotation procedure with: (a) plain-language statement
of the propagation gap, (b) failure-mode description, (c) a concrete
CLI workaround, (d) a verification step, (e) a reference to #116.

## Approach

Single-file additive edit to `docs-site/operations/security.md`.
Inserted between steps 3 and 4 of the existing rotation procedure,
before the "If the parameter type ever needs to change" section. No
existing content modified. No CDK or runtime code touched.

The CLI workaround uses `mktemp` + `trap` for the intermediate
distribution-config files (they contain the rotated secret in
plaintext). Inline-code wrapping of the literal CFN dynamic-reference
template string uses `<code v-pre>` to keep VitePress's Vue compiler
from treating the `{{...}}` as a mustache interpolation — without
this the docs build fails. Verified by running `npm run build` in
`docs-site/`.

## CLI workaround validation

The issue body's CLI form was directionally correct but had two
edge cases to nail down. Validated end-to-end against the jc
distribution (alias `agentcore-starter-jc`) on 2026-04-29; the dev
distribution (alias `agentcore-starter-dev`) was confirmed to
resolve via the same JMESPath query. All commands ran with the
operator's actual AWS credentials; the `update-distribution` call
itself was NOT executed against the live distribution — instead I
confirmed the body shape by patching to a dummy value in a temp
file and inspecting before discarding.

**1. Distribution-ID lookup.** JMESPath as written in the issue
body works:

```text
$ aws cloudfront list-distributions \
    --query "DistributionList.Items[?Aliases.Items[?contains(@, 'agentcore-starter-jc')]].Id" \
    --output text
E2SEHJWJZL768N

$ aws cloudfront list-distributions \
    --query "DistributionList.Items[?Aliases.Items[?contains(@, 'agentcore-starter-dev')]].Id" \
    --output text
EUKUNAEU6YWDQ
```

**2. `get-distribution-config` output structure.** Top-level keys
are `DistributionConfig` and `ETag`; `update-distribution` accepts
only the **inner** `DistributionConfig` as its `--distribution-config`
body. The runbook now splits the two via `jq`:

```text
$ aws cloudfront get-distribution-config --id E2SEHJWJZL768N > "$DIST_CONFIG"
$ jq 'keys' "$DIST_CONFIG"
[
  "DistributionConfig",
  "ETag"
]
$ jq -r '.ETag' "$DIST_CONFIG"
E13V1IB3...   # [REDACTED-tail]
```

**3. `X-Origin-Verify` HeaderValue path.** Lives at
`.Origins.Items[<idx>].CustomHeaders.Items[<idx>].HeaderValue` (relative
to the inner `DistributionConfig`). The Lambda Function URL origin is
the one with `CustomHeaders.Quantity > 0` (the S3 bucket origin has
no custom headers), which is the selector the runbook's `jq` patch
uses:

```text
$ jq '.DistributionConfig.Origins.Items[] | select(.CustomHeaders.Quantity > 0) | {Id, DomainName, headers: .CustomHeaders.Items[] | {HeaderName}}' "$DIST_CONFIG"
{
  "Id": "AgentCoreStarterStackjcUiDistributionOrigin24AC1AF44",
  "DomainName": "[REDACTED-lambda-function-url-host]",
  "headers": {
    "HeaderName": "X-Origin-Verify"
  }
}
```

**4. End-to-end `jq` patch dry-run.** Patched the HeaderValue to a
dummy string in a temp file (NO `update-distribution` call against
the live distribution):

```text
$ NEW_SECRET="dummy-validation-only-not-pushed-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
$ jq --arg new "$NEW_SECRET" '.Origins.Items |= map(if (.CustomHeaders.Quantity // 0) > 0 then .CustomHeaders.Items |= map(if .HeaderName == "X-Origin-Verify" then .HeaderValue = $new else . end) else . end)' "$DIST_BODY" > "$DIST_BODY_PATCHED"
$ jq '.Origins.Items[] | select(.CustomHeaders.Quantity > 0) | .CustomHeaders.Items[] | select(.HeaderName=="X-Origin-Verify") | .HeaderValue' "$DIST_BODY_PATCHED"
"dummy-validation-only-not-pushed-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
$ jq '.Origins.Items[] | select(.CustomHeaders.Quantity > 0) | .CustomHeaders.Items[] | select(.HeaderName=="X-Origin-Verify") | .HeaderValue | length' "$DIST_BODY"
64   # original 64-char hex secret untouched in the unpatched body
```

**5. Verification curls.** Confirmed against the live jc stack as it
stands today (already in sync from a manual recovery on 2026-04-29):

```text
$ curl -sS -o /dev/null -w "%{http_code}\n" "https://[REDACTED-lambda-function-url-host]/health"
403
$ curl -sS "https://agentcore-starter-jc.warlordofmars.net/health"
{"status":"ok","version":"0.8.0-jc.[REDACTED-sha]"}
```

Both observations together confirm the runbook's verification step
behaves as documented.

## Deviations from the issue body

- **Inner-body split made explicit.** The issue body said "Extract
  the inner DistributionConfig and edit ... `.Origins.Items[<api-origin>].CustomHeaders.Items[*]`". The runbook now explicitly shows the
  `jq '.DistributionConfig'` extraction (rather than implying it) and
  uses positional indexing (`<idx>`) since the Items array is
  positional, not keyed by Id.
- **`mktemp` + `trap` instead of fixed `/tmp/*.json`.** The issue
  body's template used `/tmp/dist-config.json`. The runbook uses
  `mktemp` so the intermediate files (which contain the rotated
  secret in plaintext) are wiped on shell exit. Triaged from a local
  Copilot review pass before opening the PR. Functionally equivalent;
  the operator can still `cat \"\$DIST_BODY_PATCHED\"` between steps
  to inspect.
- **VitePress `<code v-pre>` workaround.** The CFN dynamic-reference
  template string `{{resolve:ssm:...}}` cannot appear inside backtick
  inline code in a VitePress markdown file because the Vue compiler
  pre-processes the source and treats `{{...}}` as a mustache
  interpolation even inside backticks. Wrapped that one literal in
  `<code v-pre>` (with `&lt;`/`&gt;` for the `<env>` placeholder).
  The docs build now passes (`vitepress build` clean).

## Validation

- `uv run inv pre-push` — exit 0 (lint, typecheck, 269 frontend
  tests pass, no Python tests changed)
- `npm run build` in `docs-site/` — clean (`build complete in 3.03s`)
- CLI workaround validated end-to-end against the jc distribution
  (see "CLI workaround validation" above) — secrets redacted

## Halts

This is `agent-safe` per the issue's labels, but the orchestrator
directive instructed to **halt at PR ready-for-human-review without
arming auto-merge** — runbook content is load-bearing for ops and
warrants human review before it lands. Auto-merge NOT armed.