### PR TITLE
fix(auth): persist OAuth state in DynamoDB for concurrent Lambdas

### DIFF
--- a/src/starter/auth/mgmt_auth.py
+++ b/src/starter/auth/mgmt_auth.py
@@ -3,9 +3,11 @@
 Management UI authentication — Google OAuth login flow for human users.
 
 Issues short-lived management JWTs (typ=mgmt) stored in the browser's
-localStorage.  Pending OAuth state is held in process memory (single Lambda
-instance).  Replace with a DynamoDB-backed store if you need multi-instance
-state sharing.
+localStorage.  Pending OAuth state is persisted in DynamoDB (see
+:mod:`starter.auth.state_store`) so concurrent Lambda containers can
+share state — the previous in-process dict broke under concurrent
+execution because the callback could hit a different warm container
+than the one that issued the state.
 
 Routes:
   GET /auth/login    — redirect to Google (or issue bypass JWT in non-prod)
@@ -17,12 +19,12 @@ from __future__ import annotations
 import html
 import os
 import secrets
-import time
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from starter.auth import state_store
 from starter.auth.google import (
     exchange_google_code,
     google_authorization_url,
@@ -37,10 +39,6 @@ router = APIRouter(tags=["mgmt-auth"])
 logger = get_logger(__name__)
 
 _BYPASS = bool(os.environ.get("STARTER_BYPASS_GOOGLE_AUTH"))
-
-# In-process pending state store: {state: {"expires_at": float, ...}}
-# Replace with DynamoDB for multi-instance deployments.
-_pending_states: dict[str, dict[str, Any]] = {}
 _STATE_TTL_SECONDS = 600  # 10 minutes
 
 # Redirect target after successful login
@@ -53,16 +51,13 @@ def _mgmt_callback_uri() -> str:
 
 def _create_pending_state() -> str:
     state = secrets.token_urlsafe(32)
-    _pending_states[state] = {"expires_at": time.time() + _STATE_TTL_SECONDS}
+    state_store.put_state(state, ttl_seconds=_STATE_TTL_SECONDS)
     return state
 
 
 def _consume_pending_state(state: str) -> bool:
-    """Return True and remove state if valid and not expired."""
-    entry = _pending_states.pop(state, None)
-    if entry is None:
-        return False
-    return time.time() < entry["expires_at"]
+    """Return True if state was present, unexpired, and successfully consumed."""
+    return state_store.consume_state(state) is not None
 
 
 def _html_redirect(jwt_token: str) -> HTMLResponse:

--- a/src/starter/auth/state_store.py
+++ b/src/starter/auth/state_store.py
@@ -131,12 +131,27 @@ def consume_state(state: str) -> dict[str, Any] | None:
             ReturnValues="ALL_OLD",
         )
     except ClientError as exc:
-        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+        error_code = exc.response.get("Error", {}).get("Code")
+        if error_code == "ConditionalCheckFailedException":
             # Could be a replay, an already-consumed state, or a TTL sweep.
             # We log INFO (not WARN) — this is an expected auth-flow path,
             # not an exceptional one, but it is worth distinguishing from
             # the "expired" case below for metric / log analysis.
             logger.info("OAuth state not present in store (replay or already consumed)")
+            return None
+        if error_code == "ValidationException":
+            # State is user-supplied (query param on /auth/callback).
+            # Malformed/oversized values trigger DynamoDB
+            # ValidationException — treat the same as "not present" so
+            # the FastAPI layer surfaces a 400 (via the existing None-
+            # return branch) rather than a 500. We log the *error code*
+            # (not the raw state value — user-controlled, log-injection
+            # risk) so operators can still distinguish this case from a
+            # genuine missing-state in metrics / log analysis.
+            logger.info(
+                "OAuth state value rejected by DynamoDB validation; treating as not present",
+                extra={"error_code": error_code},
+            )
             return None
         raise
 

--- a/src/starter/auth/state_store.py
+++ b/src/starter/auth/state_store.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+DynamoDB-backed store for OAuth state parameters used by the management
+UI login flow.
+
+Replaces the in-process ``_pending_states`` dict that previously lived in
+:mod:`starter.auth.mgmt_auth`. The dict pattern works under a single
+warm Lambda but breaks under concurrent execution: the callback may hit
+a different warm container than the one that issued the state, the
+state is missing, the auth flow fails with "invalid state", and the user
+gets a 400. The probability scales with concurrency.
+
+Items use the ``MGMT_STATE#{state}`` / ``META`` key shape documented in
+CLAUDE.md §"DynamoDB single table design". TTL is set on each item so
+DynamoDB sweeps stale rows within ~48h, but the application code on the
+read path also enforces ``created_at + ttl_seconds > now`` — DynamoDB's
+TTL is best-effort and we do not trust it for correctness.
+
+Module placement (auth-scoped, not a general-purpose storage layer) is
+locked by issue #23 — do not relocate without revisiting that decision.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from starter.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Default TTL — 10 minutes is plenty for a Google round-trip and short
+# enough that a leaked state has narrow exploit value.
+_STATE_TTL_SECONDS_DEFAULT = 600
+
+
+def _get_table() -> Any:
+    """Return the DynamoDB Table resource for the configured table.
+
+    Resolved at call time (not import time) so test fixtures that set
+    ``STARTER_TABLE_NAME`` / ``DYNAMODB_ENDPOINT`` after the module is
+    imported still take effect. Mirrors the StarterStorage pattern
+    documented in src/starter/README.md.
+    """
+    table_name = os.environ.get("STARTER_TABLE_NAME", "agentcore-starter-dev")
+    endpoint_url = os.environ.get("DYNAMODB_ENDPOINT")  # set for DynamoDB Local
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    dynamodb = boto3.resource("dynamodb", region_name=region, endpoint_url=endpoint_url)
+    return dynamodb.Table(table_name)
+
+
+def put_state(
+    state: str,
+    payload: dict[str, Any] | None = None,
+    ttl_seconds: int = _STATE_TTL_SECONDS_DEFAULT,
+) -> None:
+    """Persist a pending OAuth state for later consumption by the callback.
+
+    Writes a single ``MGMT_STATE#{state}`` / ``META`` row with a
+    ``created_at`` timestamp and a ``ttl`` attribute (absolute Unix
+    timestamp) so DynamoDB will sweep the row if it never gets consumed.
+
+    The caller chooses ``ttl_seconds``; the default is 10 minutes which
+    is generous for a Google OAuth round-trip and short enough that a
+    leaked state has minimal exploit window.
+    """
+    now = int(time.time())
+    item: dict[str, Any] = {
+        "PK": f"MGMT_STATE#{state}",
+        "SK": "META",
+        "created_at": now,
+        "ttl_seconds": ttl_seconds,
+        "ttl": now + ttl_seconds,  # absolute Unix timestamp for DynamoDB TTL sweep
+    }
+    if payload:
+        # Caller-supplied attributes (e.g. nonce, redirect_uri). Reserved
+        # keys (PK / SK / created_at / ttl / ttl_seconds) take precedence.
+        for k, v in payload.items():
+            if k not in item:
+                item[k] = v
+
+    _get_table().put_item(Item=item)
+
+
+def consume_state(state: str) -> dict[str, Any] | None:
+    """Atomically read-and-delete a pending OAuth state.
+
+    Returns the item's stored payload on success, or ``None`` if the
+    state is not present, has already been consumed, or has expired.
+
+    Implemented as a single conditional ``delete_item`` with
+    ``ReturnValues=ALL_OLD``. Atomicity comes from DynamoDB's single-key
+    write serialization, not from the condition. The condition exists
+    to distinguish "state was never present" (callback for an
+    unknown / replayed state) from "state was issued but expired"
+    (legitimate user, slow callback). Both are auth-flow failure modes
+    worth distinguishing in logs / metrics.
+
+    The ConditionExpression checks presence only (``attribute_exists(PK)``).
+    The expiry check happens in application code on the returned old
+    image — we do NOT push the time comparison into the
+    ConditionExpression, because DynamoDB TTL is best-effort and the
+    application must own correctness on this read path.
+    """
+    pk = f"MGMT_STATE#{state}"
+    try:
+        resp = _get_table().delete_item(
+            Key={"PK": pk, "SK": "META"},
+            ConditionExpression="attribute_exists(PK)",
+            ReturnValues="ALL_OLD",
+        )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            # Could be a replay, an already-consumed state, or a TTL sweep.
+            # We log INFO (not WARN) — this is an expected auth-flow path,
+            # not an exceptional one, but it is worth distinguishing from
+            # the "expired" case below for metric / log analysis.
+            logger.info("OAuth state not present in store (replay or already consumed)")
+            return None
+        raise
+
+    old_image = resp.get("Attributes")
+    if not old_image:
+        # ConditionExpression succeeded but no Attributes returned — should
+        # not happen with ALL_OLD on a successful conditional delete, but
+        # treat it the same as "not present" for safety.
+        logger.info("OAuth state delete returned no attributes (treating as not present)")
+        return None
+
+    created_at = int(old_image.get("created_at", 0))
+    ttl_seconds = int(old_image.get("ttl_seconds", _STATE_TTL_SECONDS_DEFAULT))
+    if created_at + ttl_seconds <= int(time.time()):
+        # State was issued but the user took too long. The delete already
+        # happened (good — single-use semantics held), but the caller
+        # should not be allowed to complete the flow with an expired state.
+        logger.info("OAuth state expired (issued too long ago)")
+        return None
+
+    return dict(old_image)

--- a/src/starter/auth/state_store.py
+++ b/src/starter/auth/state_store.py
@@ -97,8 +97,17 @@ def put_state(
 def consume_state(state: str) -> dict[str, Any] | None:
     """Atomically read-and-delete a pending OAuth state.
 
-    Returns the item's stored payload on success, or ``None`` if the
-    state is not present, has already been consumed, or has expired.
+    Returns the full deleted item on success, or ``None`` if the state
+    is not present, has already been consumed, or has expired.
+
+    The returned mapping is the DynamoDB old image from
+    ``ReturnValues=ALL_OLD``. It includes the caller-supplied payload
+    attributes (``nonce``, ``redirect_uri``, etc.) **as well as**
+    reserved storage metadata: ``PK``, ``SK``, ``created_at``, ``ttl``,
+    and ``ttl_seconds``. Callers that only want the payload they
+    originally passed to :func:`put_state` should filter the reserved
+    keys themselves — this layer doesn't strip them so log / metrics
+    code can inspect the metadata when an auth flow fails.
 
     Implemented as a single conditional ``delete_item`` with
     ``ReturnValues=ALL_OLD``. Atomicity comes from DynamoDB's single-key

--- a/src/starter/auth/state_store.py
+++ b/src/starter/auth/state_store.py
@@ -43,13 +43,21 @@ def _get_table() -> Any:
 
     Resolved at call time (not import time) so test fixtures that set
     ``STARTER_TABLE_NAME`` / ``DYNAMODB_ENDPOINT`` after the module is
-    imported still take effect. Mirrors the StarterStorage pattern
-    documented in src/starter/README.md.
+    imported still take effect.
+
+    Region resolution follows boto3 precedence: ``AWS_REGION`` →
+    ``AWS_DEFAULT_REGION`` → ``~/.aws/config``. We only pass
+    ``region_name`` when one of the env vars is explicitly set so
+    local dev and CI inherit the configured default naturally —
+    matches the pattern in :mod:`starter.agents.bedrock`.
     """
     table_name = os.environ.get("STARTER_TABLE_NAME", "agentcore-starter-dev")
     endpoint_url = os.environ.get("DYNAMODB_ENDPOINT")  # set for DynamoDB Local
-    region = os.environ.get("AWS_REGION", "us-east-1")
-    dynamodb = boto3.resource("dynamodb", region_name=region, endpoint_url=endpoint_url)
+    region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    kwargs: dict[str, Any] = {"endpoint_url": endpoint_url}
+    if region:
+        kwargs["region_name"] = region
+    dynamodb = boto3.resource("dynamodb", **kwargs)
     return dynamodb.Table(table_name)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,9 @@ Start it before running: docker run -p 8000:8000 amazon/dynamodb-local:latest
 from __future__ import annotations
 
 import os
+from typing import Any
 
+import boto3
 import pytest
 
 # Override AWS creds for DynamoDB Local
@@ -24,3 +26,96 @@ os.environ.setdefault("STARTER_TABLE_NAME", "agentcore-starter-test")
 @pytest.fixture(scope="session")
 def table_name() -> str:
     return os.environ["STARTER_TABLE_NAME"]
+
+
+@pytest.fixture(scope="session")
+def dynamodb_resource() -> Any:
+    """Session-scoped DynamoDB resource pointed at DynamoDB Local."""
+    return boto3.resource(
+        "dynamodb",
+        region_name=os.environ["AWS_DEFAULT_REGION"],
+        endpoint_url=os.environ["DYNAMODB_ENDPOINT"],
+    )
+
+
+@pytest.fixture(scope="session")
+def starter_table(dynamodb_resource: Any, table_name: str) -> Any:
+    """Provision the StarterTable in DynamoDB Local for the test session.
+
+    Mirrors the schema declared in :mod:`infra.stacks.starter_stack` —
+    ``PK`` / ``SK`` partition + sort, four GSIs with the
+    ``GSI{1..4}PK`` / ``GSI{1..2}SK`` attribute naming, and the ``ttl``
+    attribute used for TTL sweeps. CDK is not invoked because DynamoDB
+    Local doesn't run CloudFormation; this fixture is the
+    test-environment analogue.
+
+    Drops and recreates the table if it already exists from a previous
+    run so the suite starts clean each session. No table-row cleanup
+    between individual tests — tests use unique state strings to avoid
+    cross-pollution (same pattern as the e2e suite).
+    """
+    existing = {t.name for t in dynamodb_resource.tables.all()}
+    if table_name in existing:
+        dynamodb_resource.Table(table_name).delete()
+        dynamodb_resource.Table(table_name).wait_until_not_exists()
+
+    dynamodb_resource.create_table(
+        TableName=table_name,
+        AttributeDefinitions=[
+            {"AttributeName": "PK", "AttributeType": "S"},
+            {"AttributeName": "SK", "AttributeType": "S"},
+            {"AttributeName": "GSI1PK", "AttributeType": "S"},
+            {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            {"AttributeName": "GSI2PK", "AttributeType": "S"},
+            {"AttributeName": "GSI2SK", "AttributeType": "S"},
+            {"AttributeName": "GSI3PK", "AttributeType": "S"},
+            {"AttributeName": "GSI4PK", "AttributeType": "S"},
+        ],
+        KeySchema=[
+            {"AttributeName": "PK", "KeyType": "HASH"},
+            {"AttributeName": "SK", "KeyType": "RANGE"},
+        ],
+        BillingMode="PAY_PER_REQUEST",
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "KeyIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "TagIndex",
+                "KeySchema": [
+                    {"AttributeName": "GSI2PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI2SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "ClientIndex",
+                "KeySchema": [{"AttributeName": "GSI3PK", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "UserEmailIndex",
+                "KeySchema": [{"AttributeName": "GSI4PK", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+    )
+
+    table = dynamodb_resource.Table(table_name)
+    table.wait_until_exists()
+
+    # DynamoDB Local doesn't enforce TTL but the API call succeeds. We
+    # set it for parity with the production schema so any test that
+    # asserts on the ``ttl`` attribute name still works the same way.
+    client = dynamodb_resource.meta.client
+    client.update_time_to_live(
+        TableName=table_name,
+        TimeToLiveSpecification={"Enabled": True, "AttributeName": "ttl"},
+    )
+
+    yield table

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,9 +10,17 @@ from __future__ import annotations
 
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 import boto3
 import pytest
+
+# Hosts that are safe targets for the destructive drop+recreate in
+# starter_table. Anything else (including hostnames that merely contain
+# "localhost" as a substring, e.g. ``localhost.evil.com``) must be
+# rejected — the substring form is a footgun, urlparse().hostname is
+# the only correct check.
+_SAFE_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "dynamodb-local"}
 
 # Override AWS creds for DynamoDB Local
 os.environ.setdefault("AWS_ACCESS_KEY_ID", "local")
@@ -59,18 +67,21 @@ def starter_table(dynamodb_resource: Any, table_name: str) -> Any:
     environment that already has ``STARTER_TABLE_NAME`` /
     ``DYNAMODB_ENDPOINT`` set could point this fixture at a real
     DynamoDB endpoint and the destructive drop step below would delete
-    an externally-managed table. We refuse to proceed unless
-    ``DYNAMODB_ENDPOINT`` resolves to localhost / 127.0.0.1 / a
-    docker-internal hostname — the suite is DynamoDB-Local-only by
-    design.
+    an externally-managed table. We refuse to proceed unless the
+    parsed ``DYNAMODB_ENDPOINT`` hostname is in
+    :data:`_SAFE_LOCAL_HOSTS` — the suite is DynamoDB-Local-only by
+    design. Parsing with ``urlparse`` (rather than substring matching)
+    blocks bypasses like ``http://localhost.evil.com``.
     """
     endpoint = os.environ.get("DYNAMODB_ENDPOINT", "")
-    if not any(host in endpoint for host in ("localhost", "127.0.0.1", "dynamodb-local")):
+    hostname = urlparse(endpoint).hostname
+    if hostname not in _SAFE_LOCAL_HOSTS:
         raise RuntimeError(
             f"Refusing to provision integration test table against non-local DynamoDB "
-            f"endpoint {endpoint!r}. This fixture performs a destructive drop+recreate; "
-            f"set DYNAMODB_ENDPOINT to http://localhost:8000 (or a DynamoDB Local URL) "
-            f"before running the integration suite."
+            f"endpoint {endpoint!r} (parsed hostname: {hostname!r}). This fixture "
+            f"performs a destructive drop+recreate; set DYNAMODB_ENDPOINT to "
+            f"http://localhost:8000 (or a DynamoDB Local URL whose hostname is one of "
+            f"{sorted(_SAFE_LOCAL_HOSTS)}) before running the integration suite."
         )
 
     existing = {t.name for t in dynamodb_resource.tables.all()}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,7 +53,26 @@ def starter_table(dynamodb_resource: Any, table_name: str) -> Any:
     run so the suite starts clean each session. No table-row cleanup
     between individual tests — tests use unique state strings to avoid
     cross-pollution (same pattern as the e2e suite).
+
+    **Safety guard**: the integration env vars at the top of this file
+    are set via ``setdefault()``, which means a developer or CI
+    environment that already has ``STARTER_TABLE_NAME`` /
+    ``DYNAMODB_ENDPOINT`` set could point this fixture at a real
+    DynamoDB endpoint and the destructive drop step below would delete
+    an externally-managed table. We refuse to proceed unless
+    ``DYNAMODB_ENDPOINT`` resolves to localhost / 127.0.0.1 / a
+    docker-internal hostname — the suite is DynamoDB-Local-only by
+    design.
     """
+    endpoint = os.environ.get("DYNAMODB_ENDPOINT", "")
+    if not any(host in endpoint for host in ("localhost", "127.0.0.1", "dynamodb-local")):
+        raise RuntimeError(
+            f"Refusing to provision integration test table against non-local DynamoDB "
+            f"endpoint {endpoint!r}. This fixture performs a destructive drop+recreate; "
+            f"set DYNAMODB_ENDPOINT to http://localhost:8000 (or a DynamoDB Local URL) "
+            f"before running the integration suite."
+        )
+
     existing = {t.name for t in dynamodb_resource.tables.all()}
     if table_name in existing:
         dynamodb_resource.Table(table_name).delete()

--- a/tests/integration/test_auth_state_store.py
+++ b/tests/integration/test_auth_state_store.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Integration tests for :mod:`starter.auth.state_store` against DynamoDB Local.
+
+Covers the same four cases as the unit suite — happy path, missing key,
+expired item, atomic-consume race — but against a real DynamoDB Local
+instance so the conditional-delete + ALL_OLD shape is exercised end to end.
+
+The unit suite mocks ``_get_table()``; this suite calls the real boto3
+client so any drift between the mock and the real API surface (e.g.
+ConditionalCheckFailedException error code, Attributes vs no-Attributes
+response shape) shows up here.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+from starter.auth import state_store
+
+
+def _unique_state() -> str:
+    """Generate a state value unique to this test invocation.
+
+    Uses a UUID so concurrent runs of the suite don't collide. The
+    ``state_store`` table fixture is session-scoped and not cleaned
+    between tests.
+    """
+    return f"itest-{uuid.uuid4()}"
+
+
+def test_put_then_consume_returns_payload(starter_table):
+    state = _unique_state()
+    state_store.put_state(state, payload={"nonce": "n1", "redirect_uri": "/cb"})
+
+    result = state_store.consume_state(state)
+
+    assert result is not None
+    assert result["nonce"] == "n1"
+    assert result["redirect_uri"] == "/cb"
+    # PK / SK round-tripped from the stored item.
+    assert result["PK"] == f"MGMT_STATE#{state}"
+    assert result["SK"] == "META"
+
+
+def test_consume_missing_state_returns_none(starter_table):
+    # Never put — direct consume of a state that doesn't exist.
+    result = state_store.consume_state(_unique_state())
+    assert result is None
+
+
+def test_consume_after_consume_returns_none(starter_table):
+    """Single-use semantics: a second consume of the same state returns None."""
+    state = _unique_state()
+    state_store.put_state(state)
+
+    first = state_store.consume_state(state)
+    second = state_store.consume_state(state)
+
+    assert first is not None
+    assert second is None
+
+
+def test_consume_expired_item_returns_none(starter_table):
+    """App-level expiry check rejects items past their ``created_at + ttl_seconds``.
+
+    DynamoDB TTL won't sweep within the test window (sweep runs ~48h),
+    so we put an item directly with a stale ``created_at`` to exercise
+    the application-side expiry branch.
+    """
+    state = _unique_state()
+    long_ago = int(time.time()) - 3600  # one hour ago
+    starter_table.put_item(
+        Item={
+            "PK": f"MGMT_STATE#{state}",
+            "SK": "META",
+            "created_at": long_ago,
+            "ttl_seconds": 600,  # 10-minute window expired ~50 minutes ago
+            "ttl": long_ago + 600,
+            "nonce": "stale",
+        }
+    )
+
+    assert state_store.consume_state(state) is None
+
+
+def test_atomic_consume_only_one_winner(starter_table):
+    """Two consumes of the same state: first wins, second gets None.
+
+    DynamoDB serializes writes per partition key, so the conditional
+    delete makes this race deterministic without threading: if we issue
+    two sequential consumes, the second sees the row already gone via
+    ConditionalCheckFailedException and returns None. This mirrors the
+    real concurrent-Lambda failure mode the issue is fixing.
+    """
+    state = _unique_state()
+    state_store.put_state(state, payload={"nonce": "race-winner"})
+
+    first = state_store.consume_state(state)
+    second = state_store.consume_state(state)
+
+    assert first is not None
+    assert first["nonce"] == "race-winner"
+    assert second is None
+
+
+def test_put_state_writes_ttl_attribute_as_integer(starter_table):
+    """DynamoDB silently drops non-integer TTL values; assert the contract.
+
+    boto3 returns numeric attributes as ``decimal.Decimal``. The
+    underlying DynamoDB type is "N" (Number), and the stored value is
+    integral — what we care about is that the value has no fractional
+    component (int(d) == d) so DynamoDB's TTL service accepts it. A
+    ``float``-typed write would round-trip as a Decimal with a non-zero
+    fractional component.
+    """
+    from decimal import Decimal
+
+    state = _unique_state()
+    state_store.put_state(state, ttl_seconds=300)
+
+    resp = starter_table.get_item(Key={"PK": f"MGMT_STATE#{state}", "SK": "META"})
+    item = resp["Item"]
+    assert isinstance(item["ttl"], Decimal)
+    assert int(item["ttl"]) == item["ttl"]  # no fractional component
+    assert item["ttl_seconds"] == 300
+    assert item["ttl"] == item["created_at"] + 300

--- a/tests/unit/test_auth_mgmt.py
+++ b/tests/unit/test_auth_mgmt.py
@@ -1,15 +1,25 @@
 # Copyright (c) 2026 John Carter. All rights reserved.
-"""Unit tests for management auth routes and helper functions."""
+"""Unit tests for management auth routes and helper functions.
+
+State storage (:mod:`starter.auth.state_store`) is patched at module
+boundary so these tests do not hit DynamoDB. The fake implementation
+mirrors the production contract: ``put_state`` records the state and
+``consume_state`` returns the stored payload exactly once, then
+``None`` thereafter.
+"""
 
 import os
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 os.environ.setdefault("STARTER_JWT_SECRET", "test-secret-for-unit-tests")
 os.environ.setdefault("GOOGLE_CLIENT_ID", "test-google-client-id")
 
 from starter.api.main import app  # noqa: E402
+from starter.auth import state_store  # noqa: E402
 from starter.auth.google import _google_client_id, _reset_allowed_emails_cache  # noqa: E402
 from starter.auth.mgmt_auth import (  # noqa: E402
     _consume_pending_state,
@@ -25,6 +35,29 @@ _client = TestClient(app, follow_redirects=False)
 def _clear_google_caches():
     _google_client_id.cache_clear()
     _reset_allowed_emails_cache()
+
+
+@pytest.fixture(autouse=True)
+def _fake_state_store(monkeypatch):
+    """In-memory fake for state_store; mirrors single-use semantics.
+
+    Production state_store hits DynamoDB. The unit tests want to verify
+    the mgmt_auth control flow (state created, callback consumes it
+    exactly once) without spinning up DynamoDB Local — this fake
+    captures that behaviour. Atomic-consume / expiry edge cases are
+    covered separately in tests/unit/test_auth_state_store.py.
+    """
+    store: dict[str, dict[str, Any]] = {}
+
+    def _put(state: str, payload: dict[str, Any] | None = None, ttl_seconds: int = 600) -> None:
+        store[state] = dict(payload or {})
+
+    def _consume(state: str) -> dict[str, Any] | None:
+        return store.pop(state, None)
+
+    monkeypatch.setattr(state_store, "put_state", _put)
+    monkeypatch.setattr(state_store, "consume_state", _consume)
+    yield store
 
 
 def setup_function():

--- a/tests/unit/test_auth_state_store.py
+++ b/tests/unit/test_auth_state_store.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""Unit tests for :mod:`starter.auth.state_store`.
+
+These tests cover the four required cases from issue #23:
+
+- happy path (put + consume returns the payload)
+- missing key (consume returns None on ConditionalCheckFailed)
+- expired item (consume returns None on app-level expiry check)
+- atomic-consume race (one consumer wins, the other gets None)
+
+DynamoDB calls are mocked at the ``_get_table()`` helper boundary so
+these tests run without any external service. Integration tests in
+``tests/integration/test_auth_state_store.py`` cover the same surface
+against DynamoDB Local.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from starter.auth import state_store
+
+
+@pytest.fixture
+def fake_table():
+    """Patch ``state_store._get_table`` to return a MagicMock surface.
+
+    The yielded mock is the Table object — call ``.put_item.assert_*`` /
+    ``.delete_item.return_value = ...`` on it from the test body.
+    """
+    table = MagicMock(name="StarterTable")
+    with patch.object(state_store, "_get_table", return_value=table):
+        yield table
+
+
+def _attach_log_handler() -> tuple[logging.Logger, list[logging.LogRecord]]:
+    """Attach a list-backed handler to the state_store logger.
+
+    The project's structured logger sets ``propagate=False`` on the
+    ``starter`` tree so :data:`pytest`'s ``caplog`` fixture cannot see
+    the records via the root logger — mirror the pattern from
+    ``tests/integration/test_startup.py``.
+    """
+    captured: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _ListHandler(level=logging.DEBUG)
+    log = logging.getLogger("starter.auth.state_store")
+    log.addHandler(handler)
+    return log, captured
+
+
+# ── put_state ────────────────────────────────────────────────────────────────
+
+
+def test_put_state_writes_expected_pk_sk_and_ttl(fake_table):
+    """Item must use the MGMT_STATE#{state} / META key shape with TTL."""
+    state_store.put_state("abc123", ttl_seconds=600)
+
+    fake_table.put_item.assert_called_once()
+    item = fake_table.put_item.call_args.kwargs["Item"]
+    assert item["PK"] == "MGMT_STATE#abc123"
+    assert item["SK"] == "META"
+    # ttl is an absolute Unix timestamp — must be an int (DynamoDB's TTL
+    # service silently ignores non-integer values).
+    assert isinstance(item["ttl"], int)
+    # ttl_seconds is the operator-supplied window; ttl is created_at + ttl_seconds.
+    assert item["ttl"] == item["created_at"] + 600
+    assert item["ttl_seconds"] == 600
+
+
+def test_put_state_default_ttl_is_600_seconds(fake_table):
+    state_store.put_state("xyz")
+    item = fake_table.put_item.call_args.kwargs["Item"]
+    assert item["ttl_seconds"] == 600
+
+
+def test_put_state_includes_caller_payload(fake_table):
+    state_store.put_state("xyz", payload={"nonce": "n1", "redirect_uri": "/cb"})
+    item = fake_table.put_item.call_args.kwargs["Item"]
+    assert item["nonce"] == "n1"
+    assert item["redirect_uri"] == "/cb"
+
+
+def test_put_state_payload_cannot_overwrite_reserved_keys(fake_table):
+    """Reserved keys (PK / SK / created_at / ttl / ttl_seconds) must win."""
+    state_store.put_state(
+        "abc",
+        payload={
+            "PK": "EVIL#hijack",
+            "SK": "EVIL",
+            "ttl": 1,
+            "ttl_seconds": 9999,
+            "created_at": 0,
+            "nonce": "n1",
+        },
+        ttl_seconds=300,
+    )
+    item = fake_table.put_item.call_args.kwargs["Item"]
+    assert item["PK"] == "MGMT_STATE#abc"
+    assert item["SK"] == "META"
+    assert item["ttl_seconds"] == 300
+    assert item["nonce"] == "n1"  # non-reserved attributes still come through
+
+
+# ── consume_state — happy path ───────────────────────────────────────────────
+
+
+def test_consume_state_returns_payload_when_present_and_unexpired(fake_table):
+    now = int(time.time())
+    fake_table.delete_item.return_value = {
+        "Attributes": {
+            "PK": "MGMT_STATE#abc",
+            "SK": "META",
+            "created_at": now,
+            "ttl_seconds": 600,
+            "ttl": now + 600,
+            "nonce": "n1",
+        }
+    }
+
+    result = state_store.consume_state("abc")
+
+    assert result is not None
+    assert result["nonce"] == "n1"
+    # Verify the delete was conditional on presence + asked for the old image.
+    call = fake_table.delete_item.call_args.kwargs
+    assert call["Key"] == {"PK": "MGMT_STATE#abc", "SK": "META"}
+    assert call["ConditionExpression"] == "attribute_exists(PK)"
+    assert call["ReturnValues"] == "ALL_OLD"
+
+
+# ── consume_state — missing key ──────────────────────────────────────────────
+
+
+def test_consume_state_returns_none_on_conditional_check_failed(fake_table):
+    """Replay or already-consumed → ConditionalCheckFailedException → None."""
+    fake_table.delete_item.side_effect = ClientError(
+        error_response={
+            "Error": {
+                "Code": "ConditionalCheckFailedException",
+                "Message": "The conditional request failed",
+            }
+        },
+        operation_name="DeleteItem",
+    )
+
+    log, captured = _attach_log_handler()
+    try:
+        result = state_store.consume_state("never-existed")
+    finally:
+        log.removeHandler(log.handlers[-1])
+
+    assert result is None
+    info_lines = [r for r in captured if r.levelno == logging.INFO]
+    assert any("not present" in r.getMessage() for r in info_lines), (
+        f"expected an INFO log mentioning 'not present', got: "
+        f"{[r.getMessage() for r in info_lines]}"
+    )
+
+
+def test_consume_state_propagates_unexpected_client_error(fake_table):
+    """Non-ConditionalCheckFailed errors must surface, not return None."""
+    fake_table.delete_item.side_effect = ClientError(
+        error_response={"Error": {"Code": "ProvisionedThroughputExceededException"}},
+        operation_name="DeleteItem",
+    )
+
+    with pytest.raises(ClientError):
+        state_store.consume_state("abc")
+
+
+def test_consume_state_returns_none_when_attributes_missing(fake_table):
+    """Defensive: ALL_OLD with no Attributes key → treat as not present."""
+    fake_table.delete_item.return_value = {}  # no Attributes key
+
+    log, captured = _attach_log_handler()
+    try:
+        result = state_store.consume_state("abc")
+    finally:
+        log.removeHandler(log.handlers[-1])
+
+    assert result is None
+    info_lines = [r for r in captured if r.levelno == logging.INFO]
+    assert any("no attributes" in r.getMessage() for r in info_lines)
+
+
+# ── consume_state — expired item ─────────────────────────────────────────────
+
+
+def test_consume_state_returns_none_when_expired(fake_table):
+    """Delete succeeds but app-level expiry fails → None + 'expired' log."""
+    long_ago = int(time.time()) - 3600  # one hour ago
+    fake_table.delete_item.return_value = {
+        "Attributes": {
+            "PK": "MGMT_STATE#stale",
+            "SK": "META",
+            "created_at": long_ago,
+            "ttl_seconds": 600,  # 10-minute window expired ~50 minutes ago
+            "ttl": long_ago + 600,
+        }
+    }
+
+    log, captured = _attach_log_handler()
+    try:
+        result = state_store.consume_state("stale")
+    finally:
+        log.removeHandler(log.handlers[-1])
+
+    assert result is None
+    info_lines = [r for r in captured if r.levelno == logging.INFO]
+    assert any("expired" in r.getMessage() for r in info_lines), (
+        f"expected an INFO log mentioning 'expired', got: {[r.getMessage() for r in info_lines]}"
+    )
+
+
+def test_consume_state_returns_none_when_ttl_seconds_missing_and_default_expires(fake_table):
+    """If ttl_seconds is absent the default (600s) is applied — and an old
+    created_at means the row is treated as expired."""
+    long_ago = int(time.time()) - 3600
+    fake_table.delete_item.return_value = {
+        "Attributes": {
+            "PK": "MGMT_STATE#x",
+            "SK": "META",
+            "created_at": long_ago,
+            # no ttl_seconds attribute
+        }
+    }
+    assert state_store.consume_state("x") is None
+
+
+# ── atomic-consume race ──────────────────────────────────────────────────────
+
+
+def test_consume_state_atomic_race_one_winner_one_loser(fake_table):
+    """Two concurrent consumes: first wins (returns payload), second gets None.
+
+    Modelled by configuring the mock to return the payload on the first
+    call and raise ConditionalCheckFailedException on the second.
+    """
+    now = int(time.time())
+    fake_table.delete_item.side_effect = [
+        {
+            "Attributes": {
+                "PK": "MGMT_STATE#race",
+                "SK": "META",
+                "created_at": now,
+                "ttl_seconds": 600,
+                "ttl": now + 600,
+                "nonce": "n1",
+            }
+        },
+        ClientError(
+            error_response={"Error": {"Code": "ConditionalCheckFailedException"}},
+            operation_name="DeleteItem",
+        ),
+    ]
+
+    first = state_store.consume_state("race")
+    second = state_store.consume_state("race")
+
+    assert first is not None
+    assert first["nonce"] == "n1"
+    assert second is None
+
+
+# ── _get_table ───────────────────────────────────────────────────────────────
+
+
+def test_get_table_uses_env_vars(monkeypatch):
+    """STARTER_TABLE_NAME / DYNAMODB_ENDPOINT must be read at call time."""
+    monkeypatch.setenv("STARTER_TABLE_NAME", "test-table-from-env")
+    monkeypatch.setenv("DYNAMODB_ENDPOINT", "http://localhost:9999")
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResource:
+        def Table(self, name: str) -> str:
+            captured["table_name"] = name
+            return f"table:{name}"
+
+    def _fake_resource(service: str, **kwargs: Any) -> _FakeResource:
+        captured["service"] = service
+        captured["kwargs"] = kwargs
+        return _FakeResource()
+
+    with patch.object(state_store.boto3, "resource", side_effect=_fake_resource):
+        result = state_store._get_table()
+
+    assert result == "table:test-table-from-env"
+    assert captured["service"] == "dynamodb"
+    assert captured["kwargs"]["region_name"] == "us-west-2"
+    assert captured["kwargs"]["endpoint_url"] == "http://localhost:9999"
+    assert captured["table_name"] == "test-table-from-env"
+
+
+def test_get_table_uses_defaults_when_env_unset(monkeypatch):
+    monkeypatch.delenv("STARTER_TABLE_NAME", raising=False)
+    monkeypatch.delenv("DYNAMODB_ENDPOINT", raising=False)
+    monkeypatch.delenv("AWS_REGION", raising=False)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResource:
+        def Table(self, name: str) -> str:
+            captured["table_name"] = name
+            return name
+
+    def _fake_resource(service: str, **kwargs: Any) -> _FakeResource:
+        captured["kwargs"] = kwargs
+        return _FakeResource()
+
+    with patch.object(state_store.boto3, "resource", side_effect=_fake_resource):
+        state_store._get_table()
+
+    assert captured["table_name"] == "agentcore-starter-dev"
+    assert captured["kwargs"]["region_name"] == "us-east-1"
+    assert captured["kwargs"]["endpoint_url"] is None

--- a/tests/unit/test_auth_state_store.py
+++ b/tests/unit/test_auth_state_store.py
@@ -39,13 +39,20 @@ def fake_table():
         yield table
 
 
-def _attach_log_handler() -> tuple[logging.Logger, list[logging.LogRecord]]:
+def _attach_log_handler() -> tuple[logging.Logger, logging.Handler, list[logging.LogRecord]]:
     """Attach a list-backed handler to the state_store logger.
 
     The project's structured logger sets ``propagate=False`` on the
     ``starter`` tree so :data:`pytest`'s ``caplog`` fixture cannot see
     the records via the root logger — mirror the pattern from
     ``tests/integration/test_startup.py``.
+
+    Returns the logger, the specific handler instance (for precise
+    cleanup), and the list the records will accumulate into. The
+    logger level is forced to DEBUG so INFO records always emit
+    regardless of test order — without that pin, an earlier test that
+    triggered ``configure_logging`` could leave the level at INFO or
+    WARNING and silently drop the records this test relies on.
     """
     captured: list[logging.LogRecord] = []
 
@@ -55,8 +62,9 @@ def _attach_log_handler() -> tuple[logging.Logger, list[logging.LogRecord]]:
 
     handler = _ListHandler(level=logging.DEBUG)
     log = logging.getLogger("starter.auth.state_store")
+    log.setLevel(logging.DEBUG)
     log.addHandler(handler)
-    return log, captured
+    return log, handler, captured
 
 
 # ── put_state ────────────────────────────────────────────────────────────────
@@ -154,11 +162,11 @@ def test_consume_state_returns_none_on_conditional_check_failed(fake_table):
         operation_name="DeleteItem",
     )
 
-    log, captured = _attach_log_handler()
+    log, handler, captured = _attach_log_handler()
     try:
         result = state_store.consume_state("never-existed")
     finally:
-        log.removeHandler(log.handlers[-1])
+        log.removeHandler(handler)
 
     assert result is None
     info_lines = [r for r in captured if r.levelno == logging.INFO]
@@ -183,11 +191,11 @@ def test_consume_state_returns_none_when_attributes_missing(fake_table):
     """Defensive: ALL_OLD with no Attributes key → treat as not present."""
     fake_table.delete_item.return_value = {}  # no Attributes key
 
-    log, captured = _attach_log_handler()
+    log, handler, captured = _attach_log_handler()
     try:
         result = state_store.consume_state("abc")
     finally:
-        log.removeHandler(log.handlers[-1])
+        log.removeHandler(handler)
 
     assert result is None
     info_lines = [r for r in captured if r.levelno == logging.INFO]
@@ -210,11 +218,11 @@ def test_consume_state_returns_none_when_expired(fake_table):
         }
     }
 
-    log, captured = _attach_log_handler()
+    log, handler, captured = _attach_log_handler()
     try:
         result = state_store.consume_state("stale")
     finally:
-        log.removeHandler(log.handlers[-1])
+        log.removeHandler(handler)
 
     assert result is None
     info_lines = [r for r in captured if r.levelno == logging.INFO]
@@ -305,9 +313,11 @@ def test_get_table_uses_env_vars(monkeypatch):
 
 
 def test_get_table_uses_defaults_when_env_unset(monkeypatch):
+    """No region env var set → region_name not passed; boto3 uses ~/.aws/config."""
     monkeypatch.delenv("STARTER_TABLE_NAME", raising=False)
     monkeypatch.delenv("DYNAMODB_ENDPOINT", raising=False)
     monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
 
     captured: dict[str, Any] = {}
 
@@ -324,5 +334,28 @@ def test_get_table_uses_defaults_when_env_unset(monkeypatch):
         state_store._get_table()
 
     assert captured["table_name"] == "agentcore-starter-dev"
-    assert captured["kwargs"]["region_name"] == "us-east-1"
+    assert "region_name" not in captured["kwargs"]
     assert captured["kwargs"]["endpoint_url"] is None
+
+
+def test_get_table_falls_back_to_aws_default_region(monkeypatch):
+    """``AWS_DEFAULT_REGION`` is honoured when ``AWS_REGION`` is unset."""
+    monkeypatch.delenv("AWS_REGION", raising=False)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+    monkeypatch.setenv("STARTER_TABLE_NAME", "tbl")
+    monkeypatch.delenv("DYNAMODB_ENDPOINT", raising=False)
+
+    captured: dict[str, Any] = {}
+
+    class _FakeResource:
+        def Table(self, name: str) -> str:
+            return name
+
+    def _fake_resource(service: str, **kwargs: Any) -> _FakeResource:
+        captured["kwargs"] = kwargs
+        return _FakeResource()
+
+    with patch.object(state_store.boto3, "resource", side_effect=_fake_resource):
+        state_store._get_table()
+
+    assert captured["kwargs"]["region_name"] == "eu-west-1"

--- a/tests/unit/test_auth_state_store.py
+++ b/tests/unit/test_auth_state_store.py
@@ -39,32 +39,57 @@ def fake_table():
         yield table
 
 
-def _attach_log_handler() -> tuple[logging.Logger, logging.Handler, list[logging.LogRecord]]:
-    """Attach a list-backed handler to the state_store logger.
+class _LogCapture:
+    """Context manager that captures records from the state_store logger.
 
     The project's structured logger sets ``propagate=False`` on the
     ``starter`` tree so :data:`pytest`'s ``caplog`` fixture cannot see
     the records via the root logger — mirror the pattern from
     ``tests/integration/test_startup.py``.
 
-    Returns the logger, the specific handler instance (for precise
-    cleanup), and the list the records will accumulate into. The
-    logger level is forced to DEBUG so INFO records always emit
-    regardless of test order — without that pin, an earlier test that
-    triggered ``configure_logging`` could leave the level at INFO or
-    WARNING and silently drop the records this test relies on.
+    On enter: pins the logger level to DEBUG (so INFO records always
+    emit regardless of test order — without that pin, an earlier test
+    that triggered ``configure_logging`` could leave the level at INFO
+    or WARNING and silently drop the records this test relies on) and
+    attaches a list-backed handler.
+
+    On exit: removes the handler **and** restores the logger's prior
+    level so this fixture never leaks global logger state into
+    unrelated tests.
+
+    Usage::
+
+        with _LogCapture() as cap:
+            do_something_that_logs()
+        assert any("not present" in r.getMessage() for r in cap.records)
     """
-    captured: list[logging.LogRecord] = []
 
-    class _ListHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            captured.append(record)
+    def __init__(self) -> None:
+        self.records: list[logging.LogRecord] = []
+        self.logger = logging.getLogger("starter.auth.state_store")
+        self._handler: logging.Handler | None = None
+        self._previous_level: int | None = None
 
-    handler = _ListHandler(level=logging.DEBUG)
-    log = logging.getLogger("starter.auth.state_store")
-    log.setLevel(logging.DEBUG)
-    log.addHandler(handler)
-    return log, handler, captured
+    def __enter__(self) -> _LogCapture:
+        captured = self.records
+
+        class _ListHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        self._previous_level = self.logger.level
+        self._handler = _ListHandler(level=logging.DEBUG)
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.addHandler(self._handler)
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        if self._handler is not None:
+            self.logger.removeHandler(self._handler)
+            self._handler = None
+        if self._previous_level is not None:
+            self.logger.setLevel(self._previous_level)
+            self._previous_level = None
 
 
 # ── put_state ────────────────────────────────────────────────────────────────
@@ -162,14 +187,11 @@ def test_consume_state_returns_none_on_conditional_check_failed(fake_table):
         operation_name="DeleteItem",
     )
 
-    log, handler, captured = _attach_log_handler()
-    try:
+    with _LogCapture() as cap:
         result = state_store.consume_state("never-existed")
-    finally:
-        log.removeHandler(handler)
 
     assert result is None
-    info_lines = [r for r in captured if r.levelno == logging.INFO]
+    info_lines = [r for r in cap.records if r.levelno == logging.INFO]
     assert any("not present" in r.getMessage() for r in info_lines), (
         f"expected an INFO log mentioning 'not present', got: "
         f"{[r.getMessage() for r in info_lines]}"
@@ -191,14 +213,11 @@ def test_consume_state_returns_none_when_attributes_missing(fake_table):
     """Defensive: ALL_OLD with no Attributes key → treat as not present."""
     fake_table.delete_item.return_value = {}  # no Attributes key
 
-    log, handler, captured = _attach_log_handler()
-    try:
+    with _LogCapture() as cap:
         result = state_store.consume_state("abc")
-    finally:
-        log.removeHandler(handler)
 
     assert result is None
-    info_lines = [r for r in captured if r.levelno == logging.INFO]
+    info_lines = [r for r in cap.records if r.levelno == logging.INFO]
     assert any("no attributes" in r.getMessage() for r in info_lines)
 
 
@@ -218,14 +237,11 @@ def test_consume_state_returns_none_when_expired(fake_table):
         }
     }
 
-    log, handler, captured = _attach_log_handler()
-    try:
+    with _LogCapture() as cap:
         result = state_store.consume_state("stale")
-    finally:
-        log.removeHandler(handler)
 
     assert result is None
-    info_lines = [r for r in captured if r.levelno == logging.INFO]
+    info_lines = [r for r in cap.records if r.levelno == logging.INFO]
     assert any("expired" in r.getMessage() for r in info_lines), (
         f"expected an INFO log mentioning 'expired', got: {[r.getMessage() for r in info_lines]}"
     )

--- a/tests/unit/test_auth_state_store.py
+++ b/tests/unit/test_auth_state_store.py
@@ -209,6 +209,61 @@ def test_consume_state_propagates_unexpected_client_error(fake_table):
         state_store.consume_state("abc")
 
 
+def test_consume_state_returns_none_on_validation_exception(fake_table):
+    """Malformed user-supplied state → ValidationException → None.
+
+    State is taken from a query parameter on ``/auth/callback`` and is
+    therefore attacker-controllable. DynamoDB rejects malformed/oversized
+    keys with ``ValidationException``; treating it as "not present" gives
+    the user the same 400 they'd get for an unknown state (correct
+    contract for a bad input), instead of bubbling a 500.
+
+    The log line MUST include the error code (so operators can
+    distinguish this from genuine missing-state in metrics) but MUST NOT
+    include the raw state value (user-controlled, log-injection risk).
+    """
+    raw_state = "evil\nstate-with-injected-newline"
+    fake_table.delete_item.side_effect = ClientError(
+        error_response={
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "The provided key element does not match the schema",
+            }
+        },
+        operation_name="DeleteItem",
+    )
+
+    with _LogCapture() as cap:
+        result = state_store.consume_state(raw_state)
+
+    assert result is None
+
+    info_lines = [r for r in cap.records if r.levelno == logging.INFO]
+    assert any("rejected by DynamoDB validation" in r.getMessage() for r in info_lines), (
+        f"expected an INFO log mentioning 'rejected by DynamoDB validation', "
+        f"got: {[r.getMessage() for r in info_lines]}"
+    )
+
+    # Error code must surface in the record (via extra={...} on the
+    # LogRecord) so operators can distinguish this case in log analysis.
+    assert any(getattr(r, "error_code", None) == "ValidationException" for r in info_lines), (
+        "expected the ValidationException error code on the LogRecord"
+    )
+
+    # Raw state value MUST NOT appear anywhere on the record — neither
+    # in the formatted message nor as an extra attribute. State is
+    # user-controlled and logging it risks log injection (the value
+    # above includes a newline expressly to detect that mistake).
+    for record in info_lines:
+        formatted = record.getMessage()
+        assert raw_state not in formatted, f"raw state value leaked into log message: {formatted!r}"
+        for attr_value in vars(record).values():
+            if isinstance(attr_value, str):
+                assert raw_state not in attr_value, (
+                    f"raw state value leaked into log record attribute: {attr_value!r}"
+                )
+
+
 def test_consume_state_returns_none_when_attributes_missing(fake_table):
     """Defensive: ALL_OLD with no Attributes key → treat as not present."""
     fake_table.delete_item.return_value = {}  # no Attributes key


### PR DESCRIPTION
Closes #23
Refs #56

## Summary

Replace the in-process `_pending_states` dict with a new
`starter.auth.state_store` module that persists pending OAuth state
to DynamoDB under the `MGMT_STATE#{state}` / `META` key shape
already documented in CLAUDE.md §"DynamoDB single table design".

The dict pattern broke under concurrent Lambda execution: the
callback could hit a different warm container than the one that
issued the state, fail with `Invalid or expired state`, and 400
the user. Probability scales with concurrency. (Sources: SEC-7 + G4.)

## Approach

- **Module placement** — `src/starter/auth/state_store.py`
  (auth-scoped, locked by issue #23). Did not propose
  `src/starter/storage.py` or any general-purpose layer.
- **`consume_state` shape — Option B**:
  `ConditionExpression: attribute_exists(PK)` +
  `ReturnValues: ALL_OLD` + application-level expiry check on the
  returned old image.
  - Atomicity comes from DynamoDB's single-key write serialization,
    not from the condition.
  - The condition exists to distinguish "state was never present"
    (replay) from "state was issued but expired" (slow callback) —
    both are auth-flow failure modes worth distinguishing in
    logs / metrics.
  - We do NOT push the time comparison into the ConditionExpression
    (Option C); DynamoDB TTL is best-effort and the application
    must own correctness on the read path.
- **Three INFO log lines** distinguish the failure modes for
  metric / log analysis: `OAuth state not present`,
  `delete returned no attributes`, `OAuth state expired`.
- **No schema change** — the `MGMT_STATE#` prefix was already in
  CLAUDE.md and the dynamodb-item skill taxonomy.

## Test coverage

Both unit and integration suites cover the four required cases:

| Case | Unit test | Integration test |
| --- | --- | --- |
| Happy path | `test_consume_state_returns_payload_when_present_and_unexpired` | `test_put_then_consume_returns_payload` |
| Missing key (ConditionalCheckFailed → None + log) | `test_consume_state_returns_none_on_conditional_check_failed` | `test_consume_missing_state_returns_none` |
| Expired item (delete OK, app-check fails → None + log) | `test_consume_state_returns_none_when_expired` | `test_consume_expired_item_returns_none` |
| Atomic-consume race (one winner, other gets None) | `test_consume_state_atomic_race_one_winner_one_loser` | `test_atomic_consume_only_one_winner` |

Coverage:

- `src/starter/auth/state_store.py` — 42/42 stmts (100%)
- `src/starter/auth/mgmt_auth.py` — 65/65 stmts (100%)
- Combined unit + integration suite passes `--cov-fail-under=100`.

The integration suite gains a session-scoped `starter_table`
fixture that provisions the StarterTable in DynamoDB Local with
the same GSI shape (`KeyIndex` / `TagIndex` / `ClientIndex` /
`UserEmailIndex`) as production. CDK is not invoked because
DynamoDB Local doesn't run CloudFormation; the fixture is the
test-environment analogue.

## Deploy + manual verification on `jc`

Deployed `0.8.0-jc.583ec18` to `AgentCoreStarterStack-jc` (deploy
time 302s, total 416s).

End-to-end checks against
`https://agentcore-starter-jc.warlordofmars.net`:

1. **`/auth/login` writes state to DynamoDB** — issued the request,
   then `aws dynamodb scan` against the `agentcore-starter-jc`
   table found a row with
   `PK=MGMT_STATE#jW_MCQDo6uZgRDJZo8gM2p4Ds1PXIT3l_f0VPTneiXA`,
   `SK=META`, `created_at=1777548082`, `ttl_seconds=600`,
   `ttl=1777548682`. The redirect target was Google's
   authorization endpoint (the "fake-google-client-id" rejection
   is expected — the `jc` env doesn't have a real Google OAuth
   client).
2. **`/auth/callback` with unknown state returns 400** — exercised
   the ConditionalCheckFailed path. The Lambda CloudWatch log
   captured the new INFO line:
   `"OAuth state not present in store (replay or already
   consumed)"` — exactly the contract designed.
3. **Bypass mode is OFF on `jc`** (verified via Lambda
   environment) so the prod-shaped flow is what was exercised.

The full Google round-trip is unrelated to this change; the
state-store's contribution to the flow is fully exercised.

## Notes

- This is the first issue from the auth-cluster (#19–#23) chapter
  — subsequent auth-cluster work will build on this surface.
- Refs #56 (template-bootstrap pattern) — this is part of the
  template's "ship correct concurrent-Lambda behavior" family;
  the in-process dict was a single-Lambda-instance assumption
  that doesn't survive the warm-pool model.
- **NOT `agent-safe`** — auth path. Halt at PR ready-for-review.