### PR TITLE
fix(ci): smoke test should hit CloudFront, not the Lambda Function URL directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,9 +564,10 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     outputs:
-      
+
       api_url: ${{ steps.urls.outputs.api_url }}
       ui_url: ${{ steps.urls.outputs.ui_url }}
+      public_url: ${{ steps.urls.outputs.public_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
@@ -616,6 +617,13 @@ jobs:
           echo "api_url_direct=$(query ApiFunctionUrl)" >> "$GITHUB_OUTPUT"
           echo "api_url=$(query ApiFunctionUrl)"  >> "$GITHUB_OUTPUT"
           echo "ui_url=$(query UiUrl)"            >> "$GITHUB_OUTPUT"
+          # public_url is the CloudFront distribution URL — the same edge
+          # endpoint that serves the UI, which CloudFront also routes to
+          # the API origin under /api, /auth, /oauth, /.well-known, /health.
+          # Smoke tests hit this so they exercise the full edge path
+          # (CloudFront injects X-Origin-Verify, which the Lambda's
+          # _verify_origin_secret middleware requires — see #127).
+          echo "public_url=$(query UiUrl)"        >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack — deploy success
         if: env.SLACK_WEBHOOK_URL != ''
@@ -671,12 +679,19 @@ jobs:
       # strip-down. Until proper e2e suites are reauthored against the
       # current API/UI surface (tracked separately), this job runs a
       # single smoke check against the deployed dev API — green smoke
-      # proves the Lambda is up and the Function URL is reachable from
-      # the runner, validating the full deploy → reachability chain.
+      # proves the Lambda is up and reachable through CloudFront from
+      # the runner, validating the full edge → Lambda chain (see #127).
       # Mirrors the e2e-prod "Smoke test prod API" precedent below.
       - name: Smoke test dev API
         env:
-          STARTER_API_URL: ${{ needs.deploy-dev.outputs.api_url }}
+          # Hit the CloudFront distribution, NOT the Lambda Function URL
+          # directly. CloudFront injects the X-Origin-Verify header that
+          # the Lambda's _verify_origin_secret middleware requires (see #127);
+          # bypassing CloudFront returns 403. CloudFront's /health behaviour
+          # forwards to the API origin, so /health is reachable through
+          # the edge. Hitting through CloudFront also validates the full
+          # edge path the way real traffic flows.
+          STARTER_PUBLIC_URL: ${{ needs.deploy-dev.outputs.public_url }}
         run: |
           # /health must return JSON with .status == 'ok' on a healthy
           # Lambda. AWSLWA returns HTTP 200 even on init failure (the
@@ -688,7 +703,7 @@ jobs:
           # -sS surfaces curl-side errors (DNS/TLS/connectivity) instead
           # of silently hiding them; --connect-timeout / --max-time
           # prevent indefinite hangs.
-          RESPONSE=$(curl -sS --connect-timeout 5 --max-time 15 -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
+          RESPONSE=$(curl -sS --connect-timeout 5 --max-time 15 -w "\nHTTP_CODE:%{http_code}" "${STARTER_PUBLIC_URL%/}/health")
           STATUS=$(printf '%s\n' "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
           BODY=$(printf '%s\n' "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"
@@ -767,9 +782,10 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     outputs:
-      
+
       api_url: ${{ steps.urls.outputs.api_url }}
       ui_url: ${{ steps.urls.outputs.ui_url }}
+      public_url: ${{ steps.urls.outputs.public_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
@@ -820,6 +836,13 @@ jobs:
           echo "api_url_direct=$(query ApiFunctionUrl)" >> "$GITHUB_OUTPUT"
           echo "api_url=$(query ApiFunctionUrl)"  >> "$GITHUB_OUTPUT"
           echo "ui_url=$(query UiUrl)"            >> "$GITHUB_OUTPUT"
+          # public_url is the CloudFront distribution URL — the same edge
+          # endpoint that serves the UI, which CloudFront also routes to
+          # the API origin under /api, /auth, /oauth, /.well-known, /health.
+          # Smoke tests hit this so they exercise the full edge path
+          # (CloudFront injects X-Origin-Verify, which the Lambda's
+          # _verify_origin_secret middleware requires — see #127).
+          echo "public_url=$(query UiUrl)"        >> "$GITHUB_OUTPUT"
 
       - name: Notify Slack — deploy success
         if: env.SLACK_WEBHOOK_URL != ''
@@ -872,7 +895,14 @@ jobs:
       # Run a lightweight smoke test instead — just verify the prod API is up.
       - name: Smoke test prod API
         env:
-          STARTER_API_URL: ${{ needs.deploy-prod.outputs.api_url }}
+          # Hit the CloudFront distribution, NOT the Lambda Function URL
+          # directly. CloudFront injects the X-Origin-Verify header that
+          # the Lambda's _verify_origin_secret middleware requires (see #127);
+          # bypassing CloudFront returns 403. CloudFront's /health behaviour
+          # forwards to the API origin, so /health is reachable through
+          # the edge. Hitting through CloudFront also validates the full
+          # edge path the way real traffic flows.
+          STARTER_PUBLIC_URL: ${{ needs.deploy-prod.outputs.public_url }}
         run: |
           # /health must return JSON with .status == 'ok' on a healthy
           # Lambda. AWSLWA returns HTTP 200 even on init failure (the
@@ -884,7 +914,7 @@ jobs:
           # -sS surfaces curl-side errors (DNS/TLS/connectivity) instead
           # of silently hiding them; --connect-timeout / --max-time
           # prevent indefinite hangs.
-          RESPONSE=$(curl -sS --connect-timeout 5 --max-time 15 -w "\nHTTP_CODE:%{http_code}" "${STARTER_API_URL%/}/health")
+          RESPONSE=$(curl -sS --connect-timeout 5 --max-time 15 -w "\nHTTP_CODE:%{http_code}" "${STARTER_PUBLIC_URL%/}/health")
           STATUS=$(printf '%s\n' "$RESPONSE" | tail -n 1 | sed 's/^HTTP_CODE://')
           BODY=$(printf '%s\n' "$RESPONSE" | sed '$d')
           echo "Health check status: $STATUS"


### PR DESCRIPTION
Closes #127

## Summary

The dev pipeline smoke step has been failing since #115 (`d47fcba`, 2026-04-29) and 5 subsequent merges (#119, #121, #122, #123, #125) shipped through it. Root cause: the `_verify_origin_secret` middleware in `src/starter/api/main.py:106-126` rejects requests missing the `X-Origin-Verify` header with 403. The smoke step set `STARTER_API_URL` to the Lambda Function URL, bypassing CloudFront — which is the only thing that injects that header.

This PR switches both the dev and prod smoke tests to hit the CloudFront distribution URL (the existing `UiUrl` CFN output, which is `https://{custom_domain}`). CloudFront's existing `/health` behaviour (already present in `infra/stacks/starter_stack.py:757-763`) routes to the API origin and CloudFront's `custom_headers=origin_verify_header` injection (line 441-455) attaches the `X-Origin-Verify` header. The middleware now passes and the smoke validates the full edge → Lambda chain end-to-end.

## Approach

- Added a new `public_url` step output (sourced from the existing `UiUrl` CFN output) to both `deploy-dev` and `deploy-prod` jobs, surfaced as a job-level output.
- Switched both smoke test env vars from `STARTER_API_URL` (Function URL) to `STARTER_PUBLIC_URL` (CloudFront edge). The new env name reflects "public CloudFront edge" semantics; `api_url` (Function URL) is preserved unchanged because `tasks.py` and `tests/e2e/conftest.py` still consume it for true e2e tests when those are reauthored.
- Updated the inline comment block in `e2e-dev` that previously claimed "Function URL is reachable" to reflect the new edge-path validation.
- The #122 hardening (assert HTTP 200 AND response body `.status == "ok"`) is preserved exactly as-is — only the target URL changed.

## Decisions / scope notes

- **No new CFN output added.** The `UiUrl` output (line 1414-1418 in `starter_stack.py`) already provides `https://{custom_domain}`, which is exactly the CloudFront edge URL. Adding a duplicate output was unnecessary; the rename happens at the GitHub Actions step-output level (`public_url`) instead.
- **No CloudFront behaviour change required.** `/health` is already routed to the API origin (line 757-763) — the issue's first halt condition is not triggered.
- **No deploy-step URL-export wiring tangle.** The only consumer of `api_url` from the deploy outputs was the smoke step itself (and a Slack notification). `STARTER_API_URL` references in `tasks.py` and `tests/e2e/conftest.py` are independent (locally set in different code paths) — no renaming needed there. The issue's second halt condition is not triggered.
- **`synthetic-traffic.yml` does not exist.** AC item is a no-op.
- **`infra/stacks/starter_stack.py` not modified.** `inv synth` confirms `UiUrl` output is already what we need.

## Validation

- `uv run inv pre-push`: clean (lint, typecheck, 204 unit + 269 frontend tests).
- `uv run inv synth`: clean (no infra changes).
- Local Copilot review (`copilot -p "/review"`): no material findings.

## Test plan

- [ ] CI on this PR is green.
- [ ] After merge, the dev pipeline's "Smoke test dev API" step is green for the first time since #115 — this is the AC's primary validation gate.