### PR TITLE
fix(ci): make protection-drift workflow parse and skip when no PAT

### DIFF
--- a/.github/workflows/protection-drift.yml
+++ b/.github/workflows/protection-drift.yml
@@ -18,8 +18,8 @@
 #   for an opt-in `BRANCH_PROTECTION_TOKEN` secret (a fine-grained PAT
 #   with `Administration: Read`) and skips gracefully when it isn't
 #   present. Forks that want the drift check to actually run should add
-#   that secret per the README (TODO: add the README pointer once the
-#   secret is documented).
+#   that secret per the instructions in `CONTRIBUTING.md`
+#   (§"Branch protection snapshot").
 #
 # Why a workflow-level skip rather than failing loudly:
 #   The whole point of #52 is to keep template hygiene high without

--- a/.github/workflows/protection-drift.yml
+++ b/.github/workflows/protection-drift.yml
@@ -10,9 +10,24 @@
 #   - Push to development — catches snapshot edits as soon as they land
 #   - workflow_dispatch — manual re-check when investigating drift reports
 #
-# Permissions: reading branch protection requires `administration: read`,
-# which is NOT in the default GITHUB_TOKEN scope set. Granting it here
-# (read-only) is sufficient — the script only reads, never writes.
+# Token scope (important):
+#   The default `GITHUB_TOKEN` does not have permission to read branch
+#   protection settings — the `permissions:` block has no `administration:`
+#   key, and `GET /repos/{owner}/{repo}/branches/{branch}/protection`
+#   requires the `administration: read` token scope. The workflow checks
+#   for an opt-in `BRANCH_PROTECTION_TOKEN` secret (a fine-grained PAT
+#   with `Administration: Read`) and skips gracefully when it isn't
+#   present. Forks that want the drift check to actually run should add
+#   that secret per the README (TODO: add the README pointer once the
+#   secret is documented).
+#
+# Why a workflow-level skip rather than failing loudly:
+#   The whole point of #52 is to keep template hygiene high without
+#   demanding new secrets at fork-time. A loud failure on every push to
+#   `development` would create exactly the kind of false-negative noise
+#   the check was supposed to prevent. A skip-with-notice keeps the
+#   contract honest: when the secret is provided, the check is
+#   authoritative; when it isn't, the workflow says so and exits 0.
 name: Branch Protection Drift Check
 
 on:
@@ -29,11 +44,6 @@ on:
 
 permissions:
   contents: read
-  # `administration: read` is required to call
-  # `GET /repos/{owner}/{repo}/branches/{branch}/protection`. The default
-  # GITHUB_TOKEN scope set does not include this; declaring it here is
-  # the minimum elevation required.
-  administration: read
 
 jobs:
   drift:
@@ -42,13 +52,29 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
 
+      - name: Skip if no PAT secret is configured
+        id: gate
+        env:
+          BRANCH_PROTECTION_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
+        run: |
+          if [ -z "${BRANCH_PROTECTION_TOKEN:-}" ]; then
+            echo "::notice title=Drift check skipped::BRANCH_PROTECTION_TOKEN secret is not set; cannot read branch-protection settings. Add a fine-grained PAT with 'Administration: Read' to enable this check."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        if: steps.gate.outputs.skip == 'false'
         with:
           version: "latest"
 
       - name: Run drift check
+        if: steps.gate.outputs.skip == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use the opt-in PAT for the branch-protection API; the default
+          # GITHUB_TOKEN lacks the `administration: read` scope.
+          GH_TOKEN: ${{ secrets.BRANCH_PROTECTION_TOKEN }}
         run: |
           set -euo pipefail
           # Use uv run so the script picks up the project's Python version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,8 @@ uv sync --all-extras       # sync all deps from lockfile
 
 `infra/branch-protection.expected.json` is the canonical record of the template repo's branch protection (`main`, `development`) and merge settings. The `Branch Protection Drift Check` workflow (`.github/workflows/protection-drift.yml`) runs weekly and on every push to `development` that touches the snapshot, comparing the file to the live GitHub state and failing on any drift. If you intentionally change protection or merge settings, refresh the snapshot in the same PR by re-fetching the relevant API responses (`gh api /repos/{owner}/{repo}` for repo settings, `gh api /repos/{owner}/{repo}/branches/{branch}/protection` for each protected branch) and merging the new fields back into the file.
 
+The drift workflow needs a `BRANCH_PROTECTION_TOKEN` repo secret (a fine-grained PAT with `Administration: Read` on this repo) to read branch protection. Without it, the workflow emits a notice and exits 0 — the default `GITHUB_TOKEN` does not have a workflow-level `administration: read` scope. Forks that want the drift check to actually run should add this secret in **Settings → Secrets and variables → Actions**.
+
 ## What makes a good PR
 
 - Focused — one thing per PR


### PR DESCRIPTION
Follow-up to #135 (which closed #52). The merged workflow declared an
`administration: read` permission, which is not a valid key in the
GitHub Actions `permissions:` block. The workflow file therefore
failed to parse on every push to `development`, surfacing as a
generic "workflow file issue" run failure (run 25216658896).

## Summary

- Drop the invalid `administration: read` permission key.
- The default `GITHUB_TOKEN` cannot be granted `administration: read`
  via the workflow `permissions:` block — those keys are a closed set
  and `administration` isn't among them. Reading branch protection
  requires a PAT with the right scope.
- Add an opt-in `BRANCH_PROTECTION_TOKEN` secret. When the secret is
  absent, the workflow emits a `::notice::` and exits 0 — keeping fork
  hygiene high without demanding new secrets at fork-time. When the
  secret is present, the workflow runs the drift check authoritatively.
- Document the secret in `CONTRIBUTING.md` so fork operators know how
  to opt in.

The drift script and its 44 unit tests are unchanged.

## Approach

The alternative was to keep the workflow failing loudly on every push
until the operator added the secret, but that creates exactly the
false-negative noise #52 was designed to prevent. Skip-with-notice
keeps the contract honest: when the secret is provided, the check is
authoritative; when it isn't, the workflow says so and exits 0.

Closes the workflow-level fallout from #52.