### PR TITLE
fix(ci): skip SonarCloud cleanly when SONAR_TOKEN is unset

### DIFF
--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -348,12 +348,60 @@ Required secrets — set each that's missing:
 
 `AWS_DEV_DEPLOY_ROLE_ARN` and `AWS_DEPLOY_ROLE_ARN` are a chicken-and-egg: the CDK stack creates the IAM role, but CI needs the ARN to deploy. Resolve by doing the first deploy manually (Phase 5), then setting the secrets from the stack outputs.
 
+`SONAR_TOKEN` is also a chicken-and-egg: the SonarCloud project must exist before a token can be generated, and the token must be set before the first scan can run. The CI workflow degrades gracefully when `SONAR_TOKEN` is unset (the SonarCloud steps are skipped with a clear log line, see #54), so you can defer the SonarCloud bootstrap until after the first deploy. Phase 4.5 below walks through the full SonarCloud setup including the new-code baseline definition.
+
 ```bash
 gh secret set AWS_DEV_DEPLOY_ROLE_ARN --body "<arn>"
 gh secret set AWS_DEPLOY_ROLE_ARN --body "<arn>"
 gh secret set SONAR_TOKEN --body "<token>"
 # etc.
 ```
+
+---
+
+## Phase 4.5 — SonarCloud project + new-code baseline
+
+The CI `Coverage Report` job runs a SonarCloud scan that requires three things to be in place before it can succeed:
+
+1. The SonarCloud project must exist for the forked repo
+2. `SONAR_TOKEN` must be set as a GitHub Actions secret (covered in Phase 4)
+3. The new-code baseline must be defined on the SonarCloud project — without this, `sonar.qualitygate.wait=true` fails CI with `sonar-scanner exit code 3` and no clear log signal
+
+When `SONAR_TOKEN` is unset, the workflow's "Check SonarCloud configured" gate skips the scan steps cleanly with a log line pointing back to this phase — the rest of the pipeline (deploy, e2e, release) still runs. So the SonarCloud bootstrap is deferrable, but the new-code baseline trap is real: once you set `SONAR_TOKEN` without also defining the baseline, post-merge CI will silently fail with exit 3 and the downstream pipeline will skip.
+
+### 4.5a. Create the SonarCloud project
+
+1. Visit [sonarcloud.io](https://sonarcloud.io) and sign in with the same GitHub account that owns the fork.
+2. Click **+** (top-right) → **Analyze new project**.
+3. Select your GitHub organisation and the forked repo. If the org isn't listed, install the SonarCloud GitHub App on it first.
+4. Choose the **Free plan** if prompted (works for public repos).
+5. Note the project key — for warlordofmars/agentcore-starter it's `warlordofmars_agentcore-starter`. Yours will follow the same `<org>_<repo>` convention.
+
+If your project key differs from `warlordofmars_agentcore-starter`, update `sonar-project.properties` (or `pom.xml`/`build.gradle` if those exist) AND the SARIF-fetch curl in `.github/workflows/ci.yml` (the `projectKeys=` query param) to match.
+
+### 4.5b. Generate SONAR_TOKEN and set it as a GitHub secret
+
+1. On sonarcloud.io, click your avatar (top-right) → **My Account** → **Security**.
+2. Generate a token with **User Token** type, scope **Execute Analysis**, and an expiry that matches your security policy (1 year is typical).
+3. Copy the token — you won't be able to view it again.
+4. Set it as a GitHub Actions secret:
+
+   ```bash
+   gh secret set SONAR_TOKEN --body "<token>"
+   ```
+
+### 4.5c. Define the new-code baseline (required, easy to miss)
+
+This step **must** be performed in the SonarCloud UI after the first analysis has run. Without it, `sonar.qualitygate.wait=true` fails CI with `sonar-scanner exit code 3` and no clear signal in the workflow logs — the scan appears to upload successfully, then the quality-gate poll exits non-zero. This trap was hit on warlordofmars/agentcore-starter on 2026-04-26 after a default-branch rename reset the baseline; affected post-merge runs for PRs #93/#94/#95 (see #96 for the misdiagnosis writeup).
+
+After the first PR-or-push CI run completes a SonarCloud scan:
+
+1. Go to your project on sonarcloud.io.
+2. Navigate to **Administration** → **New Code**.
+3. Pick a baseline definition. The recommended setting for this repo is **Reference branch** with branch `development` — every push to a feature branch is then scored against the latest `development` SHA. **Previous version** also works if you prefer release-tagged baselines.
+4. Save. The next CI run's quality gate will use the new baseline; quality-gate-wait will succeed without the silent exit-3 failure.
+
+**When this needs to be redone:** any time the default branch is renamed or recreated, the SonarCloud baseline resets to undefined. Re-do step 4.5c after any default-branch surgery (e.g. the `main`-to-`development` rename in this repo). Branch-protection setup (Phase 1.5) does not reset the baseline; only branch creation/rename does.
 
 ---
 
@@ -455,6 +503,11 @@ Phase 4 — GitHub secrets
   [x/○] SONAR_TOKEN
   [x/○] CODECOV_TOKEN
 
+Phase 4.5 — SonarCloud bootstrap
+  [x/○] SonarCloud project created
+  [x/○] SONAR_TOKEN secret set
+  [x/○] New-code baseline defined in SonarCloud UI
+
 Phase 5 — First deploy
   [x/○] Stack deployed to <env>
   [x/○] Echo endpoint smoke test passed
@@ -477,3 +530,4 @@ If any Phase 1–5 item is `○`, do not declare setup complete. Identify the fi
 - **Branch protection is non-optional.** On 2026-04-26 a wholesale `git push` from a long-lived clone force-rewound `origin/development` by 11 merges in the upstream template repo. Recovery succeeded only because a parallel clone retained the pre-rewind HEAD locally. The exact failure was made possible by the gap that Phase 1.5 closes — `development` had no protection at the time, so the force-push was accepted by GitHub. The SEC-1 incident (#15) and the corresponding remediation issue (#50) are the canonical references; ADR-0008 captures the W1–W7 push-discipline rules layered on top of the branch protection. Apply Phase 1.5 to every fork before opening a single PR — it is not optional and must not be deferred.
 - **`gh pr merge --auto` is silently a no-op without `allow_auto_merge=true`.** Phase 1.5's PATCH step turns this on. If you skip Phase 1.5, every `gh pr merge --auto --squash` call documented in CLAUDE.md will return success but never queue the merge — the PR sits open until a human merges it manually.
 - **`gh api -F field=` cannot pass JSON `null`.** The form silently degrades to an empty string, which the GitHub branch-protection API rejects. The `--input -` form with a heredoc is the only working syntax for `required_pull_request_reviews=null` and `restrictions=null`.
+- **SonarCloud's new-code baseline trap.** Setting `SONAR_TOKEN` without also defining the new-code baseline in the SonarCloud UI causes `sonar-scanner` to exit 3 silently — the scan uploads cleanly, then the quality-gate poll fails with no clear log signal. Phase 4.5c is mandatory whenever the SonarCloud project is fresh OR the default branch was renamed/recreated. This is how the same family of post-merge silent-failure cascades (#93/#94/#95) was misdiagnosed as a code-quality issue in 2026-04-26 (#96).

--- a/.claude/agents/onboarding.md
+++ b/.claude/agents/onboarding.md
@@ -375,9 +375,13 @@ When `SONAR_TOKEN` is unset, the workflow's "Check SonarCloud configured" gate s
 2. Click **+** (top-right) → **Analyze new project**.
 3. Select your GitHub organisation and the forked repo. If the org isn't listed, install the SonarCloud GitHub App on it first.
 4. Choose the **Free plan** if prompted (works for public repos).
-5. Note the project key — for warlordofmars/agentcore-starter it's `warlordofmars_agentcore-starter`. Yours will follow the same `<org>_<repo>` convention.
+5. Note both the SonarCloud **project key** and **organisation**. For warlordofmars/agentcore-starter the project key is `warlordofmars_agentcore-starter` and the organisation is `warlordofmars`. Yours will usually follow the same `<org>_<repo>` project-key convention and use your fork owner as the SonarCloud organisation.
 
-If your project key differs from `warlordofmars_agentcore-starter`, update `sonar-project.properties` (or `pom.xml`/`build.gradle` if those exist) AND the SARIF-fetch curl in `.github/workflows/ci.yml` (the `projectKeys=` query param) to match.
+If your SonarCloud project key or organisation differs from the template defaults, update **all three** locations so the scanner, the API fetch, and the project record stay in sync:
+
+1. `sonar-project.properties` — both `sonar.projectKey` and `sonar.organization`. Forks miss this most often: leaving `sonar.organization=warlordofmars` unchanged makes the scan fail with a 404-style organisation-mismatch error even when the project key and token are correct.
+2. `.github/workflows/ci.yml` — the SARIF-fetch curl's `projectKeys=` query param must match the `sonar.projectKey` value above.
+3. (If applicable) `pom.xml` / `build.gradle` — same `sonar.projectKey` / `sonar.organization` if those build configs are present.
 
 ### 4.5b. Generate SONAR_TOKEN and set it as a GitHub secret
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,11 +335,18 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [ -z "${SONAR_TOKEN:-}" ]; then
-            echo "::warning title=SonarCloud skipped::SONAR_TOKEN is not set — SonarCloud scan skipped. Fresh fork? See .claude/agents/onboarding.md Phase 4.5. Canonical repo? The secret may have been accidentally deleted (issue #54)."
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-          elif [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+          # Order matters: check Dependabot first. Dependabot PRs run
+          # with no access to repo secrets, so SONAR_TOKEN is also empty
+          # there — if the empty-token branch ran first it would emit a
+          # misleading "secret may have been accidentally deleted"
+          # warning on every Dependabot PR. The Dependabot path is the
+          # expected/known case; the empty-token-on-non-Dependabot path
+          # is the surfaced one.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
             echo "Dependabot PR — skipping SonarCloud steps (no secret access, see #120)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "${SONAR_TOKEN:-}" ]; then
+            echo "::warning title=SonarCloud skipped::SONAR_TOKEN is not set — SonarCloud scan skipped. Fresh fork? See .claude/agents/onboarding.md Phase 4.5. Canonical repo? The secret may have been accidentally deleted (issue #54)."
             echo "configured=false" >> "$GITHUB_OUTPUT"
           else
             echo "SonarCloud is configured — scan will run."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,19 +309,45 @@ jobs:
               });
             }
 
+      # Detect whether SonarCloud is configured for this fork.
+      # A fresh fork won't have SONAR_TOKEN set yet — the SonarCloud project
+      # must be created and the token generated through the SonarCloud UI
+      # before the scan can run. Without this gate the scanner fails the
+      # whole Coverage Report job, which cascades to Deploy / E2E / Release.
+      # See #54 for the bootstrap-pattern context and the onboarding doc
+      # update that walks through the SonarCloud setup steps.
+      #
+      # When SONAR_TOKEN is unset, this step emits a `::warning::`
+      # annotation (visible in the GitHub Actions run summary, not just
+      # the step logs) so that an accidental secret deletion in a repo
+      # that previously had SonarCloud configured is loudly surfaced
+      # rather than silently fail-open. The skip is the right behaviour
+      # for fresh forks (which is why the job doesn't fail), but the
+      # warning ensures the operator notices on every PR until the
+      # secret is restored.
+      #
+      # Emits `configured=true` only when the secret is non-empty AND the
+      # PR isn't from Dependabot (Dependabot PRs run with a restricted
+      # GITHUB_TOKEN and have no access to repo secrets — see #120).
+      - name: Check SonarCloud configured
+        id: sonar_configured
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [ -z "${SONAR_TOKEN:-}" ]; then
+            echo "::warning title=SonarCloud skipped::SONAR_TOKEN is not set — SonarCloud scan skipped. Fresh fork? See .claude/agents/onboarding.md Phase 4.5. Canonical repo? The secret may have been accidentally deleted (issue #54)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          elif [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "Dependabot PR — skipping SonarCloud steps (no secret access, see #120)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "SonarCloud is configured — scan will run."
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: SonarCloud Scan
-        # Dependabot PRs run with a restricted GITHUB_TOKEN and have no
-        # access to repo secrets — SONAR_TOKEN resolves to empty and the
-        # scan fails. Skip the secret-requiring steps for Dependabot PRs;
-        # the PR coverage comment above (GITHUB_TOKEN only) still runs.
-        # Gate on `pull_request.user.login` (the PR author) rather than
-        # `github.actor` — actor flips to the maintainer when a human
-        # re-runs the workflow, which would re-execute these steps on a
-        # still-Dependabot-authored PR and fail again. user.login is
-        # stable across re-runs. On push events `pull_request` is null,
-        # so the comparison is truthy and the step runs as today.
-        # See #120.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        if: steps.sonar_configured.outputs.configured == 'true'
         uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -333,7 +359,7 @@ jobs:
           args: ${{ github.ref == 'refs/heads/main' && '-Dsonar.qualitygate.wait=false' || '' }}
 
       - name: Fetch SonarCloud issues as SARIF
-        if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
+        if: always() && steps.sonar_configured.outputs.configured == 'true'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
@@ -343,7 +369,7 @@ jobs:
           python3 scripts/sonar_to_sarif.py sonar-issues.json sonar.sarif
 
       - name: Upload SonarCloud results to GitHub Security
-        if: always() && github.event.pull_request.user.login != 'dependabot[bot]'
+        if: always() && steps.sonar_configured.outputs.configured == 'true'
         uses: github/codeql-action/upload-sarif@f94817b9f0deeb3871261446912ae8f854d1b675 # codeql-bundle-v2.25.1
         with:
           sarif_file: sonar.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ uv run inv pre-push
 
 E2E tests run against a deployed environment and are handled by CI after merging to `development`. See [tests/README.md](tests/README.md) for details.
 
+CI also runs a SonarCloud quality-gate scan in the `Coverage Report` job — the scan is skipped cleanly when `SONAR_TOKEN` is unset (typical on a fresh fork), so the rest of the pipeline still runs; see Phase 4.5 of [`.claude/agents/onboarding.md`](.claude/agents/onboarding.md) for the full SonarCloud bootstrap including the new-code baseline definition (#54).
+
 ## Code style
 
 - **Python**: [ruff](https://docs.astral.sh/ruff/) for lint + format, [mypy](https://mypy-lang.org/) for type checking


### PR DESCRIPTION
Closes #54
Part of #56 (template-bootstrap epic)

## Summary

The `Coverage Report` job's SonarCloud scan fails on a fresh fork because (1) the SonarCloud project doesn't exist for the fork, (2) `SONAR_TOKEN` isn't set, and (3) — even when both of those are resolved — the new-code baseline isn't defined on the SonarCloud project, which causes `sonar.qualitygate.wait=true` to fail with a silent `sonar-scanner exit code 3`. Any of these blocks the entire downstream pipeline (Deploy → E2E → Release → Deploy-prod), so the autonomous deploy + back-merge flow is non-functional out of the box.

This PR implements the issue's recommended option 3 (workflow conditional + onboarding doc + README/CONTRIBUTING sentence):

- **`.github/workflows/ci.yml`** — adds a `Check SonarCloud configured` gate that emits `configured=true` only when `SONAR_TOKEN` is non-empty AND the PR isn't from Dependabot. The three SonarCloud steps (Scan, Fetch SARIF, Upload SARIF) now gate on this output. The Codecov step is unchanged (already gated on Dependabot).
- **`.claude/agents/onboarding.md`** — adds Phase 4.5 (SonarCloud project + new-code baseline) walking through the three-step bootstrap with explicit UI navigation. The new-code baseline trap (silent exit 3 when undefined) is called out as a required step, with the 2026-04-26 incident referenced (#96 misdiagnosis).
- **`CONTRIBUTING.md`** — one-sentence note pointing at the onboarding phase.
- Completion checklist + Common gotchas in onboarding.md updated to reflect Phase 4.5.

## Approach

### Why a `::warning::` annotation on skip

Initial draft used a plain `echo` to log the skip. Local Copilot review flagged a real defense-in-depth gap: in the canonical repo, an accidental `SONAR_TOKEN` deletion would now silently skip the scan while still letting `Coverage Report` pass green — protected branches could merge without the SonarCloud check that the repo's CI treats as required.

The fix: the skip path emits a `::warning title=SonarCloud skipped::` GitHub Actions annotation that surfaces in the run summary UI, not just the step logs. The skip itself remains the right behaviour for fresh forks (which is the issue's contract — "skip cleanly when SONAR_TOKEN is unset"), but a configured repo's operators see the warning loudly until the secret is restored. This satisfies both the bootstrap contract and the "don't silently fail-open" defense-in-depth concern.

### Why one combined gate vs. inlined `if:` per step

The existing pattern (PR #121) inlined the Dependabot check on each of the four secret-requiring steps. Three of those (the SonarCloud trio) now share a second condition (`SONAR_TOKEN` set), so a `Check SonarCloud configured` step that emits a single `configured` output is cleaner than repeating both conditions on each step. The Codecov step still uses the inline Dependabot check — it doesn't share the SonarCloud-token gate.

### Why Phase 4.5 (separate phase) vs. extending Phase 4

Phase 4 is the GitHub-secrets-table phase. SonarCloud has three sub-steps (project create → token gen → baseline definition) and the third must be performed in the SonarCloud UI **after** the first analysis run, so it doesn't fit cleanly in the secret-setting flow. Phase 4.5 keeps the bootstrap walkthrough together while preserving Phase 4's role as the secret-table reference.

## Validation

- `uv run inv pre-push` clean locally (37 ruff files, 17 mypy modules, 189 unit tests, 269 frontend tests).
- Local Copilot review: one `FAIL` (silent fail-open in canonical repo) addressed via the `::warning::` annotation in the same branch.
- Scope check (offline): WARN (issue body has no `## Files to touch` section, and `dx` is a meta-area that forces WARN). Non-blocking — agent-safe-scope CI will pass.
- This PR's own CI run is the regression check: SonarCloud will run as today (token is set on this repo), Codecov will run as today, and the new gate's logic is exercised on the configured path. The unset-token path is exercised mechanically via the `if [ -z ]` shell check; CI cannot exercise that path without unsetting the secret on this repo.

## Notes for reviewer

The issue body did NOT include a `## Files to touch` section that `scripts/check_agent_safe_scope.py` recognises — but `dx` is a meta-area in the area-label fallback, which forces WARN (not FAIL), so the agent-safe-scope CI gate is non-blocking. The three files actually touched (`.github/workflows/ci.yml`, `.claude/agents/onboarding.md`, `CONTRIBUTING.md`) match the issue's acceptance criteria one-for-one.