### PR TITLE
fix(ci): harden /health smoke check to assert response body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,19 +652,23 @@ jobs:
           # JSON), so status-only smoke is structurally incapable of
           # catching init failures. Do not unwind this assertion without
           # filing a replacement defense — see #111.
-          RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
-          STATUS=$(echo "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
-          BODY=$(echo "$RESPONSE" | sed '$d')
+          # -sS surfaces curl-side errors (DNS/TLS/connectivity) instead
+          # of silently hiding them; --connect-timeout / --max-time
+          # prevent indefinite hangs.
+          RESPONSE=$(curl -sS --connect-timeout 5 --max-time 15 -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
+          STATUS=$(printf '%s\n' "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
+          BODY=$(printf '%s\n' "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"
           # Print the body inside a workflow-command group, with each line
           # prefixed, so a malicious/malformed body cannot inject Actions
           # workflow commands (lines starting with '::...' are interpreted
-          # by the runner otherwise).
+          # by the runner otherwise). Use printf to avoid echo's
+          # implementation-defined handling of leading '-n'/'-e' tokens.
           echo "::group::Health check body"
-          echo "$BODY" | sed 's/^/  /'
+          printf '%s\n' "$BODY" | sed 's/^/  /'
           echo "::endgroup::"
           [ "$STATUS" = "200" ] || (echo "Dev health check HTTP status not 200!" && exit 1)
-          HEALTH_STATUS=$(echo "$BODY" | jq -r '.status') || (echo "Dev health check body is not valid JSON!" && exit 1)
+          HEALTH_STATUS=$(printf '%s\n' "$BODY" | jq -r '.status') || (echo "Dev health check body is not valid JSON!" && exit 1)
           [ "$HEALTH_STATUS" = "ok" ] || (echo "Dev health check .status != 'ok' (got: $HEALTH_STATUS)" && exit 1)
 
       - name: Notify Slack — e2e failure
@@ -844,19 +848,23 @@ jobs:
           # JSON), so status-only smoke is structurally incapable of
           # catching init failures. Do not unwind this assertion without
           # filing a replacement defense — see #111.
-          RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
-          STATUS=$(echo "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
-          BODY=$(echo "$RESPONSE" | sed '$d')
+          # -sS surfaces curl-side errors (DNS/TLS/connectivity) instead
+          # of silently hiding them; --connect-timeout / --max-time
+          # prevent indefinite hangs.
+          RESPONSE=$(curl -sS --connect-timeout 5 --max-time 15 -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
+          STATUS=$(printf '%s\n' "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
+          BODY=$(printf '%s\n' "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"
           # Print the body inside a workflow-command group, with each line
           # prefixed, so a malicious/malformed body cannot inject Actions
           # workflow commands (lines starting with '::...' are interpreted
-          # by the runner otherwise).
+          # by the runner otherwise). Use printf to avoid echo's
+          # implementation-defined handling of leading '-n'/'-e' tokens.
           echo "::group::Health check body"
-          echo "$BODY" | sed 's/^/  /'
+          printf '%s\n' "$BODY" | sed 's/^/  /'
           echo "::endgroup::"
           [ "$STATUS" = "200" ] || (echo "Prod health check HTTP status not 200!" && exit 1)
-          HEALTH_STATUS=$(echo "$BODY" | jq -r '.status') || (echo "Prod health check body is not valid JSON!" && exit 1)
+          HEALTH_STATUS=$(printf '%s\n' "$BODY" | jq -r '.status') || (echo "Prod health check body is not valid JSON!" && exit 1)
           [ "$HEALTH_STATUS" = "ok" ] || (echo "Prod health check .status != 'ok' (got: $HEALTH_STATUS)" && exit 1)
 
       - name: Notify Slack — e2e failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,15 +646,23 @@ jobs:
           STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
         run: |
           # /health must return JSON with .status == 'ok' on a healthy
-          # Lambda. AWSLWA returns HTTP 200 even on init failure (the error
-          # JSON is the response body), so status-only smoke is structurally
-          # incapable of catching init failures. Do not unwind this
-          # assertion without filing a replacement defense — see #111.
+          # Lambda. AWSLWA returns HTTP 200 even on init failure (the
+          # error response body is whatever the runtime emitted — often
+          # plaintext like 'Runtime.ImportModuleError: ...', sometimes
+          # JSON), so status-only smoke is structurally incapable of
+          # catching init failures. Do not unwind this assertion without
+          # filing a replacement defense — see #111.
           RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
           STATUS=$(echo "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"
-          echo "Health check body: $BODY"
+          # Print the body inside a workflow-command group, with each line
+          # prefixed, so a malicious/malformed body cannot inject Actions
+          # workflow commands (lines starting with '::...' are interpreted
+          # by the runner otherwise).
+          echo "::group::Health check body"
+          echo "$BODY" | sed 's/^/  /'
+          echo "::endgroup::"
           [ "$STATUS" = "200" ] || (echo "Dev health check HTTP status not 200!" && exit 1)
           HEALTH_STATUS=$(echo "$BODY" | jq -r '.status') || (echo "Dev health check body is not valid JSON!" && exit 1)
           [ "$HEALTH_STATUS" = "ok" ] || (echo "Dev health check .status != 'ok' (got: $HEALTH_STATUS)" && exit 1)
@@ -830,15 +838,23 @@ jobs:
           STARTER_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
         run: |
           # /health must return JSON with .status == 'ok' on a healthy
-          # Lambda. AWSLWA returns HTTP 200 even on init failure (the error
-          # JSON is the response body), so status-only smoke is structurally
-          # incapable of catching init failures. Do not unwind this
-          # assertion without filing a replacement defense — see #111.
+          # Lambda. AWSLWA returns HTTP 200 even on init failure (the
+          # error response body is whatever the runtime emitted — often
+          # plaintext like 'Runtime.ImportModuleError: ...', sometimes
+          # JSON), so status-only smoke is structurally incapable of
+          # catching init failures. Do not unwind this assertion without
+          # filing a replacement defense — see #111.
           RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
           STATUS=$(echo "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
           BODY=$(echo "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"
-          echo "Health check body: $BODY"
+          # Print the body inside a workflow-command group, with each line
+          # prefixed, so a malicious/malformed body cannot inject Actions
+          # workflow commands (lines starting with '::...' are interpreted
+          # by the runner otherwise).
+          echo "::group::Health check body"
+          echo "$BODY" | sed 's/^/  /'
+          echo "::endgroup::"
           [ "$STATUS" = "200" ] || (echo "Prod health check HTTP status not 200!" && exit 1)
           HEALTH_STATUS=$(echo "$BODY" | jq -r '.status') || (echo "Prod health check body is not valid JSON!" && exit 1)
           [ "$HEALTH_STATUS" = "ok" ] || (echo "Prod health check .status != 'ok' (got: $HEALTH_STATUS)" && exit 1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,9 +645,19 @@ jobs:
         env:
           STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STARTER_API_URL%/}/health")
+          # /health must return JSON with .status == 'ok' on a healthy
+          # Lambda. AWSLWA returns HTTP 200 even on init failure (the error
+          # JSON is the response body), so status-only smoke is structurally
+          # incapable of catching init failures. Do not unwind this
+          # assertion without filing a replacement defense — see #111.
+          RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
+          STATUS=$(echo "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
+          BODY=$(echo "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"
-          [ "$STATUS" = "200" ] || (echo "Dev health check failed!" && exit 1)
+          echo "Health check body: $BODY"
+          [ "$STATUS" = "200" ] || (echo "Dev health check HTTP status not 200!" && exit 1)
+          HEALTH_STATUS=$(echo "$BODY" | jq -r '.status') || (echo "Dev health check body is not valid JSON!" && exit 1)
+          [ "$HEALTH_STATUS" = "ok" ] || (echo "Dev health check .status != 'ok' (got: $HEALTH_STATUS)" && exit 1)
 
       - name: Notify Slack — e2e failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''
@@ -819,9 +829,19 @@ jobs:
         env:
           STARTER_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${STARTER_API_URL%/}/health")
+          # /health must return JSON with .status == 'ok' on a healthy
+          # Lambda. AWSLWA returns HTTP 200 even on init failure (the error
+          # JSON is the response body), so status-only smoke is structurally
+          # incapable of catching init failures. Do not unwind this
+          # assertion without filing a replacement defense — see #111.
+          RESPONSE=$(curl -s -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
+          STATUS=$(echo "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
+          BODY=$(echo "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"
-          [ "$STATUS" = "200" ] || (echo "Prod health check failed!" && exit 1)
+          echo "Health check body: $BODY"
+          [ "$STATUS" = "200" ] || (echo "Prod health check HTTP status not 200!" && exit 1)
+          HEALTH_STATUS=$(echo "$BODY" | jq -r '.status') || (echo "Prod health check body is not valid JSON!" && exit 1)
+          [ "$HEALTH_STATUS" = "ok" ] || (echo "Prod health check .status != 'ok' (got: $HEALTH_STATUS)" && exit 1)
 
       - name: Notify Slack — e2e failure
         if: failure() && env.SLACK_WEBHOOK_URL != ''


### PR DESCRIPTION
Closes #111

## Summary

Updates both the dev-deploy and prod-deploy smoke-test steps in `.github/workflows/ci.yml` to parse the `/health` response as JSON via `jq` and assert `.status == "ok"`, replacing the previous status-only check.

## Why

AWSLWA-fronted Lambda Function URLs return HTTP 200 even when the underlying Python init fails — the error response body (often plaintext like `Runtime.ImportModuleError: ...`, sometimes JSON) becomes the response body. Status-only smoke is structurally incapable of catching init failures on this deploy pattern. Concrete instance: #110, where the dev Lambda emitted `Runtime.ImportModuleError` on every request from 2026-04-26 19:51 UTC, and CI smoke reported "green" through every deploy in that window.

This PR closes the body-blind smoke gap that allowed #110 to ship silently. PR #115 (fail-closed startup validation for unrotated SSM placeholders) corrected #16's CFN-fail AC misspecification by surfacing init failures via deploy-fail; that defense explicitly relies on smoke that can detect a body-shape mismatch when the Lambda lies about being healthy. PR #115 has merged; this PR closes the chain.

Part of #56 (template-bootstrap pattern epic).

## Pre-condition: /health response on dev

Verified before any code change:

```
$ curl -s https://agentcore-starter-dev.warlordofmars.net/health
{"status":"ok","version":"0.0.1-dev.6bfca02"}
```

HTTP 200 with valid JSON containing `.status == "ok"`. The contract assumption (top-level `status` field, value `"ok"` on healthy Lambda) holds.

## Approach

Both smoke steps:
- Capture body and HTTP status in one `curl -sS --connect-timeout 5 --max-time 15` invocation (using a `HTTP_CODE:` sentinel suffix; `-sS` surfaces curl-side errors instead of hiding them; timeouts prevent indefinite hangs)
- Use `printf '%s\n'` for parsing/printing instead of `echo` (predictable handling of leading `-n`/`-e` tokens)
- Assert HTTP 200 first
- Parse body via `jq -r '.status'`; jq exits non-zero on invalid JSON which fails the step (catches the AWSLWA-wrapped init-error case where body is plaintext)
- Assert extracted `.status == "ok"` (exact-match on the parsed field — substring-matching would falsely pass against an error body containing the substring "ok")
- Print body inside `::group::` / `::endgroup::` with each line two-space-prefixed, so a malformed/malicious body cannot inject Actions workflow commands

Each step carries an inline comment locking the contract:

> /health must return JSON with .status == 'ok' on a healthy Lambda. AWSLWA returns HTTP 200 even on init failure (the error response body is whatever the runtime emitted — often plaintext like 'Runtime.ImportModuleError: ...', sometimes JSON), so status-only smoke is structurally incapable of catching init failures. Do not unwind this assertion without filing a replacement defense — see #111.

`jq` is pre-installed on `ubuntu-latest` GitHub Actions runners; no install step needed.

## Local validation against the actual dev /health response

The bash logic was tested against:

| Scenario | Result |
|---|---|
| Healthy dev `/health` (current state, `{"status":"ok",...}`) | PASS |
| Non-JSON body (simulated `Runtime.ImportModuleError`) | fails red on jq parse error |
| JSON with `.status == "degraded"` | fails red on `.status` mismatch |
| JSON with `.status == "broken"` but containing substring "ok" elsewhere | fails red (the explicit lock against substring-matching) |
| Body containing line starting with `::set-output ...` | rendered safely with two-space prefix; no command injection |
| Body's first line is literally `-n` | rendered correctly via printf (echo would have consumed it as a flag) |

## CI runs

| Iteration | Run ID | Conclusion |
|---|---|---|
| Initial push | [25138896263](https://github.com/warlordofmars/agentcore-starter/actions/runs/25138896263) | success |
| After Copilot iter-1 fix (commit 92ee3b4) | [25139158181](https://github.com/warlordofmars/agentcore-starter/actions/runs/25139158181) | success |
| After Copilot iter-2 fix (commit af71305) | [25139429759](https://github.com/warlordofmars/agentcore-starter/actions/runs/25139429759) | success |

All non-skipped checks pass (Lint, Unit Tests, Integration, Frontend, Infra Synth, Security Audit, Coverage Report, SonarCloud, Codecov, agent-safe scope check, Issue label check).

**Note on smoke-step execution**: the new smoke step lives inside the `e2e-dev` job, which runs only on `push` to `development` (`if: github.event_name == 'push' && github.ref == 'refs/heads/development'` — see ci.yml:619-620). It cannot execute in a `pull_request` build by design. The smoke will exercise on the post-merge `development` pipeline; the standard issue-worker §8 flow watches that run for green. Dev `/health` is currently healthy (verified above) so the post-merge smoke is expected to pass on first run.

## Copilot review iterations

- **Iteration 1** — 2 line findings: contract comment said "JSON" but error body can be plaintext; full-body echo could inject Actions workflow commands. Fixed in commit 92ee3b4 (reword to "error response body", wrap body in `::group::`/`::endgroup::` with two-space prefix).
- **Iteration 2** — 3 line findings: `echo` is brittle for `-n`/`-e` leading tokens; `curl -s` hides connectivity errors and has no timeout. Fixed in commit af71305 (switch to `printf '%s\n'`; add `-sS --connect-timeout 5 --max-time 15`).
- **Iteration 3** — Copilot reviewed and "generated no new comments". Convergence achieved (two consecutive iterations with no actionable findings, but only iter-3 returned clean — early-exit after the clean pass).

All 7 review threads have been replied to identifying the fix commits.

The pre-push Copilot WARN findings about logging the full response body unconditionally were declined: the full-body log is the diagnostic signal we need to surface when smoke fails (the AWSLWA init-error case is detected precisely because we can see the malformed body in CI logs). The `/health` happy-path response carries no secrets. Suppressing the body would defeat the issue's purpose.

## Manual regression-test procedure (human-owned)

The agent did NOT execute these steps. Documented here for the human reviewer to optionally run before merge:

1. On a side env (or dev itself), force the SSM placeholder back:
   ```
   aws ssm put-parameter --name /agentcore-starter/dev/jwt-secret --value CHANGE_ME_ON_FIRST_DEPLOY --type String --overwrite
   ```
2. Trigger a redeploy (push to a side branch with a no-op commit, or rerun the pipeline against current development HEAD).
3. The new smoke MUST fail red — either with a jq-parse failure (if the init error is plaintext) or a `.status` assertion failure (if the body parses but is not `ok`). Capture the failed run ID.
4. Restore: `aws ssm put-parameter --name /agentcore-starter/dev/jwt-secret --value $(openssl rand -hex 32) --type String --overwrite`
5. Confirm subsequent run goes green.

## Validation gates

- [x] `inv pre-push` clean (lint + typecheck + 189 unit tests + 269 frontend tests, all green; re-run after every Copilot fix)
- [x] PR's own CI runs all green across 3 iterations (latest: 25139429759)
- [x] code-reviewer / project-aware checklist clean (no FAIL findings; no copyright/dep/auth/SHA-pinning issues; agent-safe scope-boundary verified)
- [x] Copilot review converged (iter-3 clean; all threads replied to)
- [ ] Optional human-run regression test (above)

## Halt note (per orchestrator directive)

This PR is `agent-safe` but auto-merge is **NOT** armed. The smoke contract is load-bearing for every future deploy; an extra human gate is warranted before this lands. Awaiting human review + manual merge.

`HUMAN_INPUT_REQUIRED: PR #122 ready for human review + merge`