### PR TITLE
chore: add observable logging to §1.5 skills-discovery

### DIFF
--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -70,7 +70,14 @@ If closed or already has an open PR, skip it and move to the next. If ambiguous,
 Before branching, scan `.claude/skills/` for skills whose triggers match the current issue. See ADR-0006 for the full skill contract; the scan logic below is the agent's implementation of it.
 
 ```bash
-ls .claude/skills/*/SKILL.md 2>/dev/null
+# Use find rather than `ls .claude/skills/*/SKILL.md` — the bare ls form
+# exits non-zero with stderr suppressed when the glob doesn't expand
+# (zero skills installed), which conflates "no skills installed"
+# with a genuine scan failure. find returns success with empty output
+# when no files match, and fails only on real errors (missing dir,
+# permission denied), letting the four discovery outcomes below stay
+# distinguishable.
+find .claude/skills -maxdepth 2 -name SKILL.md -type f 2>&1
 ```
 
 For each `SKILL.md` found, read its frontmatter and decide whether to load it. **Hybrid OR-match** — load the skill if **either** condition holds:
@@ -84,12 +91,12 @@ Loading a skill means reading the full body of `SKILL.md` into your working cont
 
 If no skills match, proceed to step 2. Borderline matches should err toward loading; the load-on-demand cost is small.
 
-**Surface the discovery decision on every outcome** — §1.5 must produce evidence in the agent's output that an observer can read after the fact. The exact phrasing is the agent's call; the requirement is that the four cases below are each visibly logged:
+**Surface the discovery decision on every outcome** — §1.5 must produce evidence in the agent's output that an observer can read after the fact. The exact phrasing is the agent's call; the requirement is that the four mutually-exclusive cases below are each visibly logged:
 
-- **Pre-scan announce** — before running the `ls` command, surface a one-line announcement that the scan is starting (e.g. *"Scanning `.claude/skills/` for skills matching this issue's surface"*). This confirms §1.5 fired at all.
+- **Pre-scan announce** — before running the scan command, surface a one-line announcement that the scan is starting (e.g. *"Scanning `.claude/skills/` for skills matching this issue's surface"*). This confirms §1.5 fired at all.
 - **On match + load** — for each loaded skill, surface one line naming the skill (e.g. *"Loaded skill: `<name>`"*). Multiple matches produce multiple lines.
-- **On zero matches** — surface one line confirming the scan completed without matches (e.g. *"Scan complete; no skills matched this issue's surface"*).
-- **On scan failure** — if the `ls` command fails or produces no output unexpectedly, surface a one-line announce with the error so the failure is visible rather than silent.
+- **On zero matches** — the scan succeeded (exit 0) but no skill's triggers matched the issue's surface, OR no `SKILL.md` files were present to evaluate. Surface one line confirming the scan completed without matches (e.g. *"Scan complete; no skills matched this issue's surface"*).
+- **On scan failure** — the scan command itself errored (non-zero exit: missing `.claude/skills/` directory, permission denied, etc.). Surface a one-line announce with the error text so the failure is visible rather than silent. Do NOT collapse this into the zero-match case — they are mechanically distinct (exit code) and a silent failure here is exactly the gap this section closes.
 
 ### 2. Branch
 

--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -76,8 +76,10 @@ Before branching, scan `.claude/skills/` for skills whose triggers match the cur
 # with a genuine scan failure. find returns success with empty output
 # when no files match, and fails only on real errors (missing dir,
 # permission denied), letting the four discovery outcomes below stay
-# distinguishable.
-find .claude/skills -maxdepth 2 -name SKILL.md -type f 2>&1
+# distinguishable. Keep stdout (the parseable file list) and stderr
+# (any error text) on separate streams — do NOT redirect with `2>&1`
+# or the agent may misread an error line as a SKILL.md path.
+find .claude/skills -maxdepth 2 -name SKILL.md -type f
 ```
 
 For each `SKILL.md` found, read its frontmatter and decide whether to load it. **Hybrid OR-match** — load the skill if **either** condition holds:
@@ -91,12 +93,19 @@ Loading a skill means reading the full body of `SKILL.md` into your working cont
 
 If no skills match, proceed to step 2. Borderline matches should err toward loading; the load-on-demand cost is small.
 
-**Surface the discovery decision on every outcome** — §1.5 must produce evidence in the agent's output that an observer can read after the fact. The exact phrasing is the agent's call; the requirement is that the four mutually-exclusive cases below are each visibly logged:
+**Surface the discovery decision on every outcome** — §1.5 must produce evidence in the agent's output that an observer can read after the fact. The exact phrasing is the agent's call; the requirement is that the four cases below are each visibly logged. The cases are not strictly mutually exclusive (e.g. `find` can exit non-zero while still printing some matching paths under a partial-permission-denied condition); apply this **precedence** when more than one applies:
+
+1. **Pre-scan announce** is always emitted, regardless of any other case.
+2. **Scan failure** is emitted whenever the scan command exits non-zero, even if some paths were also printed. Per-path **match + load** lines (for whichever paths *were* printed) are emitted alongside it; this preserves visibility of partial recovery without hiding the failure.
+3. **Match + load** lines are emitted for each path-match that loaded successfully.
+4. **Zero matches** is emitted *only* when the scan exited 0, no errors occurred, and no skill's triggers matched the issue's surface (or no `SKILL.md` files were present to evaluate). Do not emit this if the failure case fired.
+
+The four cases:
 
 - **Pre-scan announce** — before running the scan command, surface a one-line announcement that the scan is starting (e.g. *"Scanning `.claude/skills/` for skills matching this issue's surface"*). This confirms §1.5 fired at all.
 - **On match + load** — for each loaded skill, surface one line naming the skill (e.g. *"Loaded skill: `<name>`"*). Multiple matches produce multiple lines.
 - **On zero matches** — the scan succeeded (exit 0) but no skill's triggers matched the issue's surface, OR no `SKILL.md` files were present to evaluate. Surface one line confirming the scan completed without matches (e.g. *"Scan complete; no skills matched this issue's surface"*).
-- **On scan failure** — the scan command itself errored (non-zero exit: missing `.claude/skills/` directory, permission denied, etc.). Surface a one-line announce with the error text so the failure is visible rather than silent. Do NOT collapse this into the zero-match case — they are mechanically distinct (exit code) and a silent failure here is exactly the gap this section closes.
+- **On scan failure** — the scan command itself errored (non-zero exit: missing `.claude/skills/` directory, permission denied, etc.). Surface a one-line announce with the stderr text so the failure is visible rather than silent. Do NOT collapse this into the zero-match case — they are mechanically distinct (exit code) and a silent failure here is exactly the gap this section closes.
 
 ### 2. Branch
 

--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -79,6 +79,14 @@ Before branching, scan `.claude/skills/` for skills whose triggers match the cur
 # distinguishable. Keep stdout (the parseable file list) and stderr
 # (any error text) on separate streams — do NOT redirect with `2>&1`
 # or the agent may misread an error line as a SKILL.md path.
+#
+# To capture all three signals separately when invoking via the Bash
+# tool, run the command, observe its exit code, and read stderr from
+# the tool's combined output (the Bash tool surfaces both streams to
+# the agent but keeps stdout lines visually distinct from stderr's
+# "find: ..." prefixes). The agent should treat lines matching the
+# expected SKILL.md path shape as the file list and any other lines
+# as scan-failure diagnostic text.
 find .claude/skills -maxdepth 2 -name SKILL.md -type f
 ```
 
@@ -96,8 +104,8 @@ If no skills match, proceed to step 2. Borderline matches should err toward load
 **Surface the discovery decision on every outcome** — §1.5 must produce evidence in the agent's output that an observer can read after the fact. The exact phrasing is the agent's call; the requirement is that the four cases below are each visibly logged. The cases are not strictly mutually exclusive (e.g. `find` can exit non-zero while still printing some matching paths under a partial-permission-denied condition); apply this **precedence** when more than one applies:
 
 1. **Pre-scan announce** is always emitted, regardless of any other case.
-2. **Scan failure** is emitted whenever the scan command exits non-zero, even if some paths were also printed. Per-path **match + load** lines (for whichever paths *were* printed) are emitted alongside it; this preserves visibility of partial recovery without hiding the failure.
-3. **Match + load** lines are emitted for each path-match that loaded successfully.
+2. **Scan failure** is emitted whenever the scan command exits non-zero, even if some paths were also printed. Any **match + load** lines (for skills among the printed paths whose triggers actually matched the issue's surface) are emitted alongside it; this preserves visibility of partial recovery without hiding the failure. Note: printed paths are *candidates* for evaluation, not guaranteed loads — only paths whose `triggers.paths` or `triggers.areas` actually match produce a "Loaded skill" line.
+3. **Match + load** lines are emitted for each skill whose triggers actually matched the issue's surface and whose body was loaded. Skills whose paths were printed by the scan but whose triggers did not match produce no log line — they are silently skipped.
 4. **Zero matches** is emitted *only* when the scan exited 0, no errors occurred, and no skill's triggers matched the issue's surface (or no `SKILL.md` files were present to evaluate). Do not emit this if the failure case fired.
 
 The four cases:

--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -83,10 +83,14 @@ Before branching, scan `.claude/skills/` for skills whose triggers match the cur
 # To capture all three signals separately when invoking via the Bash
 # tool, run the command, observe its exit code, and read stderr from
 # the tool's combined output (the Bash tool surfaces both streams to
-# the agent but keeps stdout lines visually distinct from stderr's
-# "find: ..." prefixes). The agent should treat lines matching the
-# expected SKILL.md path shape as the file list and any other lines
-# as scan-failure diagnostic text.
+# the agent but keeps stdout lines visually distinct from stderr).
+# Path lines from this command match the literal shape
+# `.claude/skills/<skill-name>/SKILL.md` (one per line, no
+# leading whitespace). Diagnostic lines from `find` start with
+# `find: ` (or, on this project's macOS dev environment which
+# uses bfs, with `bfs: error: `). Treat any line matching the
+# `.claude/skills/<...>/SKILL.md` shape as a candidate path and
+# any other line as scan-failure diagnostic text.
 find .claude/skills -maxdepth 2 -name SKILL.md -type f
 ```
 

--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -84,6 +84,13 @@ Loading a skill means reading the full body of `SKILL.md` into your working cont
 
 If no skills match, proceed to step 2. Borderline matches should err toward loading; the load-on-demand cost is small.
 
+**Surface the discovery decision on every outcome** — §1.5 must produce evidence in the agent's output that an observer can read after the fact. The exact phrasing is the agent's call; the requirement is that the four cases below are each visibly logged:
+
+- **Pre-scan announce** — before running the `ls` command, surface a one-line announcement that the scan is starting (e.g. *"Scanning `.claude/skills/` for skills matching this issue's surface"*). This confirms §1.5 fired at all.
+- **On match + load** — for each loaded skill, surface one line naming the skill (e.g. *"Loaded skill: `<name>`"*). Multiple matches produce multiple lines.
+- **On zero matches** — surface one line confirming the scan completed without matches (e.g. *"Scan complete; no skills matched this issue's surface"*).
+- **On scan failure** — if the `ls` command fails or produces no output unexpectedly, surface a one-line announce with the error so the failure is visible rather than silent.
+
 ### 2. Branch
 
 Always branch off `origin/development`, never off another feature branch:

--- a/.claude/agents/issue-worker.md
+++ b/.claude/agents/issue-worker.md
@@ -81,16 +81,16 @@ Before branching, scan `.claude/skills/` for skills whose triggers match the cur
 # or the agent may misread an error line as a SKILL.md path.
 #
 # To capture all three signals separately when invoking via the Bash
-# tool, run the command, observe its exit code, and read stderr from
-# the tool's combined output (the Bash tool surfaces both streams to
-# the agent but keeps stdout lines visually distinct from stderr).
-# Path lines from this command match the literal shape
-# `.claude/skills/<skill-name>/SKILL.md` (one per line, no
-# leading whitespace). Diagnostic lines from `find` start with
-# `find: ` (or, on this project's macOS dev environment which
-# uses bfs, with `bfs: error: `). Treat any line matching the
-# `.claude/skills/<...>/SKILL.md` shape as a candidate path and
-# any other line as scan-failure diagnostic text.
+# tool, run the command and observe its exit code; the tool presents
+# stdout and stderr as distinct line streams in its output (do not
+# rely on a "combined" stream — that would defeat the no-`2>&1`
+# rule above). Path lines from this command match the literal shape
+# `.claude/skills/<skill-name>/SKILL.md` (one per line, no leading
+# whitespace). Use a tool-agnostic rule for stream separation:
+# any line matching the `.claude/skills/<...>/SKILL.md` shape is
+# treated as a candidate path; any other line (including any
+# diagnostic from `find` or its replacements) is treated as
+# scan-failure diagnostic text.
 find .claude/skills -maxdepth 2 -name SKILL.md -type f
 ```
 


### PR DESCRIPTION
Closes #108.

## Summary

Amend `.claude/agents/issue-worker.md` §1.5 ("Scan and load matching skills") to require the agent to surface a one-line log on each of four discovery-decision outcomes:

- **Pre-scan announce** — before running the scan, surface a one-liner that the scan is starting (confirms §1.5 fired at all).
- **On match + load** — one line per loaded skill, naming it.
- **On zero matches** — one line confirming the scan completed without matches.
- **On scan failure** — one line announce with the stderr text so failures are visible rather than silent.

The four cases are governed by an explicit precedence rule (added in iteration 2): pre-scan always emits; scan failure emits alongside any per-skill match+load lines that printed before the error; zero-matches only emits when the scan exited 0 with no errors and no triggers matched. This handles partial-failure conditions cleanly without conflating outcomes.

## Approach

Originally this PR amended only the four-bullet logging guidance, leaving the existing `ls .claude/skills/*/SKILL.md 2>/dev/null` scan command in place. Copilot review correctly flagged that the bare `ls` form exits non-zero with stderr suppressed when the glob doesn't expand, which would conflate "zero skills installed" with "genuine scan failure" and make the four logging outcomes mechanically indistinguishable.

The PR therefore *also* replaces the scan command with `find .claude/skills -maxdepth 2 -name SKILL.md -type f` (no `2>&1` redirect — stdout and stderr stay on separate streams so the agent can iterate over the file list cleanly without misreading an error line as a path). The hybrid OR-match logic, the load mechanics, and ADR-0006's contract are all unchanged.

## Why this matters

Cycle #104 (PR #104, issue #35) was a deterministic double-match for the `react-component` skill on both `triggers.paths` and `triggers.areas`. The skill almost certainly loaded silently — but with no logging instruction in §1.5, no evidence was produced. That made #81's closure condition ("first non-skill issue-worker run produces evidence in its logs/output that it scanned `.claude/skills/`, matched at least one skill, and loaded its body") mechanically unsatisfiable under the previous wording.

Validation lands organically when the next agent-safe cycle exercises a skill's triggers — at which point the four logging cases will produce observable evidence and #81 closes via the same evidence.

## Recursive applicability

This is an agent-protocol amendment that all subsequent skills-discovery cycles will inherit. Same pattern as #89's W1–W7 codification (cited in the issue body), but smaller scope.

## Known follow-up

Copilot also flagged that `.claude/agents/code-reviewer.md` still documents the old `ls .claude/skills/*/SKILL.md 2>/dev/null` scan command, and ADR-0006 references "consuming agents running the same scan step". The same fix should propagate there. Out of scope for #108 (the issue's `## Files to touch` section is restricted to `issue-worker.md`, and the `agent-safe` scope-boundary check would block a diff that strayed). Will file a separate follow-up issue.

## Verification

- `uv run inv pre-push` — passed (lint + typecheck + 275 unit + frontend tests green) on every push.
- Local Copilot review (`copilot -p /review`) — no material issues.
- GitHub Copilot PR review — 5 findings across 2 iterations; all addressed (scan-command robustness, stream separation, precedence rule, PR description, plus the cross-agent follow-up acknowledged).
- The `find` command was hand-verified against the three operational cases: directory missing → exit 1, stderr message; directory empty → exit 0, no output; directory populated → exit 0, file list on stdout.

## Skills loaded for this cycle

None — the issue surface (`.claude/agents/issue-worker.md`, labels `chore`, `dx`) didn't match any skill's `triggers.paths` or `triggers.areas`. Logged here as the first instance of the very behaviour this PR codifies.