### PR TITLE
fix(ci): skip SonarCloud + Codecov steps for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,9 +312,16 @@ jobs:
       - name: SonarCloud Scan
         # Dependabot PRs run with a restricted GITHUB_TOKEN and have no
         # access to repo secrets — SONAR_TOKEN resolves to empty and the
-        # scan fails. Skip the secret-requiring steps for Dependabot; the
-        # PR coverage comment above (GITHUB_TOKEN only) still runs. See #120.
-        if: github.actor != 'dependabot[bot]'
+        # scan fails. Skip the secret-requiring steps for Dependabot PRs;
+        # the PR coverage comment above (GITHUB_TOKEN only) still runs.
+        # Gate on `pull_request.user.login` (the PR author) rather than
+        # `github.actor` — actor flips to the maintainer when a human
+        # re-runs the workflow, which would re-execute these steps on a
+        # still-Dependabot-authored PR and fail again. user.login is
+        # stable across re-runs. On push events `pull_request` is null,
+        # so the comparison is truthy and the step runs as today.
+        # See #120.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -326,7 +333,7 @@ jobs:
           args: ${{ github.ref == 'refs/heads/main' && '-Dsonar.qualitygate.wait=false' || '' }}
 
       - name: Fetch SonarCloud issues as SARIF
-        if: always() && github.actor != 'dependabot[bot]'
+        if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
@@ -336,14 +343,14 @@ jobs:
           python3 scripts/sonar_to_sarif.py sonar-issues.json sonar.sarif
 
       - name: Upload SonarCloud results to GitHub Security
-        if: always() && github.actor != 'dependabot[bot]'
+        if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
         uses: github/codeql-action/upload-sarif@f94817b9f0deeb3871261446912ae8f854d1b675 # codeql-bundle-v2.25.1
         with:
           sarif_file: sonar.sarif
           category: sonarcloud
 
       - name: Upload to Codecov
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage-unit.xml,coverage-combined.xml,lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,11 @@ jobs:
             }
 
       - name: SonarCloud Scan
+        # Dependabot PRs run with a restricted GITHUB_TOKEN and have no
+        # access to repo secrets — SONAR_TOKEN resolves to empty and the
+        # scan fails. Skip the secret-requiring steps for Dependabot; the
+        # PR coverage comment above (GITHUB_TOKEN only) still runs. See #120.
+        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -321,7 +326,7 @@ jobs:
           args: ${{ github.ref == 'refs/heads/main' && '-Dsonar.qualitygate.wait=false' || '' }}
 
       - name: Fetch SonarCloud issues as SARIF
-        if: always()
+        if: always() && github.actor != 'dependabot[bot]'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
@@ -331,13 +336,14 @@ jobs:
           python3 scripts/sonar_to_sarif.py sonar-issues.json sonar.sarif
 
       - name: Upload SonarCloud results to GitHub Security
-        if: always()
+        if: always() && github.actor != 'dependabot[bot]'
         uses: github/codeql-action/upload-sarif@f94817b9f0deeb3871261446912ae8f854d1b675 # codeql-bundle-v2.25.1
         with:
           sarif_file: sonar.sarif
           category: sonarcloud
 
       - name: Upload to Codecov
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage-unit.xml,coverage-combined.xml,lcov.info


### PR DESCRIPTION
Closes #120

## Summary

Dependabot PRs fail the `Coverage Report` job in `ci.yml` because Dependabot runs with a restricted `GITHUB_TOKEN` and **no access to repository secrets** — `SONAR_TOKEN` and `CODECOV_TOKEN` both resolve to empty, the SonarCloud scan exits 3, and the downstream SARIF upload + Codecov upload cascade fail. This blocks auto-merge despite all functional checks (lint, unit, integration, frontend, synth, security audit, scope checks) being green. Surfaced by PR #119 (lucide-react bump).

This change gates the four secret-requiring steps in the `coverage` job with `if: github.event.pull_request.user.login != 'dependabot[bot]'`:

- SonarCloud Scan
- Fetch SonarCloud issues as SARIF (combined with existing `always()`)
- Upload SonarCloud results to GitHub Security (combined with existing `always()`)
- Upload to Codecov

The `Post coverage comment on PR` step (`GITHUB_TOKEN` only, no secrets needed) is **unchanged** — it continues to run on Dependabot PRs and post the coverage table as today.

## Approach

### `pull_request.user.login` (final) vs `github.actor` (initial)

The issue body suggested `github.actor != 'dependabot[bot]'` for readability. The initial commit used that form. **Copilot review caught a real correctness gap**: `github.actor` flips to the maintainer when a human re-runs the workflow via the "Re-run jobs" UI button, which would re-execute the secret-requiring steps on a still-Dependabot-authored PR and fail again. This matches GitHub Docs' explicit recommendation to use `github.event.pull_request.user.login` for "is this a Dependabot PR" decisions — `user.login` is the PR author, which is stable across re-runs.

Switched to `github.event.pull_request.user.login != 'dependabot[bot]'` in commit a86edf6. On non-PR `push` events (the existing development/main-branch deploy path), `github.event.pull_request` is null, so the comparison is truthy and the step runs as today — verified by the post-fix CI run on this PR.

### Why gate (not `pull_request_target`)

Locked in by the issue body: running untrusted dependency-bump code with elevated permissions for code-quality scans is not a worthwhile tradeoff. Skipping the secret-requiring steps for Dependabot PRs is the safer choice — the dependency-bump itself is still gated by lint, unit, integration, frontend, synth, audit, and scope checks (none of which need repo secrets).

## Validation

- `inv pre-push` clean locally on both commits (189 unit tests, 269 frontend tests, all green).
- This PR's CI run is the regression check on the non-Dependabot path (PR is human-authored, so `pull_request.user.login != 'dependabot[bot]'` is true and the SonarCloud + Codecov steps still run as today).

## Post-merge validation procedure

Acceptance for the Dependabot path can only be verified once this fix is on `development`. After merging:

1. Comment `@dependabot rebase` on PR #119 (or push an empty commit to its branch) to re-run CI against the updated workflow.
2. The `Coverage Report` job should now succeed — the four gated steps will be skipped (visible as "Skipped" in the run UI), and the "Post coverage comment on PR" step should still run and post the coverage table.
3. Once #119's CI is green, that PR is unblocked for auto-merge.

Do **not** close #119 from this PR — it stays open until its CI re-runs cleanly.

## Related

- Surfaced by: #119 (lucide-react 1.11.0 → 1.14.0 — left open for re-run after this lands)
- Part of: #56 (template-bootstrap epic — SonarCloud integration assumed all PRs have token access)