### PR TITLE
test(e2e): assert SSE inter-chunk arrival timing on /agents/echo/stream

### DIFF
--- a/tests/e2e/test_streaming_e2e.py
+++ b/tests/e2e/test_streaming_e2e.py
@@ -240,16 +240,23 @@ def _count_sse_deltas(body: bytes) -> int:
 def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> None:
     """Fail the test if the stream looks like it was buffered, not streamed.
 
-    Three orthogonal signals, each catching a different buffering
+    Four orthogonal signals, each catching a different buffering
     failure mode:
 
     * `delta_count >= 2` — sanity check; if the response had only one
-      delta there's no inter-chunk timing to assert against.
-    * `time-to-first-byte` — catches "buffer everything, flush at end"
-      where the response body arrives in one giant chunk after the
-      origin closes the connection.
-    * `max inter-chunk gap` — catches periodic flushes; even one
-      multi-second stall between flushes is enough to break the
+      delta there's no streaming behaviour to verify in the first
+      place. The remaining checks assume at least two deltas.
+    * `time-to-first-byte < 8s` — catches "buffer everything, flush
+      at end" where the entire response body arrives in one giant
+      chunk after the origin closes the connection.
+    * `len(arrivals) >= 2 when delta_count >= 2` — catches the
+      sub-8s coalesce: even a fast response that delivers two-plus
+      deltas in a single TCP flush is the buffering regression
+      this test exists to detect. Without this check, a buffered
+      response that fits inside the TTFB threshold would pass
+      silently.
+    * `max inter-chunk gap < 1.5s` — catches periodic flushes; even
+      one multi-second stall between flushes is enough to break the
       real-time UX.
     """
     assert observation.delta_count >= 2, (
@@ -271,17 +278,30 @@ def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> No
     )
 
     arrivals = observation.chunk_arrival_times
-    if len(arrivals) >= 2:
-        gaps = [arrivals[i] - arrivals[i - 1] for i in range(1, len(arrivals))]
-        max_gap = max(gaps)
-        assert max_gap < _MAX_INTERCHUNK_GAP_SECONDS, (
-            f"Max inter-chunk gap {max_gap:.2f}s exceeds "
-            f"{_MAX_INTERCHUNK_GAP_SECONDS}s threshold "
-            f"(gaps={[round(g, 3) for g in gaps]}). Likely cause: "
-            "CloudFront response compression buffering SSE chunks; "
-            "verify the /api/* behaviour has compress=False (issue "
-            "#34)."
-        )
+    # Coalesce check: if the origin emitted N>=2 deltas but the edge
+    # delivered them in a single network chunk, that *is* the
+    # buffering regression — even if the whole response arrived
+    # inside the TTFB threshold. Without this assertion, a fast
+    # buffered response would slip past TTFB and have no inter-chunk
+    # gap to fail on.
+    assert len(arrivals) >= 2, (
+        f"Origin emitted {observation.delta_count} SSE delta events "
+        f"but the edge delivered them in {len(arrivals)} network "
+        "chunk — multiple deltas were coalesced into a single TCP "
+        "flush. This is the streaming-buffering regression this "
+        "test exists to catch (issue #34: verify the /api/* "
+        "behaviour has compress=False)."
+    )
+    gaps = [arrivals[i] - arrivals[i - 1] for i in range(1, len(arrivals))]
+    max_gap = max(gaps)
+    assert max_gap < _MAX_INTERCHUNK_GAP_SECONDS, (
+        f"Max inter-chunk gap {max_gap:.2f}s exceeds "
+        f"{_MAX_INTERCHUNK_GAP_SECONDS}s threshold "
+        f"(gaps={[round(g, 3) for g in gaps]}). Likely cause: "
+        "CloudFront response compression buffering SSE chunks; "
+        "verify the /api/* behaviour has compress=False (issue "
+        "#34)."
+    )
 
 
 @_SKIP_IF_NOT_CLOUDFRONT

--- a/tests/e2e/test_streaming_e2e.py
+++ b/tests/e2e/test_streaming_e2e.py
@@ -88,6 +88,38 @@ _MAX_TIME_TO_FIRST_BYTE_SECONDS = 8.0
 _STREAM_TIMEOUT_SECONDS = 30.0
 
 
+def _is_cloudfront_url(url: str) -> bool:
+    """True if `url` looks like a deployed (non-local) HTTPS endpoint.
+
+    The streaming timing assertion is only meaningful against a real
+    CloudFront distribution. Under `inv e2e-local`, `STARTER_UI_URL`
+    is the Vite dev-server URL (e.g. `http://localhost:5174`); the
+    Vite proxy bypasses CloudFront entirely so the test would pass
+    or fail for the wrong reason. Local URLs are filtered out here.
+    """
+    if not url:
+        return False
+    return not (
+        url.startswith("http://localhost")
+        or url.startswith("http://127.0.0.1")
+        or url.startswith("https://localhost")
+    )
+
+
+# Use skipif rather than an in-test pytest.skip(): pytest evaluates
+# skipif before xfail, so a skipped test under skipif is reported as
+# SKIPPED — not the XFAIL that an in-test pytest.skip() would produce
+# under an xfail-marked function.
+_SKIP_IF_NOT_CLOUDFRONT = pytest.mark.skipif(
+    not _is_cloudfront_url(EDGE_URL),
+    reason=(
+        "STARTER_UI_URL is unset or points at a local dev server "
+        f"({EDGE_URL!r}); this test is only meaningful against a "
+        "deployed CloudFront distribution."
+    ),
+)
+
+
 @dataclass
 class _StreamObservation:
     """Network-level timing data for one SSE response.
@@ -252,6 +284,7 @@ def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> No
         )
 
 
+@_SKIP_IF_NOT_CLOUDFRONT
 @pytest.mark.xfail(
     reason=(
         "Issue #34 (CloudFront compress=False on /api/*) has not shipped — "
@@ -262,9 +295,6 @@ def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> No
 )
 async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
     """Echo-stream SSE chunks arrive in real time at the CloudFront edge."""
-    if not EDGE_URL:
-        pytest.skip("STARTER_UI_URL not set (CloudFront edge URL is required for this test)")
-
     # A short multi-token prompt so the model emits multiple deltas
     # without racking up wall-time. Echo wraps `converse_stream`, so
     # this still hits Bedrock and incurs token charges — see the
@@ -277,6 +307,7 @@ async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
     _assert_streaming_timing_is_real_time(observation)
 
 
+@_SKIP_IF_NOT_CLOUDFRONT
 @pytest.mark.xfail(
     reason=(
         "Issue #34 (CloudFront compress=False on /api/*) has not shipped — "
@@ -294,8 +325,6 @@ async def test_invoke_stream_inter_chunk_timing(live_admin_token: str) -> None:
     demand to catch buffering regressions specific to the inline-
     agent streaming surface.
     """
-    if not EDGE_URL:
-        pytest.skip("STARTER_UI_URL not set (CloudFront edge URL is required for this test)")
     if os.environ.get("STARTER_E2E_RUN_INVOKE_STREAM") != "1":
         pytest.skip(
             "Set STARTER_E2E_RUN_INVOKE_STREAM=1 to exercise the inline-agent "

--- a/tests/e2e/test_streaming_e2e.py
+++ b/tests/e2e/test_streaming_e2e.py
@@ -11,9 +11,15 @@ clock timestamp of each SSE chunk and asserting an inter-arrival
 upper bound, this test fails fast if a CloudFront config change
 silently re-introduces buffering.
 
-Test target: the deployed CloudFront URL (`STARTER_API_URL`), not
-the Lambda Function URL directly. The whole point is to exercise the
-edge path that real browsers traverse.
+Test target: the deployed CloudFront URL (`STARTER_UI_URL`), not
+the Lambda Function URL (`STARTER_API_URL` resolves to
+`ApiFunctionUrl` in `tasks.e2e()`, which bypasses CloudFront
+entirely). CloudFront serves the React SPA at the apex and proxies
+`/api/*` to the same Lambda — so `${STARTER_UI_URL}/api/agents/...`
+is the actual edge path real browsers traverse, and is the only
+path that exercises CloudFront's compression decision. Hitting the
+Lambda Function URL directly would skip CloudFront and silently
+mask the very buffering regression this test is meant to catch.
 
 Currently `xfail` (`strict=False`) until issue #34 lands
 (`compress=False` on the `/api/*` / `/auth/*` / `/oauth/*` CloudFront
@@ -40,7 +46,14 @@ from collections.abc import AsyncIterator
 import httpx
 import pytest
 
-API_URL = os.environ.get("STARTER_API_URL", "")
+# STARTER_UI_URL is the CloudFront URL (UiUrl CloudFormation output);
+# CloudFront proxies /api/* to the same Lambda the Function URL serves.
+# We deliberately do NOT use STARTER_API_URL — that's the Lambda
+# Function URL, which bypasses CloudFront entirely and would defeat
+# the purpose of this test. The live_admin_token fixture issues the
+# JWT via STARTER_API_URL on its own; the JWT is host-agnostic and
+# is accepted at the CloudFront edge as well.
+EDGE_URL = os.environ.get("STARTER_UI_URL", "")
 
 # Maximum allowed wall-clock gap between consecutive SSE chunks. Generous
 # enough to absorb network jitter and TLS/handshake variability, tight
@@ -116,8 +129,8 @@ async def _iter_sse_data_lines(lines: AsyncIterator[str]) -> AsyncIterator[str]:
 )
 async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
     """Consecutive echo-stream SSE chunks must arrive within 1.5s of each other."""
-    if not API_URL:
-        pytest.skip("STARTER_API_URL not set")
+    if not EDGE_URL:
+        pytest.skip("STARTER_UI_URL not set (CloudFront edge URL is required for this test)")
 
     # A short multi-token prompt so the model emits multiple deltas without
     # racking up cost or wall time. Echo stream is a thin wrapper over
@@ -125,7 +138,7 @@ async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
     body = {"message": "Count to five, one number per line.", "system": None}
 
     timestamps = await _record_chunk_arrival_times(
-        API_URL, live_admin_token, "/api/agents/echo/stream", body
+        EDGE_URL, live_admin_token, "/api/agents/echo/stream", body
     )
 
     assert len(timestamps) >= 2, (
@@ -158,8 +171,8 @@ async def test_invoke_stream_inter_chunk_timing(live_admin_token: str) -> None:
     real model cost. Gated on ``STARTER_E2E_RUN_INVOKE_STREAM=1`` so
     routine CI runs only exercise the cheap echo-stream variant.
     """
-    if not API_URL:
-        pytest.skip("STARTER_API_URL not set")
+    if not EDGE_URL:
+        pytest.skip("STARTER_UI_URL not set (CloudFront edge URL is required for this test)")
     if os.environ.get("STARTER_E2E_RUN_INVOKE_STREAM") != "1":
         pytest.skip(
             "Set STARTER_E2E_RUN_INVOKE_STREAM=1 to exercise the inline-agent "
@@ -169,7 +182,7 @@ async def test_invoke_stream_inter_chunk_timing(live_admin_token: str) -> None:
     body = {"message": "Count to five, one number per line.", "session_id": None}
 
     timestamps = await _record_chunk_arrival_times(
-        API_URL, live_admin_token, "/api/agents/invoke/stream", body
+        EDGE_URL, live_admin_token, "/api/agents/invoke/stream", body
     )
 
     assert len(timestamps) >= 2, (

--- a/tests/e2e/test_streaming_e2e.py
+++ b/tests/e2e/test_streaming_e2e.py
@@ -240,12 +240,14 @@ def _count_sse_deltas(body: bytes) -> int:
 def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> None:
     """Fail the test if the stream looks like it was buffered, not streamed.
 
-    Four orthogonal signals, each catching a different buffering
-    failure mode:
+    Three orthogonal signals plus a signal-availability gate, each
+    catching a different buffering failure mode:
 
-    * `delta_count >= 2` — sanity check; if the response had only one
-      delta there's no streaming behaviour to verify in the first
-      place. The remaining checks assume at least two deltas.
+    * (gate) `delta_count >= 2` — if the response had only one
+      delta we don't have signal to assert against. Skip rather
+      than fail; Bedrock makes no guarantee about how a short
+      reply is split, so a single-delta response is a known
+      possibility on healthy streams.
     * `time-to-first-byte < 8s` — catches "buffer everything, flush
       at end" where the entire response body arrives in one giant
       chunk after the origin closes the connection.
@@ -259,11 +261,19 @@ def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> No
       one multi-second stall between flushes is enough to break the
       real-time UX.
     """
-    assert observation.delta_count >= 2, (
-        f"Expected at least 2 SSE delta events to give the timing "
-        f"assertion signal, got {observation.delta_count}. If the "
-        "model produced a single-delta reply, broaden the prompt."
-    )
+    # Skip rather than fail if the response had too few deltas to give
+    # the assertion signal: `converse_stream` / `invoke_stream` yield
+    # one SSE event per upstream Bedrock chunk, and Bedrock makes no
+    # guarantee about how a short reply is split. A single-delta
+    # response is rare for the multi-token prompt below but possible,
+    # and isn't itself evidence of a buffering regression — it just
+    # means we don't have enough signal here.
+    if observation.delta_count < 2:
+        pytest.skip(
+            f"Got only {observation.delta_count} SSE delta event(s) — "
+            "not enough signal to assert inter-chunk timing. Broaden "
+            "the prompt if this happens consistently."
+        )
     assert observation.chunk_arrival_times, (
         "No transport-level chunks were observed — the response may have been empty."
     )
@@ -315,11 +325,19 @@ def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> No
 )
 async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
     """Echo-stream SSE chunks arrive in real time at the CloudFront edge."""
-    # A short multi-token prompt so the model emits multiple deltas
-    # without racking up wall-time. Echo wraps `converse_stream`, so
-    # this still hits Bedrock and incurs token charges — see the
-    # cost note in the module docstring.
-    body = {"message": "Count to five, one number per line.", "system": None}
+    # Multi-token prompt that virtually guarantees the model emits
+    # several Bedrock chunks (one SSE delta per chunk). A short reply
+    # can collapse into a single delta even on a healthy stream;
+    # asking for a paragraph keeps the assertion signal-rich without
+    # blowing up the wall-time. Echo wraps `converse_stream`, so this
+    # still hits Bedrock and incurs token charges — see the cost note
+    # in the module docstring.
+    body = {
+        "message": (
+            "Write a short paragraph (4-5 sentences) about ocean tides. Be descriptive but concise."
+        ),
+        "system": None,
+    }
 
     observation = await _observe_sse_stream(
         EDGE_URL, live_admin_token, "/api/agents/echo/stream", body
@@ -351,7 +369,12 @@ async def test_invoke_stream_inter_chunk_timing(live_admin_token: str) -> None:
             "streaming endpoint (incurs higher Bedrock cost than echo)."
         )
 
-    body = {"message": "Count to five, one number per line.", "session_id": None}
+    body = {
+        "message": (
+            "Write a short paragraph (4-5 sentences) about ocean tides. Be descriptive but concise."
+        ),
+        "session_id": None,
+    }
 
     observation = await _observe_sse_stream(
         EDGE_URL, live_admin_token, "/api/agents/invoke/stream", body

--- a/tests/e2e/test_streaming_e2e.py
+++ b/tests/e2e/test_streaming_e2e.py
@@ -6,10 +6,10 @@ This test guards against silent buffering regressions on the deployed
 edge — most notably CloudFront response compression on `/api/*`. With
 compression enabled on a streaming behaviour, gzip can coalesce many
 deltas into a single multi-second flush, breaking the real-time UX
-that streaming endpoints are designed for. By recording the wall-
-clock timestamp of each SSE chunk and asserting an inter-arrival
-upper bound, this test fails fast if a CloudFront config change
-silently re-introduces buffering.
+that streaming endpoints are designed for. By recording the monotonic
+arrival time of each transport-level chunk and asserting an
+inter-arrival upper bound, this test fails fast if a CloudFront
+config change silently re-introduces buffering.
 
 Test target: the deployed CloudFront URL (`STARTER_UI_URL`), not
 the Lambda Function URL (`STARTER_API_URL` resolves to
@@ -21,6 +21,16 @@ path that exercises CloudFront's compression decision. Hitting the
 Lambda Function URL directly would skip CloudFront and silently
 mask the very buffering regression this test is meant to catch.
 
+Why transport-level timing: `aiter_lines()` yields lines from an
+in-memory text buffer, so a single TCP flush carrying ten SSE events
+back-to-back would yield those ten events with near-zero gaps
+between them — the multi-second buffering delay would show up only
+as a single large pre-amble, easy to miss with a naive max-gap
+assertion. We instead use `aiter_raw()` to record arrivals at the
+network-flush level and additionally assert time-to-first-byte, so
+both end-of-response coalescing and start-of-response stalls are
+caught.
+
 Currently `xfail` (`strict=False`) until issue #34 lands
 (`compress=False` on the `/api/*` / `/auth/*` / `/oauth/*` CloudFront
 behaviours). With compression still enabled on the dev environment,
@@ -31,9 +41,14 @@ through the transition; if the timing somehow already passes (e.g.
 infra fix lands ahead of this test), the run is reported as XPASS,
 not a hard failure — the next contributor flips the marker.
 
-Echo stream is the primary fixture (no Bedrock cost). The
-invoke-stream variant is a separate smoke test gated on
-`STARTER_E2E_RUN_INVOKE_STREAM=1` to avoid charging on every CI run.
+Cost note: both `/agents/echo/stream` and `/agents/invoke/stream`
+call Bedrock on every request. Echo wraps `converse_stream` directly,
+which is cheaper per-call than the inline-agent overhead in
+`invoke_stream` but still incurs token charges. The echo test runs
+unconditionally because deployed e2e is only triggered on dev/main
+deploys (not on every PR). The invoke-stream variant is additionally
+gated behind `STARTER_E2E_RUN_INVOKE_STREAM=1` because inline-agent
+spend per call is meaningfully higher.
 """
 
 from __future__ import annotations
@@ -41,7 +56,7 @@ from __future__ import annotations
 import json
 import os
 import time
-from collections.abc import AsyncIterator
+from dataclasses import dataclass
 
 import httpx
 import pytest
@@ -55,68 +70,186 @@ import pytest
 # is accepted at the CloudFront edge as well.
 EDGE_URL = os.environ.get("STARTER_UI_URL", "")
 
-# Maximum allowed wall-clock gap between consecutive SSE chunks. Generous
-# enough to absorb network jitter and TLS/handshake variability, tight
-# enough to catch gzip-induced multi-second coalescing (which typically
-# delays the first flush by 5-10s when buffer thresholds aren't hit).
+# Maximum allowed monotonic gap between consecutive transport-level
+# chunks. Generous enough to absorb network jitter and TLS handshake
+# variability, tight enough to catch gzip-induced multi-second
+# coalescing (which typically delays the first flush by 5-10s when
+# buffer thresholds aren't hit).
 _MAX_INTERCHUNK_GAP_SECONDS = 1.5
 
-# Total streaming response timeout — well above the longest legitimate
-# generation duration for the short echo prompt below.
+# Maximum acceptable time-to-first-byte. Catches the case where
+# CloudFront swallows every chunk and only releases the response when
+# the origin closes the connection. Set generously to absorb cold-
+# start latency on the Lambda + Bedrock model invocation.
+_MAX_TIME_TO_FIRST_BYTE_SECONDS = 8.0
+
+# Total streaming response timeout — well above the longest
+# legitimate generation duration for the short prompt below.
 _STREAM_TIMEOUT_SECONDS = 30.0
 
 
-async def _record_chunk_arrival_times(
-    api_url: str,
+@dataclass
+class _StreamObservation:
+    """Network-level timing data for one SSE response.
+
+    `chunk_arrival_times` are monotonic timestamps, one per TCP-flush
+    chunk yielded by `aiter_raw()`. `delta_count` is the number of
+    `{"type": "delta"}` SSE events parsed from the assembled body —
+    used to fail loudly if the response had too few deltas to give
+    the timing assertion any signal at all.
+    """
+
+    request_start: float
+    chunk_arrival_times: list[float]
+    delta_count: int
+
+
+async def _observe_sse_stream(
+    edge_url: str,
     token: str,
     path: str,
     body: dict[str, object],
-) -> list[float]:
-    """POST to an SSE endpoint and return monotonic timestamps of each delta.
+) -> _StreamObservation:
+    """POST to an SSE endpoint and record transport-level chunk arrival timing.
 
-    Returns the wall-clock arrival time of each ``data: {"type": "delta", ...}``
-    SSE event. The terminating ``done`` event is excluded — it doesn't
-    represent a streamed token and its timing isn't load-bearing.
+    Records the monotonic arrival time of each raw network chunk
+    (using `aiter_raw()` so each yield corresponds to a TCP flush from
+    the origin via CloudFront, not to a line of in-memory text).
+    Separately parses the assembled body for SSE `delta` events so we
+    can assert the response actually exercised the streaming path.
     """
-    timestamps: list[float] = []
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
-        # Advertise gzip/br so CloudFront actually exercises its
+        # Advertise gzip so CloudFront actually exercises its
         # compression decision for this request. Sending
         # `Accept-Encoding: identity` would let CloudFront skip
         # compression entirely, masking exactly the buffering
-        # regression this test is designed to catch.
-        "Accept-Encoding": "gzip, br",
+        # regression this test is designed to catch. We deliberately
+        # omit `br` because brotli is an optional httpx extra; gzip
+        # alone is sufficient to trigger the compression path on
+        # CloudFront and is supported by Python's stdlib for
+        # post-stream decoding below.
+        "Accept-Encoding": "gzip",
         "Accept": "text/event-stream",
     }
 
+    chunk_arrival_times: list[float] = []
+    raw_body = bytearray()
+    content_encoding = ""
+
     timeout = httpx.Timeout(_STREAM_TIMEOUT_SECONDS, connect=10.0)
+    request_start = time.monotonic()
     async with (
-        httpx.AsyncClient(base_url=api_url, timeout=timeout) as client,
+        httpx.AsyncClient(base_url=edge_url, timeout=timeout) as client,
         client.stream("POST", path, headers=headers, json=body) as resp,
     ):
         resp.raise_for_status()
-        async for line in _iter_sse_data_lines(resp.aiter_lines()):
-            # Ignore non-delta events; only deltas reflect token-by-token streaming.
-            try:
-                payload = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            # Valid non-object JSON ([], "x", 1, true, null) decodes successfully but
-            # has no .get(); guard explicitly so unexpected payloads are skipped, not
-            # raised as AttributeError.
-            if not isinstance(payload, dict) or payload.get("type") != "delta":
-                continue
-            timestamps.append(time.monotonic())
-    return timestamps
+        content_encoding = resp.headers.get("content-encoding", "").lower()
+        # aiter_raw yields raw network bytes as they arrive — each
+        # yield reflects a TCP flush, not an in-memory line iteration.
+        # That's the timing signal we need; aiter_lines() would mask
+        # buffering by emitting many lines back-to-back from a single
+        # flush. The trade-off: aiter_raw bytes are *not* decompressed
+        # by httpx, so if the server applied gzip/br we have to undo
+        # that ourselves before parsing SSE.
+        async for raw_chunk in resp.aiter_raw():
+            chunk_arrival_times.append(time.monotonic())
+            raw_body.extend(raw_chunk)
+
+    decoded_body = _decompress_body(bytes(raw_body), content_encoding)
+    delta_count = _count_sse_deltas(decoded_body)
+    return _StreamObservation(
+        request_start=request_start,
+        chunk_arrival_times=chunk_arrival_times,
+        delta_count=delta_count,
+    )
 
 
-async def _iter_sse_data_lines(lines: AsyncIterator[str]) -> AsyncIterator[str]:
-    """Yield the JSON payload of each ``data:`` line from an SSE stream."""
-    async for raw in lines:
-        if raw.startswith("data:"):
-            yield raw[len("data:") :].strip()
+def _decompress_body(body: bytes, content_encoding: str) -> bytes:
+    """Decompress a response body if Content-Encoding indicates gzip.
+
+    `aiter_raw()` returns network bytes without applying content
+    decoding, so we have to handle gzip ourselves before parsing SSE.
+    Identity / unset encoding falls through unchanged. We don't
+    advertise `br` upstream (see the request-header comment), so we
+    don't need to handle it here.
+    """
+    if content_encoding == "gzip":
+        import gzip
+
+        return gzip.decompress(body)
+    return body
+
+
+def _count_sse_deltas(body: bytes) -> int:
+    """Return the number of ``{"type": "delta"}`` SSE events in a response body.
+
+    Decodes the body once after the stream completes; the timing
+    signal we care about lives in `chunk_arrival_times`, not here.
+    Robust to non-object JSON (`[]`, `"x"`, `1`, `true`, `null`)
+    showing up on `data:` lines — those decode successfully but have
+    no `.get()`, so we guard with `isinstance(..., dict)`.
+    """
+    count = 0
+    for line in body.decode("utf-8", errors="replace").splitlines():
+        if not line.startswith("data:"):
+            continue
+        payload_text = line[len("data:") :].strip()
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("type") == "delta":
+            count += 1
+    return count
+
+
+def _assert_streaming_timing_is_real_time(observation: _StreamObservation) -> None:
+    """Fail the test if the stream looks like it was buffered, not streamed.
+
+    Three orthogonal signals, each catching a different buffering
+    failure mode:
+
+    * `delta_count >= 2` — sanity check; if the response had only one
+      delta there's no inter-chunk timing to assert against.
+    * `time-to-first-byte` — catches "buffer everything, flush at end"
+      where the response body arrives in one giant chunk after the
+      origin closes the connection.
+    * `max inter-chunk gap` — catches periodic flushes; even one
+      multi-second stall between flushes is enough to break the
+      real-time UX.
+    """
+    assert observation.delta_count >= 2, (
+        f"Expected at least 2 SSE delta events to give the timing "
+        f"assertion signal, got {observation.delta_count}. If the "
+        "model produced a single-delta reply, broaden the prompt."
+    )
+    assert observation.chunk_arrival_times, (
+        "No transport-level chunks were observed — the response may have been empty."
+    )
+
+    time_to_first_byte = observation.chunk_arrival_times[0] - observation.request_start
+    assert time_to_first_byte < _MAX_TIME_TO_FIRST_BYTE_SECONDS, (
+        f"Time-to-first-byte {time_to_first_byte:.2f}s exceeds "
+        f"{_MAX_TIME_TO_FIRST_BYTE_SECONDS}s threshold. Likely cause: "
+        "CloudFront buffered the entire response and only released it "
+        "when the origin closed the connection (issue #34: verify the "
+        "/api/* behaviour has compress=False)."
+    )
+
+    arrivals = observation.chunk_arrival_times
+    if len(arrivals) >= 2:
+        gaps = [arrivals[i] - arrivals[i - 1] for i in range(1, len(arrivals))]
+        max_gap = max(gaps)
+        assert max_gap < _MAX_INTERCHUNK_GAP_SECONDS, (
+            f"Max inter-chunk gap {max_gap:.2f}s exceeds "
+            f"{_MAX_INTERCHUNK_GAP_SECONDS}s threshold "
+            f"(gaps={[round(g, 3) for g in gaps]}). Likely cause: "
+            "CloudFront response compression buffering SSE chunks; "
+            "verify the /api/* behaviour has compress=False (issue "
+            "#34)."
+        )
 
 
 @pytest.mark.xfail(
@@ -128,32 +261,20 @@ async def _iter_sse_data_lines(lines: AsyncIterator[str]) -> AsyncIterator[str]:
     strict=False,
 )
 async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
-    """Consecutive echo-stream SSE chunks must arrive within 1.5s of each other."""
+    """Echo-stream SSE chunks arrive in real time at the CloudFront edge."""
     if not EDGE_URL:
         pytest.skip("STARTER_UI_URL not set (CloudFront edge URL is required for this test)")
 
-    # A short multi-token prompt so the model emits multiple deltas without
-    # racking up cost or wall time. Echo stream is a thin wrapper over
-    # Bedrock Converse, but the prompt itself is intentionally trivial.
+    # A short multi-token prompt so the model emits multiple deltas
+    # without racking up wall-time. Echo wraps `converse_stream`, so
+    # this still hits Bedrock and incurs token charges — see the
+    # cost note in the module docstring.
     body = {"message": "Count to five, one number per line.", "system": None}
 
-    timestamps = await _record_chunk_arrival_times(
+    observation = await _observe_sse_stream(
         EDGE_URL, live_admin_token, "/api/agents/echo/stream", body
     )
-
-    assert len(timestamps) >= 2, (
-        f"Expected at least 2 SSE delta chunks for timing assertion, got {len(timestamps)}. "
-        "If the model produced a single-chunk reply, broaden the prompt."
-    )
-
-    gaps = [timestamps[i] - timestamps[i - 1] for i in range(1, len(timestamps))]
-    max_gap = max(gaps)
-    assert max_gap < _MAX_INTERCHUNK_GAP_SECONDS, (
-        f"Max inter-chunk gap {max_gap:.2f}s exceeds {_MAX_INTERCHUNK_GAP_SECONDS}s "
-        f"threshold (gaps={[round(g, 3) for g in gaps]}). "
-        "Likely cause: CloudFront response compression buffering SSE chunks; "
-        "verify the /api/* behaviour has compress=False (issue #34)."
-    )
+    _assert_streaming_timing_is_real_time(observation)
 
 
 @pytest.mark.xfail(
@@ -165,35 +286,25 @@ async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
     strict=False,
 )
 async def test_invoke_stream_inter_chunk_timing(live_admin_token: str) -> None:
-    """Consecutive invoke-stream SSE chunks must arrive within 1.5s of each other.
+    """Inline-agent streaming SSE chunks arrive in real time at the CloudFront edge.
 
-    This test invokes a Bedrock inline agent on every run, which incurs
-    real model cost. Gated on ``STARTER_E2E_RUN_INVOKE_STREAM=1`` so
-    routine CI runs only exercise the cheap echo-stream variant.
+    Gated on ``STARTER_E2E_RUN_INVOKE_STREAM=1`` because inline-agent
+    spend per call is meaningfully higher than echo-stream. Routine
+    CI runs only exercise the cheaper echo path; this test runs on
+    demand to catch buffering regressions specific to the inline-
+    agent streaming surface.
     """
     if not EDGE_URL:
         pytest.skip("STARTER_UI_URL not set (CloudFront edge URL is required for this test)")
     if os.environ.get("STARTER_E2E_RUN_INVOKE_STREAM") != "1":
         pytest.skip(
             "Set STARTER_E2E_RUN_INVOKE_STREAM=1 to exercise the inline-agent "
-            "streaming endpoint (incurs Bedrock cost)."
+            "streaming endpoint (incurs higher Bedrock cost than echo)."
         )
 
     body = {"message": "Count to five, one number per line.", "session_id": None}
 
-    timestamps = await _record_chunk_arrival_times(
+    observation = await _observe_sse_stream(
         EDGE_URL, live_admin_token, "/api/agents/invoke/stream", body
     )
-
-    assert len(timestamps) >= 2, (
-        f"Expected at least 2 SSE delta chunks for timing assertion, got {len(timestamps)}."
-    )
-
-    gaps = [timestamps[i] - timestamps[i - 1] for i in range(1, len(timestamps))]
-    max_gap = max(gaps)
-    assert max_gap < _MAX_INTERCHUNK_GAP_SECONDS, (
-        f"Max inter-chunk gap {max_gap:.2f}s exceeds {_MAX_INTERCHUNK_GAP_SECONDS}s "
-        f"threshold (gaps={[round(g, 3) for g in gaps]}). "
-        "Likely cause: CloudFront response compression buffering SSE chunks; "
-        "verify the /api/* behaviour has compress=False (issue #34)."
-    )
+    _assert_streaming_timing_is_real_time(observation)

--- a/tests/e2e/test_streaming_e2e.py
+++ b/tests/e2e/test_streaming_e2e.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 John Carter. All rights reserved.
+"""
+E2e regression test: SSE streaming endpoints emit chunks in real time.
+
+This test guards against silent buffering regressions on the deployed
+edge — most notably CloudFront response compression on `/api/*`. With
+compression enabled on a streaming behaviour, gzip can coalesce many
+deltas into a single multi-second flush, breaking the real-time UX
+that streaming endpoints are designed for. By recording the wall-
+clock timestamp of each SSE chunk and asserting an inter-arrival
+upper bound, this test fails fast if a CloudFront config change
+silently re-introduces buffering.
+
+Test target: the deployed CloudFront URL (`STARTER_API_URL`), not
+the Lambda Function URL directly. The whole point is to exercise the
+edge path that real browsers traverse.
+
+Currently `xfail` (`strict=False`) until issue #34 lands
+(`compress=False` on the `/api/*` / `/auth/*` / `/oauth/*` CloudFront
+behaviours). With compression still enabled on the dev environment,
+gzip buffers SSE deltas into multi-second flushes, so the assertion
+would fail on every run. Once #34 ships, flip the marker off and the
+strict assertion takes over. `strict=False` keeps the suite green
+through the transition; if the timing somehow already passes (e.g.
+infra fix lands ahead of this test), the run is reported as XPASS,
+not a hard failure — the next contributor flips the marker.
+
+Echo stream is the primary fixture (no Bedrock cost). The
+invoke-stream variant is a separate smoke test gated on
+`STARTER_E2E_RUN_INVOKE_STREAM=1` to avoid charging on every CI run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+API_URL = os.environ.get("STARTER_API_URL", "")
+
+# Maximum allowed wall-clock gap between consecutive SSE chunks. Generous
+# enough to absorb network jitter and TLS/handshake variability, tight
+# enough to catch gzip-induced multi-second coalescing (which typically
+# delays the first flush by 5-10s when buffer thresholds aren't hit).
+_MAX_INTERCHUNK_GAP_SECONDS = 1.5
+
+# Total streaming response timeout — well above the longest legitimate
+# generation duration for the short echo prompt below.
+_STREAM_TIMEOUT_SECONDS = 30.0
+
+
+async def _record_chunk_arrival_times(
+    api_url: str,
+    token: str,
+    path: str,
+    body: dict[str, object],
+) -> list[float]:
+    """POST to an SSE endpoint and return monotonic timestamps of each delta.
+
+    Returns the wall-clock arrival time of each ``data: {"type": "delta", ...}``
+    SSE event. The terminating ``done`` event is excluded — it doesn't
+    represent a streamed token and its timing isn't load-bearing.
+    """
+    timestamps: list[float] = []
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        # Advertise gzip/br so CloudFront actually exercises its
+        # compression decision for this request. Sending
+        # `Accept-Encoding: identity` would let CloudFront skip
+        # compression entirely, masking exactly the buffering
+        # regression this test is designed to catch.
+        "Accept-Encoding": "gzip, br",
+        "Accept": "text/event-stream",
+    }
+
+    timeout = httpx.Timeout(_STREAM_TIMEOUT_SECONDS, connect=10.0)
+    async with (
+        httpx.AsyncClient(base_url=api_url, timeout=timeout) as client,
+        client.stream("POST", path, headers=headers, json=body) as resp,
+    ):
+        resp.raise_for_status()
+        async for line in _iter_sse_data_lines(resp.aiter_lines()):
+            # Ignore non-delta events; only deltas reflect token-by-token streaming.
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Valid non-object JSON ([], "x", 1, true, null) decodes successfully but
+            # has no .get(); guard explicitly so unexpected payloads are skipped, not
+            # raised as AttributeError.
+            if not isinstance(payload, dict) or payload.get("type") != "delta":
+                continue
+            timestamps.append(time.monotonic())
+    return timestamps
+
+
+async def _iter_sse_data_lines(lines: AsyncIterator[str]) -> AsyncIterator[str]:
+    """Yield the JSON payload of each ``data:`` line from an SSE stream."""
+    async for raw in lines:
+        if raw.startswith("data:"):
+            yield raw[len("data:") :].strip()
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Issue #34 (CloudFront compress=False on /api/*) has not shipped — "
+        "gzip on the streaming behaviour buffers SSE deltas. Flip this "
+        "marker off once #34 lands."
+    ),
+    strict=False,
+)
+async def test_echo_stream_inter_chunk_timing(live_admin_token: str) -> None:
+    """Consecutive echo-stream SSE chunks must arrive within 1.5s of each other."""
+    if not API_URL:
+        pytest.skip("STARTER_API_URL not set")
+
+    # A short multi-token prompt so the model emits multiple deltas without
+    # racking up cost or wall time. Echo stream is a thin wrapper over
+    # Bedrock Converse, but the prompt itself is intentionally trivial.
+    body = {"message": "Count to five, one number per line.", "system": None}
+
+    timestamps = await _record_chunk_arrival_times(
+        API_URL, live_admin_token, "/api/agents/echo/stream", body
+    )
+
+    assert len(timestamps) >= 2, (
+        f"Expected at least 2 SSE delta chunks for timing assertion, got {len(timestamps)}. "
+        "If the model produced a single-chunk reply, broaden the prompt."
+    )
+
+    gaps = [timestamps[i] - timestamps[i - 1] for i in range(1, len(timestamps))]
+    max_gap = max(gaps)
+    assert max_gap < _MAX_INTERCHUNK_GAP_SECONDS, (
+        f"Max inter-chunk gap {max_gap:.2f}s exceeds {_MAX_INTERCHUNK_GAP_SECONDS}s "
+        f"threshold (gaps={[round(g, 3) for g in gaps]}). "
+        "Likely cause: CloudFront response compression buffering SSE chunks; "
+        "verify the /api/* behaviour has compress=False (issue #34)."
+    )
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Issue #34 (CloudFront compress=False on /api/*) has not shipped — "
+        "gzip on the streaming behaviour buffers SSE deltas. Flip this "
+        "marker off once #34 lands."
+    ),
+    strict=False,
+)
+async def test_invoke_stream_inter_chunk_timing(live_admin_token: str) -> None:
+    """Consecutive invoke-stream SSE chunks must arrive within 1.5s of each other.
+
+    This test invokes a Bedrock inline agent on every run, which incurs
+    real model cost. Gated on ``STARTER_E2E_RUN_INVOKE_STREAM=1`` so
+    routine CI runs only exercise the cheap echo-stream variant.
+    """
+    if not API_URL:
+        pytest.skip("STARTER_API_URL not set")
+    if os.environ.get("STARTER_E2E_RUN_INVOKE_STREAM") != "1":
+        pytest.skip(
+            "Set STARTER_E2E_RUN_INVOKE_STREAM=1 to exercise the inline-agent "
+            "streaming endpoint (incurs Bedrock cost)."
+        )
+
+    body = {"message": "Count to five, one number per line.", "session_id": None}
+
+    timestamps = await _record_chunk_arrival_times(
+        API_URL, live_admin_token, "/api/agents/invoke/stream", body
+    )
+
+    assert len(timestamps) >= 2, (
+        f"Expected at least 2 SSE delta chunks for timing assertion, got {len(timestamps)}."
+    )
+
+    gaps = [timestamps[i] - timestamps[i - 1] for i in range(1, len(timestamps))]
+    max_gap = max(gaps)
+    assert max_gap < _MAX_INTERCHUNK_GAP_SECONDS, (
+        f"Max inter-chunk gap {max_gap:.2f}s exceeds {_MAX_INTERCHUNK_GAP_SECONDS}s "
+        f"threshold (gaps={[round(g, 3) for g in gaps]}). "
+        "Likely cause: CloudFront response compression buffering SSE chunks; "
+        "verify the /api/* behaviour has compress=False (issue #34)."
+    )


### PR DESCRIPTION
Closes #33

## Summary

Adds `tests/e2e/test_streaming_e2e.py` — an e2e regression test that
records transport-level chunk arrivals on the streaming echo
endpoint and asserts the response actually streams (TTFB < 8s,
multiple network chunks for multiple deltas, max inter-chunk gap
< 1.5s). Catches buffering regressions on the deployed CloudFront
edge (most notably gzip on `/api/*`, which coalesces SSE deltas
into multi-second flushes and breaks real-time streaming UX).

## Approach

- Test hits `STARTER_UI_URL` (the deployed **CloudFront** URL,
  resolved from the `UiUrl` CloudFormation output) — **not**
  `STARTER_API_URL`, which `tasks.e2e()` populates from
  `ApiFunctionUrl` (the Lambda Function URL, which bypasses
  CloudFront entirely).
- Uses `httpx.AsyncClient.aiter_raw()` to record arrivals at the
  TCP-flush level, then decompresses the assembled gzip body once
  to count SSE deltas. `aiter_lines()` would mask buffering by
  yielding many lines from a single in-memory flush.
- Four orthogonal assertions (delta count, TTFB, multi-chunk count
  when delta count >= 2, max inter-chunk gap) so each buffering
  failure mode has a dedicated detector.
- Sends `Accept-Encoding: gzip` so CloudFront actually exercises
  its compression decision (an `identity` request would let
  CloudFront skip compression entirely and mask the very
  regression this test catches). Drops `br` to avoid the optional
  brotli dep — gzip alone is enough to trigger CF's compression
  path.
- Reuses the existing `live_admin_token` fixture from
  `tests/e2e/conftest.py`; the JWT is host-agnostic and is
  accepted at the CloudFront edge as well.
- Echo stream runs unconditionally (deployed e2e only triggers on
  dev/main deploys, not every PR). The invoke-stream variant is
  additionally gated behind `STARTER_E2E_RUN_INVOKE_STREAM=1`
  because inline-agent spend per call is meaningfully higher than
  the raw `converse_stream` call echo wraps.
- `skipif` marker on both tests filters out `localhost` /
  `127.0.0.1` URLs so `inv e2e-local` runs cleanly: Vite proxy
  bypasses CloudFront and the timing assertion would pass or fail
  for the wrong reason.

### `xfail` rationale (soft sequencing)

The issue body soft-sequences this test after a sibling
`compress=False` infra change (issue #34, the "#proposal-19" planning
shorthand the body uses). #34 is still open, so the deployed dev
CloudFront still has compression enabled on `/api/*`. Per the
issue's own guidance, both tests are marked
`@pytest.mark.xfail(strict=False, reason="#34 not shipped yet ...")`.
Once #34 lands, flip the markers off and the strict assertion takes
over. `strict=False` means an unexpected pass is reported as XPASS
rather than a hard failure — keeps the suite green through the
transition.

### Known gap (out of scope here)

The deployed-e2e CI job currently runs only a curl smoke check
against `/health` — it does **not** invoke `pytest tests/e2e/`.
Per `tests/README.md`, the per-suite e2e files were stripped down
during #47-era refactoring and reauthoring is tracked separately.
The new test is correct as written and will be picked up
automatically once the e2e CI workflow is restored. Restoring
that workflow is out of scope for issue #33.

## Files to touch

- `tests/e2e/test_streaming_e2e.py` (new)

Issue lists `tests/conftest.py` as "possibly" needed; it wasn't —
the existing `live_admin_token` fixture and `httpx` already covered
the streaming-friendly client need.

## Local validation

- `uv run inv pre-push` — green (lint + typecheck + 258 unit + 275
  frontend, all pass)
- `uv run pytest tests/e2e/test_streaming_e2e.py -v` (no env vars or
  localhost URL) — both tests SKIPPED, as expected
- Local e2e not run — this is a test-only addition targeting the
  deployed CloudFront surface; nothing local to validate against.
  CI will exercise it on the development-branch deploy once the
  e2e CI workflow is restored.

## Copilot review iterations

Findings addressed across four iterations:

1. `Accept-Encoding: identity` would have defeated the test's
   purpose — switched to `gzip`.
2. `payload.get("type")` could raise `AttributeError` on valid
   non-dict JSON — added an `isinstance(payload, dict)` guard.
3. `STARTER_API_URL` is the Lambda Function URL, not CloudFront —
   switched to `STARTER_UI_URL` (CloudFront URL).
4. Docstring said "wall-clock" but used `time.monotonic()` —
   updated docstring.
5. `aiter_lines()` would mask buffering — switched to `aiter_raw()`
   plus a TTFB assertion.
6. Echo stream incurs Bedrock cost — corrected the comment claim.
7. `inv e2e-local` would run the test against Vite — added a
   `skipif` marker for `localhost` URLs.
8. Sub-8s coalesce could slip through — added an explicit
   "delta_count >= 2 implies len(arrivals) >= 2" assertion.

Final review pass: clean.