### PR TITLE
chore(docs): retitle "Sessions & memory" to "Sessions" (#43)

### DIFF
--- a/docs-site/.vitepress/config.mjs
+++ b/docs-site/.vitepress/config.mjs
@@ -47,7 +47,7 @@ export default defineConfig({
         text: "Building agents",
         items: [
           { text: "Overview", link: "/agents/overview" },
-          { text: "Sessions & memory", link: "/agents/sessions" },
+          { text: "Sessions", link: "/agents/sessions" },
         ],
       },
       {

--- a/docs-site/agents/overview.md
+++ b/docs-site/agents/overview.md
@@ -65,7 +65,7 @@ data: {"type": "done", "stop_reason": "end_turn", "input_tokens": 14, "output_to
 
 ## The agent endpoints (Inline Agent)
 
-These use `bedrock-agent-runtime.invoke_inline_agent` — the same model, but with session continuity between turns. See [Sessions & memory](./sessions) for the full conversation flow.
+These use `bedrock-agent-runtime.invoke_inline_agent` — the same model, but with session continuity between turns. See [Sessions](./sessions) for the full conversation flow.
 
 ### `POST /api/agents/invoke`
 

--- a/docs-site/agents/sessions.md
+++ b/docs-site/agents/sessions.md
@@ -1,4 +1,4 @@
-# Sessions & memory
+# Sessions
 
 ## How sessions work
 

--- a/docs-site/getting-started/introduction.md
+++ b/docs-site/getting-started/introduction.md
@@ -16,5 +16,5 @@ AgentCore Starter is a production-ready template for building AWS-native AI agen
 
 - [Quick start](/getting-started/quick-start) — deploy to your AWS account
 - [Building agents](/agents/overview) — call the Bedrock endpoints and consume SSE streams
-- [Sessions & memory](/agents/sessions) — multi-turn conversations, session scoping, tool-calling
+- [Sessions](/agents/sessions) — multi-turn conversations, session scoping, tool-calling
 - [Security and secrets](/operations/security) — operational secret contracts and rotation procedures


### PR DESCRIPTION
Closes #43

## Summary

Retitles the docs page at `docs-site/agents/sessions.md` from "Sessions & memory" to "Sessions". The "& memory" portion was residue from the earlier memory-product scaffold — the page content is exclusively about Bedrock inline-agent session state.

## Approach

Found four references to "Sessions & memory" in the docs site:

- `docs-site/agents/sessions.md` — page H1
- `docs-site/getting-started/introduction.md` — bullet link text
- `docs-site/agents/overview.md` — cross-link text in the inline-agent section
- `docs-site/.vitepress/config.mjs` — sidebar entry text

Updated all four. Page content stays unchanged. Updated issue #46's `## Files to touch` to reflect all four files (the original wording said "Possibly: config.mjs"; in practice all four needed touching).

## Test plan

- [x] `uv run inv pre-push` — green locally
- [ ] CI green
- [ ] Agent-safe-scope check green
- [ ] Copilot review clean