### PR TITLE
chore: reconcile docs label taxonomy (documentation -> docs) (#46)

### DIFF
--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -71,7 +71,7 @@ BOUNDED_AREA_GLOBS: dict[str, list[str]] = {
     "auth": ["src/starter/auth/**", "tests/unit/test_auth_*.py", "tests/e2e/test_auth_*.py"],
     "infra": ["infra/**"],
     "ui": ["ui/**"],
-    "documentation": ["docs/**", "docs-site/**", "README.md", "CHANGELOG.md"],
+    "docs": ["docs/**", "docs-site/**", "README.md", "CHANGELOG.md"],
     "ci": [".github/workflows/**", "scripts/**"],
 }
 

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -162,10 +162,11 @@ def test_area_label_paths_bounded_area_ui_bare_label():
     assert any(g.startswith("ui/") for g in globs)
 
 
-def test_area_label_paths_bounded_area_documentation():
-    """The live area label is `documentation` (not `docs` — CLAUDE.md
-    taxonomy is forward-looking; the live label set is the ground truth)."""
-    globs = scope_check.area_label_paths(["documentation", "priority:p2"])
+def test_area_label_paths_bounded_area_docs():
+    """The live area label is `docs` (per CLAUDE.md taxonomy — issue #46
+    reconciled the historical `documentation` label to the canonical
+    short-form `docs` matching the rest of the area taxonomy)."""
+    globs = scope_check.area_label_paths(["docs", "priority:p2"])
     assert globs is not None
     assert any(g.startswith("docs/") or g.startswith("docs-site/") for g in globs)
 
@@ -194,7 +195,7 @@ def test_area_label_paths_filters_out_non_area_labels():
             "ui",
             "agent-safe",
             "enhancement",
-            "documentation",
+            "docs",
             "status:ready",
             "priority:p2",
             "size:s",
@@ -752,11 +753,14 @@ def test_implicit_test_glob_in_files_to_touch_does_not_widen_scope():
 
 def test_fix2_kept_areas_still_resolve():
     """Issue #90 Fix 2: the kept area labels (`api`, `auth`, `infra`, `ui`,
-    `documentation`, `ci`) must still resolve to their globs after the
+    `docs`, `ci`) must still resolve to their globs after the
     prune. Live meta-areas (`dx`, `security`, `reliability`,
-    `observability`) must still trigger the meta-area WARN fall-through."""
+    `observability`) must still trigger the meta-area WARN fall-through.
+
+    Note: `documentation` was renamed to `docs` per issue #46 to align with
+    the CLAUDE.md taxonomy."""
     # Bounded areas still map.
-    for area in ("api", "auth", "infra", "ui", "documentation", "ci"):
+    for area in ("api", "auth", "infra", "ui", "docs", "ci"):
         assert area in scope_check.BOUNDED_AREA_GLOBS, f"{area!r} should still map"
     api_globs = scope_check.area_label_paths(["api", "priority:p2"])
     assert api_globs is not None


### PR DESCRIPTION
Closes #46

## Summary

Reconciles the live repo label set with CLAUDE.md "Backlog labels and milestones" taxonomy. The historical `documentation` label (auto-created at repo init) was being used for docs work, but CLAUDE.md defines the area label as `docs` — matching the rest of the short-form area taxonomy (`ui`, `api`, `auth`, `infra`, etc.). Picked Option A (rename + bulk-relabel) per the issue recommendation.

## Approach

**Label changes (out-of-tree — already executed):**

- Created `docs` label (description "Documentation", color `#0075ca` — same as old `documentation` label).
- Bulk-relabeled all 31 issues (open + closed) carrying `documentation` to `docs` via `gh issue edit`.
- Deleted the obsolete `documentation` label.

Verified zero open or closed issues now carry `documentation`, and zero PRs do either.

**Code changes:**

- `scripts/check_agent_safe_scope.py`: rename `BOUNDED_AREA_GLOBS["documentation"]` → `BOUNDED_AREA_GLOBS["docs"]` so future agent-safe issues carrying the `docs` area label resolve to the bounded-area globs. Without this, they would fall through to WARN and silently degrade the agent-safe scope gate.
- `tests/unit/test_check_agent_safe_scope.py`: update the three tests that asserted on the `documentation` key (`test_area_label_paths_bounded_area_documentation` → `test_area_label_paths_bounded_area_docs`, plus two list-membership assertions).

`.github/ISSUE_TEMPLATE/*.yml` did not reference the old label, so no template changes were needed. Other matches across the repo (retro doc, CLAUDE.md prose, ADRs) are either historical record or unrelated word usage; left untouched.

## Scope-boundary acknowledgment (additive scope expansion)

Per #77 escape-hatch / retro precedent (`docs/retros/2026-04-26-strategy-session-retro.md` §C6 "Additive-scope-during-fix-commit handling"): the issue's `## Files to touch` section names only `.github/ISSUE_TEMPLATE/*.yml` (conditionally) and `CLAUDE.md`. The script + test changes are technically out of that stated scope.

I extended scope to include them because:

1. **Same shape of bug as the original** — the script's `BOUNDED_AREA_GLOBS` keyed `documentation` against the live label set, which the retro itself flagged as a script-vs-taxonomy mismatch (commit `5331d73`). Renaming the label without updating the script reintroduces the same drift in reverse.
2. **Functional necessity** — agent-safe issues carrying the new `docs` label would lose their bounded-area glob mapping and degrade the scope gate to WARN.
3. **Surfaced before applying** — flagging this here in the PR body, per the retro's documented pattern.

The agent-safe-scope CI check on this PR will likely report this PR as out-of-scope, since `scripts/**` and `tests/unit/**` are not in #46's `## Files to touch` and `dx` is a meta-area (WARN fall-through, not a path-mapping). That's the gate working correctly — surfacing the discrepancy. The right disposition is human review.

## Halt-before-merge

Per the instructions for this batch (#46 is potentially the first label-taxonomy reconciliation done by the agent), auto-merge is **not** enabled. Awaiting human review of the diff before merge.

## Test plan

- [x] `uv run inv pre-push` — green locally
- [x] Local Copilot review — clean ("No material issues found")
- [ ] CI green (lint + type + unit + frontend + infra synth + security scans)
- [ ] Agent-safe-scope check (expected to FAIL or WARN — see acknowledgment above)
- [ ] Copilot review on PR — clean