### PR TITLE
chore(dx): clearer error when 'Files to touch' uses prose form

### DIFF
--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -488,17 +488,22 @@ def evaluate(
 
     if files_to_touch is not None:
         if not files_to_touch:
-            # Heading present but empty bullet list — fail closed. A section
-            # with no entries can't gate a diff; falling back to WARN would
-            # let any diff pass scope-check trivially by leaving the section
-            # blank.
+            # Heading present but parser returned no paths — fail closed. The
+            # zero-paths condition covers three shapes: (1) bullets present
+            # but empty, (2) bullets present with only prose content (no
+            # backticks, no path-shaped tokens), (3) prose-form section with
+            # backtick-quoted paths but no bullets at all. A section with no
+            # entries can't gate a diff; falling back to WARN would let any
+            # diff pass scope-check trivially by leaving the section blank.
             #
-            # Issue #130: distinguish the prose-form shape mismatch from a
-            # truly empty section. When the section contains backtick-quoted
-            # path-shaped tokens but no bullets, the author wrote prose
-            # instead of bullets — emit a targeted message naming the shape
-            # and showing the fix, rather than the generic "empty or
-            # malformed" string that doesn't tell them what to do.
+            # Issue #130: distinguish shape (3) from shapes (1) and (2). When
+            # the section contains backtick-quoted path-shaped tokens but no
+            # bullets, the author wrote prose instead of bullets — emit a
+            # targeted message naming the shape and showing the fix, rather
+            # than the generic "empty or malformed" string that doesn't tell
+            # them what to do. Shapes (1) and (2) keep the generic message
+            # because the bullet shape was correct; the content was the
+            # problem.
             section = _extract_files_to_touch_section(issue_body or "") or ""
             if _section_has_prose_form_paths(section):
                 return Verdict(

--- a/scripts/check_agent_safe_scope.py
+++ b/scripts/check_agent_safe_scope.py
@@ -126,6 +126,67 @@ _BACKTICK_TOKEN_RE = re.compile(r"`([^`]+)`")
 _BULLET_RE = re.compile(r"^\s*[-*+]\s+(.*)$", re.MULTILINE)
 
 
+def _extract_files_to_touch_section(body: str) -> str | None:
+    """
+    Return the text of the `## Files to touch` / `### Files to touch`
+    section (everything between the heading and the next heading of any
+    level), or None if no such heading is present.
+
+    Pulled out so both `parse_files_to_touch` and the prose-form shape
+    detector in `evaluate` operate on the same bounded slice — neither
+    should ever scan the whole issue body, which would risk pulling in
+    unrelated backticks from `## Context` or `## Notes`.
+    """
+    if not body:
+        return None
+
+    heading_match = _FILES_TO_TOUCH_HEADING_RE.search(body)
+    if not heading_match:
+        return None
+
+    section_start = heading_match.end()
+
+    # Find the next heading of any level after our heading — that bounds the
+    # section. If none, the section runs to end-of-body.
+    next_match = _NEXT_HEADING_RE.search(body, pos=section_start)
+    section_end = next_match.start() if next_match else len(body)
+    return body[section_start:section_end]
+
+
+def _section_has_prose_form_paths(section: str) -> bool:
+    """
+    Return True when the `## Files to touch` section contains backtick-
+    quoted path-shaped tokens but no markdown bullets.
+
+    This is the shape-mismatch signal: the issue author wrote the section
+    as prose paragraphs (e.g. "Touch `src/foo.py` and `tests/test_foo.py`")
+    instead of the required bullet form (`- ` / `* ` / `+ `). The parser
+    only walks bullets, so a prose section parses to an empty path list and
+    the gate currently fails with the generic "empty or malformed" message
+    — which doesn't tell the issue author what to fix. This detector lets
+    the gate emit a targeted prose-form message instead.
+
+    "Path-shaped" applies the same heuristic the bullet-fallback path uses
+    (contains `/` OR ends in a `.<letter><word-char>+` extension) — so a
+    prose section like "Option B: choose `bullets`." doesn't trigger the
+    prose-form branch on the bare word `bullets`.
+    """
+    # If the section has any bullets at all, it is NOT prose-form. The
+    # bullet path is the canonical shape; an empty bullet list means the
+    # bullets are present but blank, which the existing "empty or malformed"
+    # message correctly describes.
+    if _BULLET_RE.search(section):
+        return False
+
+    for token in _BACKTICK_TOKEN_RE.findall(section):
+        token = token.strip()
+        if not token:
+            continue
+        if "/" in token or re.search(r"\.[A-Za-z]\w+$", token):
+            return True
+    return False
+
+
 def parse_files_to_touch(body: str) -> list[str] | None:
     """
     Extract the list of allowed paths/globs from an issue body's
@@ -153,20 +214,9 @@ def parse_files_to_touch(body: str) -> list[str] | None:
         - None if no `## Files to touch` / `### Files to touch` heading is
           found (caller falls back to area-label mapping).
     """
-    if not body:
+    section = _extract_files_to_touch_section(body)
+    if section is None:
         return None
-
-    heading_match = _FILES_TO_TOUCH_HEADING_RE.search(body)
-    if not heading_match:
-        return None
-
-    section_start = heading_match.end()
-
-    # Find the next heading of any level after our heading — that bounds the
-    # section. If none, the section runs to end-of-body.
-    next_match = _NEXT_HEADING_RE.search(body, pos=section_start)
-    section_end = next_match.start() if next_match else len(body)
-    section = body[section_start:section_end]
 
     paths: list[str] = []
     for bullet in _BULLET_RE.findall(section):
@@ -442,6 +492,25 @@ def evaluate(
             # with no entries can't gate a diff; falling back to WARN would
             # let any diff pass scope-check trivially by leaving the section
             # blank.
+            #
+            # Issue #130: distinguish the prose-form shape mismatch from a
+            # truly empty section. When the section contains backtick-quoted
+            # path-shaped tokens but no bullets, the author wrote prose
+            # instead of bullets — emit a targeted message naming the shape
+            # and showing the fix, rather than the generic "empty or
+            # malformed" string that doesn't tell them what to do.
+            section = _extract_files_to_touch_section(issue_body or "") or ""
+            if _section_has_prose_form_paths(section):
+                return Verdict(
+                    level="FAIL",
+                    summary=(
+                        '"Files to touch" section is present but uses prose form; '
+                        "rewrite as a bullet list (each path on its own line "
+                        "prefixed with `-`). Bullet form is required so the parser "
+                        "can extract path entries unambiguously."
+                    ),
+                    source="files-to-touch",
+                )
             return Verdict(
                 level="FAIL",
                 summary=(

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -769,3 +769,132 @@ def test_fix2_kept_areas_still_resolve():
     for meta in ("dx", "security", "reliability", "observability"):
         assert meta in scope_check.META_AREAS, f"{meta!r} should still be a meta-area"
         assert scope_check.area_label_paths([meta, "priority:p2"]) is None
+
+
+# ── Issue #130: prose-form shape-mismatch detection ──────────────────────────
+#
+# When `## Files to touch` is present but the author wrote it as prose
+# paragraphs (no markdown bullets) containing backtick-quoted paths, the
+# parser returns []. Pre-#130 the gate emitted the generic "empty or
+# malformed" message — which doesn't tell the issue author what to fix.
+# After #130 the gate detects this specific shape and emits a targeted
+# message naming "prose form" and showing the bullet-form fix.
+
+
+def test_evaluate_emits_prose_form_message_when_section_uses_prose():
+    """The exact shape that bit PR #129 (issue #46): a `## Files to touch`
+    section written as prose paragraphs containing backtick-quoted paths,
+    no bullets. The gate must emit the prose-form-specific message instead
+    of the generic 'empty or malformed' string."""
+    body = """## Files to touch
+
+Option A: rename `scripts/check_agent_safe_scope.py` and update
+`tests/unit/test_check_agent_safe_scope.py` to match. Option B:
+update `CLAUDE.md` only.
+
+## Acceptance criteria
+"""
+    v = scope_check.evaluate(body, ["agent-safe"], ["scripts/check_agent_safe_scope.py"])
+    assert v.level == "FAIL"
+    assert v.source == "files-to-touch"
+    assert "prose form" in v.summary
+    # The fix instruction must name the bullet character so the issue
+    # author can act on the message without leaving the CI log.
+    assert "bullet list" in v.summary
+    assert "`-`" in v.summary
+    # The generic "empty or malformed" string must NOT appear — that is
+    # the message we are explicitly replacing for this shape.
+    assert "empty or malformed" not in v.summary
+
+
+def test_evaluate_keeps_generic_empty_message_when_section_truly_empty():
+    """When `## Files to touch` is present but the section body is whitespace-
+    only (no bullets, no backticks, no prose paths), the original generic
+    'empty or malformed' message is the right one — there's nothing to point
+    at as 'prose form'."""
+    body = "## Files to touch\n\n## Acceptance criteria\n"
+    v = scope_check.evaluate(body, ["agent-safe"], ["foo.py"])
+    assert v.level == "FAIL"
+    assert v.source == "files-to-touch"
+    assert "empty or malformed" in v.summary
+    assert "prose form" not in v.summary
+
+
+def test_evaluate_keeps_generic_message_when_section_has_bullets_but_no_paths():
+    """A bullet section that fails to yield any paths (e.g. bullets contain
+    only prose, no backticks and no path-shaped tokens) is the
+    'empty-after-parse' case, not the prose-form case. The detector requires
+    NO bullets to fire — bullets-but-no-paths keeps the generic message so
+    we don't mislead the author into thinking they used the wrong shape
+    when they actually used the right shape but no parseable content."""
+    body = """## Files to touch
+
+- This is just prose with no real paths
+- Another bullet without any path-shaped tokens
+
+## Acceptance criteria
+"""
+    v = scope_check.evaluate(body, ["agent-safe"], ["foo.py"])
+    assert v.level == "FAIL"
+    assert v.source == "files-to-touch"
+    assert "empty or malformed" in v.summary
+    assert "prose form" not in v.summary
+
+
+def test_section_has_prose_form_paths_returns_true_for_prose_with_backtick_paths():
+    section = "Touch `src/foo.py` and `tests/test_foo.py` to make this work.\n"
+    assert scope_check._section_has_prose_form_paths(section) is True
+
+
+def test_section_has_prose_form_paths_returns_false_when_bullets_present():
+    """Even if bullets contain no paths, the presence of bullets means the
+    author used the canonical shape — not the prose-form failure mode."""
+    section = "\n- some bullet without paths\n"
+    assert scope_check._section_has_prose_form_paths(section) is False
+
+
+def test_section_has_prose_form_paths_returns_false_for_prose_without_paths():
+    """Backtick-quoted tokens that aren't path-shaped (no `/`, no extension)
+    don't count — e.g. `bullets`, `prose`, `option A`. Without this filter
+    the detector would fire on any section that mentions a backtick-quoted
+    word."""
+    section = "Choose `bullets` over `prose` for clarity.\n"
+    assert scope_check._section_has_prose_form_paths(section) is False
+
+
+def test_section_has_prose_form_paths_returns_false_for_empty_section():
+    assert scope_check._section_has_prose_form_paths("") is False
+    assert scope_check._section_has_prose_form_paths("   \n\n  ") is False
+
+
+def test_section_has_prose_form_paths_recognises_extension_only_paths():
+    """Top-level files like `tasks.py` (extension, no slash) count as
+    path-shaped — same heuristic as the bullet-fallback parser."""
+    section = "Edit `tasks.py` to add a new invoke task.\n"
+    assert scope_check._section_has_prose_form_paths(section) is True
+
+
+def test_extract_files_to_touch_section_returns_section_text():
+    body = """## Context
+
+intro
+
+## Files to touch
+
+- `foo.py`
+
+## Acceptance criteria
+"""
+    section = scope_check._extract_files_to_touch_section(body)
+    assert section is not None
+    assert "- `foo.py`" in section
+    # Must NOT bleed into the next section.
+    assert "Acceptance criteria" not in section
+    # Must NOT include the heading line itself.
+    assert "Files to touch" not in section
+
+
+def test_extract_files_to_touch_section_returns_none_when_heading_absent():
+    assert scope_check._extract_files_to_touch_section("## Context\n\nstuff\n") is None
+    assert scope_check._extract_files_to_touch_section("") is None
+    assert scope_check._extract_files_to_touch_section(None) is None  # type: ignore[arg-type]

--- a/tests/unit/test_check_agent_safe_scope.py
+++ b/tests/unit/test_check_agent_safe_scope.py
@@ -16,6 +16,7 @@ Covers all six matrix cases (a)–(f) from issue #77 refinements
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
@@ -890,8 +891,15 @@ intro
     assert "- `foo.py`" in section
     # Must NOT bleed into the next section.
     assert "Acceptance criteria" not in section
-    # Must NOT include the heading line itself.
-    assert "Files to touch" not in section
+    # Must NOT include the heading line itself. Test by line — a section
+    # body could legitimately mention the words "Files to touch" inside its
+    # content (e.g. an issue note), so substring-checking the whole section
+    # would be brittle. Instead, assert no non-empty line in the returned
+    # text is the heading itself.
+    for line in section.splitlines():
+        assert not re.match(r"^#{2,3}\s+Files to touch\s*$", line, re.IGNORECASE), (
+            f"heading line leaked into extracted section: {line!r}"
+        )
 
 
 def test_extract_files_to_touch_section_returns_none_when_heading_absent():


### PR DESCRIPTION
Closes #130

## Summary

When an issue's `## Files to touch` section is written as prose paragraphs containing backtick-quoted paths (e.g. "Touch `src/foo.py` and `tests/test_foo.py`") instead of markdown bullets, the parser returns an empty list and the gate falls through to the generic `"Files to touch" section present but empty or malformed` message. That message doesn't tell the issue author *what's wrong* or *how to fix it* — the actual cost paid by PR #129 (issue #46), where the diagnosis required reading the parser source.

This PR implements **Option B** from the issue (recommended): keep the parser strict, but split the failure mode so the prose-form shape mismatch surfaces a targeted message that names "prose form" and shows the bullet-form fix:

> "Files to touch" section is present but uses prose form; rewrite as a bullet list (each path on its own line prefixed with `-`). Bullet form is required so the parser can extract path entries unambiguously.

## Approach

- New `_section_has_prose_form_paths(section)` helper detects the shape: section has **no** markdown bullets BUT contains backtick-quoted **path-shaped** tokens (same `/` or `.<letter><word-char>+` heuristic the bullet-fallback parser uses, so a prose mention of `` `bullets` `` or `` `option A` `` doesn't trigger).
- Refactored the section-bounding logic into `_extract_files_to_touch_section(body)` so both `parse_files_to_touch` and the new detector operate on the same bounded slice — neither should ever scan the whole issue body, which would risk pulling in unrelated backticks from `## Context` or `## Notes`.
- `evaluate()` now consults the prose-form detector when `parse_files_to_touch` returns an empty list. Existing strict bullet-form parsing is unchanged; the truly-empty whitespace-only section keeps its original generic message; bullets-but-no-paths also keeps the generic message (the bullet shape was correct, content was the problem).

## Tests

Added 9 tests covering the new behaviour:

- Prose-form section emits the targeted message (positive case mirroring the PR #129 / issue #46 shape)
- Truly empty section keeps the generic "empty or malformed" message
- Bullets-without-paths keeps the generic message (don't mislead the author about which axis was wrong)
- Helper unit tests: prose-with-paths True, bullets-present False, prose-without-paths False, empty-section False, extension-only paths True
- Section-extraction helper: returns bounded text, returns None for missing/empty/None body

All 66 tests in `test_check_agent_safe_scope.py` pass.

## Manual verification

```
$ uv run python scripts/check_agent_safe_scope.py \
    --issue-body-file /tmp/prose_form_issue.md \
    --issue-labels "agent-safe,priority:p3,size:s,dx" \
    --diff-files-file /tmp/prose_form_files.txt
agent-safe scope check (offline mode)
  source : files-to-touch
  verdict: FAIL
  summary: "Files to touch" section is present but uses prose form;
           rewrite as a bullet list (each path on its own line prefixed with `-`).
           Bullet form is required so the parser can extract path entries unambiguously.
```

## Test plan

- [x] `uv run inv pre-push` — green locally
- [x] Local Copilot review — clean (no actionable findings)
- [ ] CI green
- [ ] Agent-safe scope check (in-scope: `scripts/check_agent_safe_scope.py` + co-located test, both listed in #130's `## Files to touch`)
- [ ] Copilot review on PR