### PR TITLE
chore(deps): align @vitejs/plugin-react declared range with installed

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -28,7 +28,7 @@
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.5.2",
-        "@vitejs/plugin-react": "^4.3.1",
+        "@vitejs/plugin-react": "^4.7.0",
         "@vitest/coverage-v8": "^1.6.0",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,7 +33,7 @@
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",
-    "@vitejs/plugin-react": "^4.3.1",
+    "@vitejs/plugin-react": "^4.7.0",
     "@vitest/coverage-v8": "^1.6.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.3",


### PR DESCRIPTION
Closes #41

## Summary

Bump declared minimum of `@vitejs/plugin-react` from `^4.3.1` to `^4.7.0` so the declared baseline matches what npm has resolved. No behavior change — same major, same installed artifact.

## Approach

The drift documented in #41's body has largely already been reconciled:

- `@tailwindcss/vite` — installed `4.2.4`, declared `^4.2.4`. Already matched (Dependabot PR #2 fixed this on 2026-04-25, before #41 was filed).
- `@vitejs/plugin-react` — installed `4.7.0`, declared `^4.3.1`. The installed version satisfies the range, so `npm install` / `npm ci` already run cleanly with no warnings.

Following the issue's recommended option 1 ("chase forward, not back"): nudged the declared minimum up to `^4.7.0`, which matches what's actually installed. This guards against a regression where a fresh resolve drops back to a 4.3.x build.

Stayed within the major (v4) intentionally — `@vitejs/plugin-react@6.0.1` exists but typically requires Vite 7+, which is squarely in #39's scope (Vite v8 bump). Coordinated with #39 as the issue body requested: this PR sticks to within-major nudges; #39 handles the major-version churn.

## Validation

- `npm install` and `npm ci` both run cleanly
- `inv pre-push` passes (lint + typecheck + 204 unit tests + 269 frontend tests)
- Local Copilot review reports no material findings